### PR TITLE
extract update files from memory. don't hardcode file list. cleanup files after update

### DIFF
--- a/StationeersLaunchPad/Github.cs
+++ b/StationeersLaunchPad/Github.cs
@@ -1,0 +1,142 @@
+using Cysharp.Threading.Tasks;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using UnityEngine.Networking;
+
+namespace StationeersLaunchPad
+{
+  public class Github
+  {
+    public const string RepoUrl = "https://github.com/StationeersLaunchPad/StationeersLaunchPad";
+    public const string ReleaseUrlBase = "https://api.github.com/repos/StationeersLaunchPad/StationeersLaunchPad/releases";
+    public static string TagReleaseUrl(string tag) => $"{ReleaseUrlBase}/tags/{tag}";
+    public static string LatestReleaseUrl => $"{ReleaseUrlBase}/latest";
+
+    public static UniTask<Release> FetchLatestRelease() => FetchRelease("latest", LatestReleaseUrl);
+    public static UniTask<Release> FetchTagRelease(string version) => FetchRelease(version, TagReleaseUrl(version));
+
+    private static async UniTask<Release> FetchRelease(string version, string url)
+    {
+      try
+      {
+        using (var request = UnityWebRequest.Get(url))
+        {
+          request.timeout = 10; // 10 seconds because we are only fetching a json file
+
+          Logger.Global.LogDebug($"Fetching {version} release info");
+          var result = await request.SendWebRequest();
+
+          if (result.result != UnityWebRequest.Result.Success)
+          {
+            Logger.Global.LogError($"Failed to fetch {version} release info! result: {result.result}, error: {result.error}");
+            return null;
+          }
+
+          return JsonConvert.DeserializeObject<Release>(result.downloadHandler.text);
+        }
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+        Logger.Global.LogError($"Failed to fetch {version} release info. Skipping update");
+        return null;
+      }
+    }
+
+    public static async UniTask<ZipArchive> FetchZipArchive(Asset asset)
+    {
+      using (var downloadRequest = UnityWebRequest.Get(asset.BrowserDownloadUrl))
+      {
+        downloadRequest.timeout = 45; // max of 45 seconds to download the zip file
+
+        Logger.Global.LogDebug($"Downloading {asset.Name}");
+        var downloadResult = await downloadRequest.SendWebRequest();
+
+        if (downloadResult.result != UnityWebRequest.Result.Success)
+        {
+          Logger.Global.LogError($"Failed to download {asset.Name}! result: {downloadResult.result}, error: {downloadResult.error}");
+          return null;
+        }
+
+        var data = downloadRequest.downloadHandler.data;
+        Logger.Global.LogDebug($"Downloaded {data.Length} bytes");
+        var stream = new MemoryStream(data.Length);
+        stream.Write(data, 0, data.Length);
+        stream.Position = 0;
+
+        return new ZipArchive(stream);
+      }
+    }
+
+    public class Release
+    {
+      [JsonProperty("name")] public string Name;
+      [JsonProperty("tag_name")] public string TagName;
+      [JsonProperty("target_commitish")] public string BranchName;
+      [JsonProperty("id")] public int Id;
+      [JsonProperty("body")] public string Description;
+      [JsonProperty("author")] public User Author;
+      [JsonProperty("assets")] public List<Asset> Assets;
+      [JsonProperty("draft")] public bool Draft;
+      [JsonProperty("prerelease")] public bool Prerelease;
+      [JsonProperty("created_at")] public DateTime Created;
+      [JsonProperty("uploaded_at")] public DateTime Uploaded;
+      [JsonProperty("mentions_count")] public int UsersMentioned;
+      [JsonProperty("url")] public string Url;
+      [JsonProperty("assets_url")] public string AssetsUrl;
+      [JsonProperty("upload_url")] public string UploadUrl;
+      [JsonProperty("html_url")] public string HtmlUrl;
+      [JsonProperty("tarball_url")] public string TarballUrl;
+      [JsonProperty("zipball_url")] public string ZipballUrl;
+    }
+
+    public class Asset
+    {
+      [JsonProperty("name")] public string Name;
+      [JsonProperty("id")] public int Id;
+      [JsonProperty("size")] public int Size;
+      [JsonProperty("content_type")] public string Type;
+      [JsonProperty("uploader")] public User Uploader;
+      [JsonProperty("created_at")] public DateTime Created;
+      [JsonProperty("updated_at")] public DateTime Updated;
+      [JsonProperty("download_count")] public int DownloadCount;
+      [JsonProperty("label")] public string Label;
+      [JsonProperty("state")] public string State;
+      [JsonProperty("url")] public string Url;
+      [JsonProperty("digest")] public string Digest;
+      [JsonProperty("browser_download_url")] public string BrowserDownloadUrl;
+    }
+
+    public class User
+    {
+      [JsonProperty("login")] public string Name;
+      [JsonProperty("id")] public int Id;
+      [JsonProperty("type")] public string Type;
+      [JsonProperty("url")] public string Url;
+      [JsonProperty("avatar_url")] public string AvatarUrl;
+      [JsonProperty("html_url")] public string HtmlUrl;
+    }
+
+    public static string FormatDescription(string description)
+    {
+      var text = description
+        .Replace($"{RepoUrl}/pull/", "#")
+        .Replace($"{RepoUrl}/compare/", "")
+        .TrimEnd('v', 'V', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.')
+        .Split('\n')
+        .ToList();
+
+      var desc = "";
+      for (var i = 1; i < text.Count - 2; i++)
+      {
+        desc += text[i] + "\n";
+      }
+
+      return $"Whats Changed?\n{desc}";
+    }
+  }
+}

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -42,6 +42,7 @@ namespace StationeersLaunchPad
     public static ConfigEntry<LoadStrategyType> StrategyType;
     public static ConfigEntry<LoadStrategyMode> StrategyMode;
     public static ConfigEntry<bool> DisableSteam;
+    public static ConfigEntry<bool> PostUpdateCleanup;
     public static SortedConfigFile SortedConfig;
 
     public static SplashBehaviour SplashBehaviour;
@@ -164,6 +165,9 @@ namespace StationeersLaunchPad
         SortByDeps();
 
         Logger.Global.LogInfo("Mod Config Initialized");
+
+        if (CheckUpdate && PostUpdateCleanup.Value)
+          LaunchPadUpdater.RunPostUpdateCleanup();
 
         if (CheckUpdate)
         {

--- a/StationeersLaunchPad/LaunchPadPlugin.cs
+++ b/StationeersLaunchPad/LaunchPadPlugin.cs
@@ -32,13 +32,13 @@ namespace StationeersLaunchPad
     {
       if (Harmony.HasAnyPatches(pluginGuid))
         return;
-       LaunchPadConfig.DebugMode = this.Config.Bind(
-        new ConfigDefinition("Startup", "DebugMode"),
-        false,
-        new ConfigDescription(
-          "If you run into issues with loading mods, or anything else, please enable this for more verbosity in error reports"
-        )
-       );
+      LaunchPadConfig.DebugMode = this.Config.Bind(
+       new ConfigDefinition("Startup", "DebugMode"),
+       false,
+       new ConfigDescription(
+         "If you run into issues with loading mods, or anything else, please enable this for more verbosity in error reports"
+       )
+      );
       LaunchPadConfig.AutoLoadOnStart = this.Config.Bind(
         new ConfigDefinition("Startup", "AutoLoadOnStart"),
         true,
@@ -92,11 +92,20 @@ namespace StationeersLaunchPad
       LaunchPadConfig.StrategyMode = this.Config.Bind(
         new ConfigDefinition("Mod Loading", "LoadStrategyMode"),
         LoadStrategyMode.Serial,
-         new ConfigDescription(
+        new ConfigDescription(
           "Parallel mode loads faster for a large number of mods, but may fail in extremely rare cases. Switch to serial mode if running into loading issues."
         )
       );
-      LaunchPadConfig.SortedConfig = new SortedConfigFile(this.Config);
+      LaunchPadConfig.PostUpdateCleanup = this.Config.Bind(
+        new ConfigDefinition("Internal", "PostUpdateCleanup"),
+        true,
+        new ConfigDescription(
+          "This setting is automatically managed and should probably not be manually changed. Remove update backup files on start."
+        )
+      );
+      var sortedConfig = new SortedConfigFile(this.Config);
+      sortedConfig.Categories.Remove(sortedConfig.Categories.Find(cat => cat.Category == "Internal"));
+      LaunchPadConfig.SortedConfig = sortedConfig;
 
       var harmony = new Harmony(pluginGuid);
       harmony.PatchAll();
@@ -277,6 +286,5 @@ namespace StationeersLaunchPad
 
       return false;
     }
-    
   }
 }

--- a/StationeersLaunchPad/LaunchPadUpdater.cs
+++ b/StationeersLaunchPad/LaunchPadUpdater.cs
@@ -1,15 +1,11 @@
 ﻿using Assets.Scripts;
 using BepInEx;
 using Cysharp.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using UnityEngine;
-using UnityEngine.Networking;
 
 namespace StationeersLaunchPad
 {
@@ -18,23 +14,24 @@ namespace StationeersLaunchPad
   {
     public static bool AllowUpdate;
 
-    public const string LatestReleaseUrl = "https://api.github.com/repos/StationeersLaunchPad/StationeersLaunchPad/releases/latest";
-    public const string GithubUrl = "https://github.com/StationeersLaunchPad/StationeersLaunchPad";
+    private static List<UpdateAction> UpdateActions = new();
 
-    public static string TemporaryPath => Path.GetTempPath();
-    public static string ExtractionPath => Path.Combine(TemporaryPath, "StationeersLaunchPad");
+    private static string PluginPath => Path.Combine(Paths.PluginPath, "StationeersLaunchPad");
 
-    public static List<string> Assemblies = new()
+    public static void RunPostUpdateCleanup()
     {
-      "RG.ImGui",
-      "StationeersMods.Interface",
-      "StationeersMods.Shared",
-      "StationeersLaunchPad",
-    };
+      Logger.Global.LogDebug("Running post-update cleanup");
+      foreach (var file in Directory.EnumerateFiles(PluginPath, "*.dll.bak"))
+      {
+        Logger.Global.LogDebug($"Removing update backup file {file}");
+        File.Delete(Path.Combine(PluginPath, file));
+      }
+      LaunchPadConfig.PostUpdateCleanup.Value = false;
+    }
 
     public static async UniTask CheckVersion()
     {
-      var latestRelease = await FetchLatestRelease();
+      var latestRelease = await Github.FetchLatestRelease();
       // If we failed to get a release for whatever reason, just bail
       if (latestRelease == null)
         return;
@@ -59,6 +56,7 @@ namespace StationeersLaunchPad
         await PerformUpdate(latestRelease);
 
         LaunchPadConfig.HasUpdated = true;
+        LaunchPadConfig.PostUpdateCleanup.Value = true;
         Logger.Global.LogError($"Mod loader has been updated to version {latestVersion}, please restart your game!");
       }
       catch (Exception ex)
@@ -66,34 +64,6 @@ namespace StationeersLaunchPad
         Logger.Global.LogException(ex);
         Logger.Global.LogError("An error occurred during update. Rolling back");
         RevertUpdate();
-      }
-    }
-
-    private static async UniTask<Github.Release> FetchLatestRelease()
-    {
-      try
-      {
-        using (var request = UnityWebRequest.Get(LaunchPadUpdater.LatestReleaseUrl))
-        {
-          request.timeout = 10; // 10 seconds because we are only fetching a json file
-
-          Logger.Global.LogDebug($"Requesting version...");
-          UnityWebRequest result = await request.SendWebRequest();
-
-          if (result.result != UnityWebRequest.Result.Success)
-          {
-            Logger.Global.LogError($"Failed to send web request! result: {result.result}, error: {result.error}");
-            return null;
-          }
-
-          return JsonConvert.DeserializeObject<Github.Release>(result.downloadHandler.text);
-        }
-      }
-      catch (Exception ex)
-      {
-        Logger.Global.LogException(ex);
-        Logger.Global.LogError("Failed to fetch latest release info. Skipping update");
-        return null;
       }
     }
 
@@ -123,7 +93,7 @@ namespace StationeersLaunchPad
       );
     }
 
