### PR TITLE
Mod loading robustness | WorkshopMenuDrawConfig

### DIFF
--- a/StationeersLaunchPad/LaunchPadPlugin.cs
+++ b/StationeersLaunchPad/LaunchPadPlugin.cs
@@ -209,7 +209,14 @@ namespace StationeersLaunchPad
       if (workshopMenuSelectedField == null)
         workshopMenuSelectedField = typeof(WorkshopMenu).GetField("_selectedModItem", BindingFlags.Instance | BindingFlags.NonPublic);
 
-      var modData = ((WorkshopModListItem)workshopMenuSelectedField.GetValue(WorkshopMenu.Instance)).Data;
+      var selectedModItem = workshopMenuSelectedField.GetValue(WorkshopMenu.Instance) as WorkshopModListItem;
+      if (selectedModItem == null)
+        return;
+
+      var modData = selectedModItem.Data;
+      if (modData == null)
+        return;
+
       LaunchPadGUI.DrawMenuConfig(modData);
     }
 


### PR DESCRIPTION
These changes have been tested with the user that was having issues, my changes seem to have fixed it for them, i also tested the build on my end and everything seemed okay 👍

But since i just started looking at the source yesterday im not sure if I've done something incorrectly, or broke something else in the process, so please review carefully :P 

LaunchPadConfig - LoadConfig():
1. Path Normalization
- Added case-insensitive path comparison (OrdinalIgnoreCase) in the dictionary
- Implemented NormalizePath() helper to standardize path by:
* Converting backslashes to forward slashes
* Trimming whitepsace
* Converting to lowercase
* Handling null paths safely

2. Error logging for null paths

3. Special Core mod handling
- Added explicit handling for core mod with empty path (uses "Core" as key)

LaunchPadPlugin - WorkshopMenuDrawConfig:

1. Added null safety checks for:
   - The reflected WorkshopModListItem instance
   - The mod Data object before usage
2. Split field access into separate steps for better readability
3. Removed direct cast/access chain that could throw NullReferenceException
4. Added early returns for invalid states