### PR TITLE
build: make copy task run on each project build instead of on solution

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,17 +1,17 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)global.VS.props" />
   <Target Name="CopyToPlugins" AfterTargets="Build">
     <ItemGroup>
-      <PluginFiles Include="$(OutputPath)/*" />
-      <_PluginFiles_Dest Include="@(PluginFiles)">
+      <InputFiles Include="$(OutputPath)$(AssemblyName).*" />
+      <OutputFiles Include="$(PluginPath)/$(AssemblyName).*" />
+      <_CopyFiles_Dest Include="@(InputFiles)">
         <Dest>$(PluginPath)\%(Filename)%(Extension)</Dest>
-      </_PluginFiles_Dest>
-      <CopyFiles Include="@(_PluginFiles_Dest)">
+      </_CopyFiles_Dest>
+      <CopyFiles Include="@(_CopyFiles_Dest)">
         <PrettySrc>$([System.String]::Copy('%(FullPath)').Replace('$(SolutionDir)', ''))</PrettySrc>
         <PrettyDest>$([System.String]::Copy('%(Dest)').Replace('$(StationeersDirectory)', ''))</PrettyDest>
       </CopyFiles>
     </ItemGroup>
-    <RemoveDir Directories="$(PluginPath)" />
+    <Delete Files="%(OutputFiles.FullPath)" />
     <Message Text="%(CopyFiles.PrettySrc) -> %(CopyFiles.PrettyDest)" Importance="high" />
     <Copy SourceFiles="%(CopyFiles.FullPath)" DestinationFiles="%(CopyFiles.Dest)" />
   </Target>


### PR DESCRIPTION
This makes each project build copy its output files (dll and optionally pdb) to the bepinex plugins directory on build.

Previously this was run only on solution build, so individual project builds didn't copy anything over.