-    private static async UniTask ExtractDownloadArchive(Github.Release release)
+    private static async UniTask PerformUpdate(Github.Release release)
     {
       var assetName = GameManager.IsBatchMode ? $"StationeersLaunchPad-server-{release.TagName}.zip" : $"StationeersLaunchPad-{release.TagName}.zip";
       var asset = release.Assets.Find(a => a.Name == assetName);
@@ -133,120 +103,29 @@ namespace StationeersLaunchPad
         return;
       }
 
-      if (Directory.Exists(LaunchPadUpdater.ExtractionPath))
+      using (var archive = await Github.FetchZipArchive(asset))
       {
-        foreach (var file in Directory.GetFiles(LaunchPadUpdater.ExtractionPath))
+        foreach (var entry in archive.Entries)
         {
-          var path = Path.Combine(LaunchPadUpdater.ExtractionPath, file);
+          if (!entry.Name.EndsWith(".dll"))
+            continue;
 
-          if (File.Exists(path))
-          {
-            File.Delete(path);
-          }
+          var path = Path.Combine(PluginPath, $"{entry.Name}");
+          UpdateAction action = File.Exists(path) ? new ReplaceFileUpdateAction(path) : new NewFileUpdateAction(path);
+          UpdateActions.Add(action);
+
+          action.PerformUpdate(entry);
         }
-        Directory.Delete(LaunchPadUpdater.ExtractionPath);
       }
