### PR TITLE
Improve autoupdate error handling

### DIFF
--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -34,6 +34,7 @@ namespace StationeersLaunchPad
   public static class LaunchPadConfig
   {
     public static ConfigEntry<bool> DebugMode;
+    public static ConfigEntry<bool> CheckForUpdate;
     public static ConfigEntry<bool> AutoUpdateOnStart;
     public static ConfigEntry<bool> AutoLoadOnStart;
     public static ConfigEntry<bool> AutoSortOnStart;
@@ -67,7 +68,7 @@ namespace StationeersLaunchPad
       AutoLoad = AutoLoadOnStart.Value;
       LoadStrategyType = StrategyType.Value;
       LoadStrategyMode = StrategyMode.Value;
-      
+
       await Load();
 
       while (LoadState < LoadState.Updating)
@@ -77,7 +78,7 @@ namespace StationeersLaunchPad
       {
         AutoLoad = false;
 
-        await LaunchPadAlertGUI.Show("Restart Recommended", "StationeersLaunchPad has been updated, it is recommended to restart the game.", 
+        await LaunchPadAlertGUI.Show("Restart Recommended", "StationeersLaunchPad has been updated, it is recommended to restart the game.",
           LaunchPadAlertGUI.DefaultSize,
           LaunchPadAlertGUI.DefaultPosition,
           ("Continue Loading", () => {
@@ -154,17 +155,11 @@ namespace StationeersLaunchPad
 
         Logger.Global.Log("Mod Config Initialized");
 
-        LoadState = LoadState.Updating;
-        Logger.Global.Log("Checking Version");
-        try
+        if (CheckForUpdate.Value)
         {
+          LoadState = LoadState.Updating;
+          Logger.Global.Log("Checking Version");
           await LaunchPadUpdater.CheckVersion();
-        }
-        catch (Exception ex)
-        {
-          Logger.Global.LogError("Error occurred during updating.");
-          Logger.Global.LogException(ex);
-          await UniTask.Run(() => LaunchPadUpdater.RevertUpdate());
         }
 
         LoadState = LoadState.Configuring;
@@ -173,12 +168,12 @@ namespace StationeersLaunchPad
       {
         if (!GameManager.IsBatchMode)
         {
-         Logger.Global.LogError("Error occurred during initialization. Mods will not be loaded.");
-         Logger.Global.LogException(ex);
+          Logger.Global.LogError("Error occurred during initialization. Mods will not be loaded.");
+          Logger.Global.LogException(ex);
 
-         Mods = new();
-         LoadState = LoadState.ModsLoaded;
-         AutoLoad = false;
+          Mods = new();
+          LoadState = LoadState.ModsLoaded;
+          AutoLoad = false;
         }
         else
         {

--- a/StationeersLaunchPad/LaunchPadPlugin.cs
+++ b/StationeersLaunchPad/LaunchPadPlugin.cs
@@ -21,7 +21,7 @@ namespace StationeersLaunchPad
   {
     public const string pluginGuid = "stationeers.launchpad";
     public const string pluginName = "StationeersLaunchPad";
-    public const string pluginVersion = "0.1.9";
+    public const string pluginVersion = "0.1.10";
 
     void Awake()
     {

--- a/StationeersLaunchPad/LaunchPadPlugin.cs
+++ b/StationeersLaunchPad/LaunchPadPlugin.cs
@@ -21,7 +21,7 @@ namespace StationeersLaunchPad
   {
     public const string pluginGuid = "stationeers.launchpad";
     public const string pluginName = "StationeersLaunchPad";
-    public const string pluginVersion = "0.1.10";
+    public const string pluginVersion = "0.1.9";
 
     void Awake()
     {
@@ -41,11 +41,18 @@ namespace StationeersLaunchPad
           "Automatically load after the configured wait time on startup. Can be stopped by clicking the loading window at the bottom"
         )
        );
+      LaunchPadConfig.CheckForUpdate = this.Config.Bind(
+        new ConfigDefinition("Startup", "CheckForUpdate"),
+        !GameManager.IsBatchMode, // Default to false on DS
+        new ConfigDescription(
+          "Automatically check for mod loader updates on startup."
+        )
+      );
       LaunchPadConfig.AutoUpdateOnStart = this.Config.Bind(
         new ConfigDefinition("Startup", "AutoUpdateOnStart"),
         !GameManager.IsBatchMode, // Default to false on DS
         new ConfigDescription(
-          "Automatically update mod loader on startup."
+          "Automatically update mod loader on startup. Ignored if CheckForUpdate is not also enabled."
         )
       );
       LaunchPadConfig.AutoLoadWaitTime = this.Config.Bind(

--- a/StationeersLaunchPad/LaunchPadUpdater.cs
+++ b/StationeersLaunchPad/LaunchPadUpdater.cs
@@ -1,6 +1,7 @@
 ﻿using Assets.Scripts;
 using BepInEx;
 using Cysharp.Threading.Tasks;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,184 +10,259 @@ using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.Networking;
 
-namespace StationeersLaunchPad {
+namespace StationeersLaunchPad
+{
   // similar to jixxed's updater
-  public static class LaunchPadUpdater {
+  public static class LaunchPadUpdater
+  {
     public static bool AllowUpdate;
 
     public static List<string> Assemblies = new()
     {
-            "RG.ImGui",
-            "StationeersMods.Interface",
-            "StationeersMods.Shared",
-            "StationeersLaunchPad",
+      "RG.ImGui",
+      "StationeersMods.Interface",
+      "StationeersMods.Shared",
+      "StationeersLaunchPad",
     };
 
-    private static Regex versionRegex = new(@"""tag_name""\:\s""([V\d.]*)""", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static Regex downloadRegexClient = new(@"""browser_download_url""\:\s""([^""]*StationeersLaunchPad-v.+\.zip)""", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static Regex downloadRegexServer = new(@"""browser_download_url""\:\s""([^""]*StationeersLaunchPad-server-v.+\.zip)""", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    public static async UniTask CheckVersion()
+    {
+      var latestRelease = await FetchLatestRelease();
+      // If we failed to get a release for whatever reason, just bail
+      if (latestRelease == null)
+        return;
 
-    public static async UniTask CheckVersion() {
-      using (var request = UnityWebRequest.Get("https://api.github.com/repos/StationeersLaunchPad/StationeersLaunchPad/releases/latest")) {
-        request.timeout = 10; // 10 seconds because we are only fetching a json file
+      var latestVersion = new Version(latestRelease.TagName.TrimStart('V', 'v'));
+      var currentVersion = new Version(LaunchPadPlugin.pluginVersion.TrimStart('V', 'v'));
 
-        Logger.Global.LogDebug($"Requesting version...");
-        UnityWebRequest result = await request.SendWebRequest();
+      if (latestVersion <= currentVersion)
+      {
+        Logger.Global.Log($"Plugin is up-to-date.");
+        return;
+      }
 
-        if (result.result != UnityWebRequest.Result.Success) {
-          Logger.Global.LogError($"Failed to send web request! result: {result.result}, error: {result.error}");
-          return;
-        }
+      Logger.Global.LogWarning($"Plugin is NOT up-to-date.");
 
-        var text = result.downloadHandler.text;
-        var matches = versionRegex.Matches(text);
-        if (matches.Count == 0) {
-          Logger.Global.LogError($"Failed to find version regex matches.");
-          return;
-        }
+      await CheckShouldUpdate(latestRelease);
+      if (!AllowUpdate)
+        return;
 
-        var latestVersion = new Version(matches[0].Groups[1].Value.TrimStart('V', 'v'));
-        var currentVersion = new Version(LaunchPadPlugin.pluginVersion.TrimStart('V', 'v'));
+      try
+      {
+        await PerformUpdate(latestRelease);
 
-        if (latestVersion <= currentVersion) {
-          Logger.Global.Log($"Plugin is up-to-date.");
-          return;
-        }
-
-        Logger.Global.LogWarning($"Plugin is NOT up-to-date.");
-
-        if (!LaunchPadConfig.AutoUpdate) {
-          await LaunchPadAlertGUI.Show("Update Available", "An update is available, would you like to automatically download and update?",
-            LaunchPadAlertGUI.DefaultSize,
-            LaunchPadAlertGUI.DefaultPosition,
-            ("Yes", () => {
-              AllowUpdate = true;
-              return true;
-            }),
-            ("Open GitHub", () => {
-              AllowUpdate = false;
-              Application.OpenURL("https://github.com/StationeersLaunchPad/StationeersLaunchPad/releases/tag/latest");
-              return true;
-            }),
-            ("No", () => {
-              AllowUpdate = false;
-              return true;
-            })
-          );
-
-          if (!AllowUpdate)
-            return;
-        }
-
-        var downloadMatches = GameManager.IsBatchMode ? downloadRegexServer.Matches(text) : downloadRegexClient.Matches(text);
-        if (downloadMatches.Count == 0) {
-          Logger.Global.LogError($"Failed to find download regex matches.");
-          return;
-        }
-
-        using (var downloadRequest = UnityWebRequest.Get(downloadMatches[0].Groups[1].Value)) {
-          downloadRequest.timeout = 45; // max of 45 seconds to download the zip file
-
-          Logger.Global.LogDebug($"Requesting download file...");
-          UnityWebRequest downloadResult = await downloadRequest.SendWebRequest();
-
-          if (downloadResult.result != UnityWebRequest.Result.Success) {
-            Logger.Global.LogError($"Failed to send web request to download! result: {result.result}, error: {result.error}");
-            return;
-          }
-
-          var tempPath = Path.GetTempPath();
-          var extractionPath = Path.Combine(tempPath, "StationeersLaunchPad");
-          if (Directory.Exists(extractionPath)) {
-            foreach (var file in Directory.GetFiles(extractionPath)) {
-              var path = Path.Combine(extractionPath, file);
-
-              if (File.Exists(path)) {
-                File.Delete(path);
-              }
-            }
-            Directory.Delete(extractionPath);
-          }
-
-          var zipFilePath = Path.Combine(tempPath, "SLP.zip");
-          if (File.Exists(zipFilePath)) {
-            File.Delete(zipFilePath);
-          }
-
-          Logger.Global.LogDebug($"Writing file to {zipFilePath}...");
-          File.WriteAllBytes(zipFilePath, downloadResult.downloadHandler.data);
-
-          using (var zipFile = ZipFile.Open(zipFilePath, ZipArchiveMode.Read)) {
-            Logger.Global.LogDebug($"Extracting file contents to {extractionPath}...");
-            zipFile.ExtractToDirectory(tempPath);
-          }
-          File.Delete(zipFilePath);
-
-          Logger.Global.LogDebug($"Extracted file contents to {extractionPath}!");
-          if (!Directory.Exists(extractionPath)) {
-            Logger.Global.LogError($"Failed to exteract zip file");
-            return;
-          }
-
-          var pluginPath = Path.Combine(Paths.PluginPath, "StationeersLaunchPad");
-          foreach (var file in LaunchPadUpdater.Assemblies) {
-            var fileName = $"{file}.dll";
-            var backupFileName = $"{file}.dll.bak";
-            var newPath = Path.Combine(extractionPath, fileName);
-            if (!File.Exists(newPath)) {
-              continue;
-            }
-
-            var path = Path.Combine(pluginPath, fileName);
-            if (!File.Exists(path)) {
-              continue;
-            }
-
-            var backupPath = Path.Combine(pluginPath, backupFileName);
-            if (File.Exists(backupPath)) {
-              File.Delete(backupPath);
-            }
-
-            Logger.Global.LogDebug($"Backing up DLL to {backupPath}!");
-            File.Move(path, backupPath);
-            Logger.Global.LogDebug($"Deleting DLL at {path}!");
-            File.Delete(path);
-
-            Logger.Global.LogDebug($"Moving new DLL to {newPath}!");
-            File.Move(newPath, path);
-            //File.Delete(newPath);
-          }
-          Directory.Delete(extractionPath);
-
-          LaunchPadConfig.HasUpdated = true;
-          Logger.Global.LogError($"Mod loader has been updated to version {latestVersion}, please restart your game!");
-        }
+        LaunchPadConfig.HasUpdated = true;
+        Logger.Global.LogError($"Mod loader has been updated to version {latestVersion}, please restart your game!");
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+        Logger.Global.LogError("An error occurred during update. Rolling back");
+        RevertUpdate();
       }
     }
 
-    public static async UniTask RevertUpdate() {
+    private static async UniTask<GithubRelease> FetchLatestRelease()
+    {
+      try
+      {
+        using (var request = UnityWebRequest.Get("https://api.github.com/repos/StationeersLaunchPad/StationeersLaunchPad/releases/latest"))
+        {
+          request.timeout = 10; // 10 seconds because we are only fetching a json file
+
+          Logger.Global.LogDebug($"Requesting version...");
+          UnityWebRequest result = await request.SendWebRequest();
+
+          if (result.result != UnityWebRequest.Result.Success)
+          {
+            Logger.Global.LogError($"Failed to send web request! result: {result.result}, error: {result.error}");
+            return null;
+          }
+
+          return JsonConvert.DeserializeObject<GithubRelease>(result.downloadHandler.text);
+        }
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+        Logger.Global.LogError("Failed to fetch latest release info. Skipping update");
+        return null;
+      }
+    }
+
+    private static async UniTask CheckShouldUpdate(GithubRelease release)
+    {
+      if (LaunchPadConfig.AutoUpdate)
+      {
+        AllowUpdate = true;
+        return;
+      }
+
+      await LaunchPadAlertGUI.Show("Update Available", "An update is available, would you like to automatically download and update?",
+        LaunchPadAlertGUI.DefaultSize,
+        LaunchPadAlertGUI.DefaultPosition,
+        ("Yes", () => {
+          AllowUpdate = true; return true;
+        }),
+        ("Open GitHub", () => {
+          AllowUpdate = false;
+          Application.OpenURL(release.HtmlUrl);
+          return false;
+        }),
+        ("No", () => {
+          AllowUpdate = false;
+          return true;
+        })
+      );
+    }
+
+    private static async UniTask PerformUpdate(GithubRelease release)
+    {
+      var assetName = GameManager.IsBatchMode ? $"StationeersLaunchPad-server-{release.TagName}.zip" : $"StationeersLaunchPad-{release.TagName}.zip";
+      var asset = release.Assets.Find(a => a.Name == assetName);
+      if (asset == null)
+      {
+        Logger.Global.LogError($"Failed to find {assetName} in release. Skipping update");
+        return;
+      }
+
+      var tempPath = Path.GetTempPath();
+      var extractionPath = Path.Combine(tempPath, "StationeersLaunchPad");
+      if (Directory.Exists(extractionPath))
+      {
+        foreach (var file in Directory.GetFiles(extractionPath))
+        {
+          var path = Path.Combine(extractionPath, file);
+
+          if (File.Exists(path))
+          {
+            File.Delete(path);
+          }
+        }
+        Directory.Delete(extractionPath);
+      }
+      var zipFilePath = Path.Combine(tempPath, "SLP.zip");
+      if (File.Exists(zipFilePath))
+      {
+        File.Delete(zipFilePath);
+      }
+
+      using (var downloadRequest = UnityWebRequest.Get(asset.BrowserDownloadUrl))
+      {
+        downloadRequest.timeout = 45; // max of 45 seconds to download the zip file
+
+        Logger.Global.LogDebug($"Requesting download file...");
+        UnityWebRequest downloadResult = await downloadRequest.SendWebRequest();
+
+        if (downloadResult.result != UnityWebRequest.Result.Success)
+        {
+          Logger.Global.LogError($"Failed to send web request to download! result: {downloadResult.result}, error: {downloadResult.error}");
+          return;
+        }
+
+        Logger.Global.LogDebug($"Writing file to {zipFilePath}...");
+        File.WriteAllBytes(zipFilePath, downloadResult.downloadHandler.data);
+      }
+
+      using (var zipFile = ZipFile.Open(zipFilePath, ZipArchiveMode.Read))
+      {
+        Logger.Global.LogDebug($"Extracting file contents to {extractionPath}...");
+        zipFile.ExtractToDirectory(tempPath);
+      }
+      File.Delete(zipFilePath);
+
+      Logger.Global.LogDebug($"Extracted file contents to {extractionPath}!");
+      if (!Directory.Exists(extractionPath))
+      {
+        Logger.Global.LogError($"Failed to exteract zip file");
+        return;
+      }
+
       var pluginPath = Path.Combine(Paths.PluginPath, "StationeersLaunchPad");
-      foreach (var file in LaunchPadUpdater.Assemblies) {
+      foreach (var file in LaunchPadUpdater.Assemblies)
+      {
         var fileName = $"{file}.dll";
         var backupFileName = $"{file}.dll.bak";
-
-        var backupPath = Path.Combine(pluginPath, backupFileName);
-        if (!File.Exists(backupPath)) {
+        var newPath = Path.Combine(extractionPath, fileName);
+        if (!File.Exists(newPath))
+        {
           continue;
         }
 
         var path = Path.Combine(pluginPath, fileName);
-        if (File.Exists(path)) {
-          File.Delete(path);
+        if (!File.Exists(path))
+        {
+          continue;
         }
 
-        Logger.Global.LogDebug($"Moving backup DLL to {path}!");
-        File.Move(backupPath, path);
-        //Logger.Global.Log($"Deleting DLL at {backupPath}!");
-        //File.Delete(backupPath);
-      }
+        var backupPath = Path.Combine(pluginPath, backupFileName);
+        if (File.Exists(backupPath))
+        {
+          File.Delete(backupPath);
+        }
 
-      Logger.Global.LogWarning($"Mod loader has reverted update changes due to an error.");
+        Logger.Global.LogDebug($"Backing up DLL to {backupPath}!");
+        File.Move(path, backupPath);
+        Logger.Global.LogDebug($"Deleting DLL at {path}!");
+        File.Delete(path);
+
+        Logger.Global.LogDebug($"Moving new DLL to {newPath}!");
+        File.Move(newPath, path);
+      }
+      Directory.Delete(extractionPath);
+    }
+
+    private static void RevertUpdate()
+    {
+      try
+      {
+        var pluginPath = Path.Combine(Paths.PluginPath, "StationeersLaunchPad");
+        foreach (var file in LaunchPadUpdater.Assemblies)
+        {
+          var fileName = $"{file}.dll";
+          var backupFileName = $"{file}.dll.bak";
+
+          var backupPath = Path.Combine(pluginPath, backupFileName);
+          if (!File.Exists(backupPath))
+          {
+            continue;
+          }
+
+          var path = Path.Combine(pluginPath, fileName);
+          if (File.Exists(path))
+          {
+            File.Delete(path);
+          }
+
+          Logger.Global.LogDebug($"Moving backup DLL to {path}!");
+          File.Move(backupPath, path);
+        }
+
+        Logger.Global.LogWarning($"Mod loader has reverted update changes due to an error.");
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+        Logger.Global.LogError("Error rolling back update. StationeersLaunchPad install may be in an invalid state.");
+      }
+    }
+
+    public class GithubRelease
+    {
+      [JsonProperty("tag_name")]
+      public string TagName;
+      [JsonProperty("html_url")]
+      public string HtmlUrl;
+      [JsonProperty("assets")]
+      public List<GithubReleaseAsset> Assets;
+    }
+
+    public class GithubReleaseAsset
+    {
+      [JsonProperty("name")]
+      public string Name;
+      [JsonProperty("browser_download_url")]
+      public string BrowserDownloadUrl;
     }
   }
 }

--- a/StationeersLaunchPad/LaunchPadUpdater.cs
+++ b/StationeersLaunchPad/LaunchPadUpdater.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.Networking;
 

--- a/globalRefs.VS.props
+++ b/globalRefs.VS.props
@@ -8,6 +8,10 @@
       <HintPath>$(StationeersDirectory)\rocketstation_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(StationeersDirectory)\rocketstation_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System.IO.Compression">
       <HintPath>$(StationeersDirectory)\rocketstation_Data\Managed\System.IO.Compression.dll</HintPath>
       <Private>False</Private>


### PR DESCRIPTION
- Only try to revert if we started updating
- Catch revert errors and don't fail mod loading
- Add `CheckForUpdate` setting (disabled by default on DS) that entirely skips the update check if disabled
- Use json deserializer instead of regex for parsing release info

Fixes #17 