-
-      var zipFilePath = Path.Combine(LaunchPadUpdater.TemporaryPath, assetName);
-      if (File.Exists(zipFilePath))
-      {
-        File.Delete(zipFilePath);
-      }
-
-      using (var downloadRequest = UnityWebRequest.Get(asset.BrowserDownloadUrl))
-      {
-        downloadRequest.timeout = 45; // max of 45 seconds to download the zip file
-
-        Logger.Global.LogDebug($"Requesting download file...");
-        UnityWebRequest downloadResult = await downloadRequest.SendWebRequest();
-
-        if (downloadResult.result != UnityWebRequest.Result.Success)
-        {
-          Logger.Global.LogError($"Failed to send web request to download! result: {downloadResult.result}, error: {downloadResult.error}");
-          return;
-        }
-
-        Logger.Global.LogDebug($"Writing file to {zipFilePath}...");
-        File.WriteAllBytes(zipFilePath, downloadResult.downloadHandler.data);
-      }
-
-      using (var zipFile = ZipFile.Open(zipFilePath, ZipArchiveMode.Read))
-      {
-        Logger.Global.LogDebug($"Extracting file contents to {LaunchPadUpdater.ExtractionPath}...");
-        zipFile.ExtractToDirectory(LaunchPadUpdater.TemporaryPath);
-      }
-      File.Delete(zipFilePath);
-    }
-
-    private static async UniTask PerformUpdate(Github.Release release)
-    {
-      await ExtractDownloadArchive(release);
-
-      Logger.Global.LogDebug($"Extracted file contents to {LaunchPadUpdater.ExtractionPath}!");
-      if (!Directory.Exists(LaunchPadUpdater.ExtractionPath))
-      {
-        Logger.Global.LogError($"Failed to exteract zip file");
-        return;
-      }
-
-      var pluginPath = Path.Combine(Paths.PluginPath, "StationeersLaunchPad");
-      foreach (var file in LaunchPadUpdater.Assemblies)
-      {
-        var fileName = $"{file}.dll";
-        var backupFileName = $"{file}.dll.bak";
-        var newPath = Path.Combine(LaunchPadUpdater.ExtractionPath, fileName);
-        if (!File.Exists(newPath))
-        {
-          continue;
-        }
-
-        var path = Path.Combine(pluginPath, fileName);
-        if (!File.Exists(path))
-        {
-          continue;
-        }
-
-        var backupPath = Path.Combine(pluginPath, backupFileName);
-        if (File.Exists(backupPath))
-        {
-          File.Delete(backupPath);
-        }
-
-        Logger.Global.LogDebug($"Backing up DLL to {backupPath}!");
-        File.Move(path, backupPath);
-        Logger.Global.LogDebug($"Deleting DLL at {path}!");
-        File.Delete(path);
-
-        Logger.Global.LogDebug($"Moving new DLL to {newPath}!");
-        File.Move(newPath, path);
-      }
-      Directory.Delete(LaunchPadUpdater.ExtractionPath);
     }
 
     private static void RevertUpdate()
     {
       try
       {
-        var pluginPath = Path.Combine(Paths.PluginPath, "StationeersLaunchPad");
-        foreach (var file in LaunchPadUpdater.Assemblies)
+        foreach (var action in UpdateActions)
         {
-          var fileName = $"{file}.dll";
-          var backupFileName = $"{file}.dll.bak";
-
-          var backupPath = Path.Combine(pluginPath, backupFileName);
-          if (!File.Exists(backupPath))
-          {
-            continue;
-          }
-
-          var path = Path.Combine(pluginPath, fileName);
-          if (File.Exists(path))
-          {
-            File.Delete(path);
-          }
-
-          Logger.Global.LogDebug($"Moving backup DLL to {path}!");
-          File.Move(backupPath, path);
+          action.RevertUpdate();
         }
 
         Logger.Global.LogWarning($"Mod loader has reverted update changes due to an error.");
@@ -258,145 +137,73 @@ namespace StationeersLaunchPad
       }
     }
 
-    public class Github
+    private abstract class UpdateAction
     {
-      public class Release
+      public abstract void PerformUpdate(ZipArchiveEntry entry);
+      public abstract void RevertUpdate();
+    }
+
+    private class NewFileUpdateAction : UpdateAction
+    {
+      private string path;
+      public NewFileUpdateAction(string path) => this.path = path;
+
+      public override void PerformUpdate(ZipArchiveEntry entry)
       {
-        [JsonProperty("name")]
-        public string Name;
-
-        [JsonProperty("tag_name")]
-        public string TagName;
-
-        [JsonProperty("target_commitish")]
-        public string BranchName;
-
-        [JsonProperty("id")]
-        public int Id;
-
-        [JsonProperty("body")]
-        public string Description;
-
-        [JsonProperty("author")]
-        public User Author;
-
-        [JsonProperty("assets")]
-        public List<Asset> Assets;
-
-        [JsonProperty("draft")]
-        public bool Draft;
-
-        [JsonProperty("prerelease")]
-        public bool Prerelease;
-
-        [JsonProperty("created_at")]
-        public DateTime Created;
-
-        [JsonProperty("uploaded_at")]
-        public DateTime Uploaded;
-
-        [JsonProperty("mentions_count")]
-        public int UsersMentioned;
-
-        [JsonProperty("url")]
-        public string Url;
-
-        [JsonProperty("assets_url")]
-        public string AssetsUrl;
-
-        [JsonProperty("upload_url")]
-        public string UploadUrl;
-
-        [JsonProperty("html_url")]
-        public string HtmlUrl;
-
-        [JsonProperty("tarball_url")]
-        public string TarballUrl;
-
-        [JsonProperty("zipball_url")]
-        public string ZipballUrl;
+        Logger.Global.LogDebug($"Extracting new file to {this.path}");
+        entry.ExtractToFile(this.path);
       }
 
-
-      public class Asset
+      public override void RevertUpdate()
       {
-        [JsonProperty("name")]
-        public string Name;
-
-        [JsonProperty("id")]
-        public int Id;
-
-        [JsonProperty("size")]
-        public int Size;
-
-        [JsonProperty("content_type")]
-        public string Type;
-
-        [JsonProperty("uploader")]
-        public User Uploader;
-
-        [JsonProperty("created_at")]
-        public DateTime Created;
-
-        [JsonProperty("updated_at")]
-        public DateTime Updated;
-
-        [JsonProperty("download_count")]
-        public int DownloadCount;
-
-        [JsonProperty("label")]
-        public string Label;
-
-        [JsonProperty("state")]
-        public string State;
-
-        [JsonProperty("url")]
-        public string Url;
-
-        [JsonProperty("digest")]
-        public string Digest;
-
-        [JsonProperty("browser_download_url")]
-        public string BrowserDownloadUrl;
-      }
-
-      public class User
-      {
-        [JsonProperty("login")]
-        public string Name;
-
-        [JsonProperty("id")]
-        public int Id;
-
-        [JsonProperty("type")]
-        public string Type;
-
-        [JsonProperty("url")]
-        public string Url;
-
-        [JsonProperty("avatar_url")]
-        public string AvatarUrl;
-
-        [JsonProperty("html_url")]
-        public string HtmlUrl;
-      }
-
-      public static string FormatDescription(string description)
-      {
-        var text = description
-          .Replace($"{LaunchPadUpdater.GithubUrl}/pull/", "#")
-          .Replace($"{LaunchPadUpdater.GithubUrl}/compare/", "")
-          .TrimEnd('v', 'V', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.')
-          .Split('\n')
-          .ToList();
-
-        var desc = "";
-        for (var i = 1; i < text.Count - 2; i++)
+        if (File.Exists(this.path))
         {
-          desc += text[i] + "\n";
+          Logger.Global.LogDebug($"Removing new file {this.path}");
+          File.Delete(this.path);
+        }
+      }
+    }
+
+    private class ReplaceFileUpdateAction : UpdateAction
+    {
+      private string path;
+      public ReplaceFileUpdateAction(string path) => this.path = path;
+
+      private string backupPath => $"{this.path}.bak";
+
+      public override void PerformUpdate(ZipArchiveEntry entry)
+      {
+        Logger.Global.LogDebug($"Replacing file {this.path}");
+
+        if (File.Exists(this.backupPath))
+        {
+          Logger.Global.LogDebug($"Removing old backup {this.backupPath}");
+          File.Delete(this.backupPath);
         }
 
-        return $"Whats Changed?\n{desc}";
+        Logger.Global.LogDebug($"Backing up existing file to {this.backupPath}");
+        File.Move(this.path, this.backupPath);
+
+        Logger.Global.LogDebug($"Extracting new file to {this.path}");
+        entry.ExtractToFile(this.path);
+      }
+
+      public override void RevertUpdate()
+      {
+        if (!File.Exists(this.backupPath))
+        {
+          // nothing to do
+          return;
+        }
+
+        if (File.Exists(this.path))
+        {
+          Logger.Global.LogDebug($"Removing new file {this.path}");
+          File.Delete(this.path);
+        }
+
+        Logger.Global.LogDebug($"Restoring backup file {this.backupPath}");
+        File.Move(this.backupPath, this.path);
       }
     }
   }


### PR DESCRIPTION
Handles the downloaded zip file in memory to avoid any issues with managing temp files
Uses the list of dlls in the zip as the files to update instead of hardcoding a list of filenames
Adds an internal setting value that cleans up backup files on the first launch after an update was done