### PR TITLE
Various dedicated server, logging, and workshop fixes

### DIFF
--- a/StationeersLaunchPad/LaunchPadConfigGUI.cs
+++ b/StationeersLaunchPad/LaunchPadConfigGUI.cs
@@ -1,11 +1,7 @@
 ﻿using BepInEx.Configuration;
 using ImGuiNET;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using UI.ImGuiUi;
 using UnityEngine;
 
@@ -168,8 +164,7 @@ namespace StationeersLaunchPad
 
         foreach (var entry in category.Entries)
         {
-          if (DrawConfigEntry(entry))
-            ConfigChanged = true;
+          DrawConfigEntry(entry);
         }
       }
 

--- a/StationeersLaunchPad/LaunchPadConsoleGUI.cs
+++ b/StationeersLaunchPad/LaunchPadConsoleGUI.cs
@@ -19,8 +19,7 @@ namespace StationeersLaunchPad
     internal static bool shouldScroll = false;
     public static void DrawConsole()
     {
-      if (LaunchPadConfigGUI.DrawEnumEntry(LaunchPadConfig.LogSeverities, logSeverity))
-        LaunchPadConfigGUI.ConfigChanged = true;
+      LaunchPadConfigGUI.DrawEnumEntry(LaunchPadConfig.LogSeverities, logSeverity);
       ImGui.BeginChild("##logs", ImGuiWindowFlags.HorizontalScrollbar);
 
       var logger = LaunchPadLoaderGUI.SelectedLogger ?? Logger.Global;
@@ -63,7 +62,7 @@ namespace StationeersLaunchPad
       if (line == null)
         return;
 
-      var text = line.ToString();
+      var text = LaunchPadConfig.CompactLogs.Value ? line.CompactString : line.FullString;
       switch (line.Severity)
       {
         case LogSeverity.Debug:

--- a/StationeersLaunchPad/LaunchPadLoaderGUI.cs
+++ b/StationeersLaunchPad/LaunchPadLoaderGUI.cs
@@ -126,7 +126,10 @@ namespace StationeersLaunchPad
           else
           {
             if (LaunchPadConfigGUI.DrawConfigEntry(LaunchPadConfig.AutoSortOnStart))
+            {
+              LaunchPadConfig.AutoSort = LaunchPadConfig.AutoSortOnStart.Value;
               LaunchPadConfigGUI.ConfigChanged = true;
+            }
 
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetStyle().ItemSpacing.y);
             ImGui.Separator();

--- a/StationeersLaunchPad/LaunchPadPlugin.cs
+++ b/StationeersLaunchPad/LaunchPadPlugin.cs
@@ -44,7 +44,6 @@ namespace StationeersLaunchPad
       // *** DO NOT REFERENCE LaunchPadConfig FIELDS IN THIS METHOD ***
       // referencing LaunchPadConfig fields in this method will force the class to initialize before the method starts
       // we need to add the resolve hook above before LaunchPadConfig initializes so the steamworks types will be valid on linux
-      this.InitConfig();
 
       var harmony = new Harmony(pluginGuid);
       harmony.PatchAll();
@@ -55,112 +54,7 @@ namespace StationeersLaunchPad
       var playerLoop = PlayerLoop.GetCurrentPlayerLoop();
       PlayerLoopHelper.Initialize(ref playerLoop);
 
-      LaunchPadConfig.Run();
-    }
-
-    private void InitConfig()
-    {
-      LaunchPadConfig.DebugMode = this.Config.Bind(
-        new ConfigDefinition("Startup", "DebugMode"),
-        false,
-        new ConfigDescription(
-          "If you run into issues with loading mods, or anything else, please enable this for more verbosity in error reports"
-        )
-      );
-      LaunchPadConfig.AutoLoadOnStart = this.Config.Bind(
-        new ConfigDefinition("Startup", "AutoLoadOnStart"),
-        true,
-        new ConfigDescription(
-          "Automatically load after the configured wait time on startup. Can be stopped by clicking the loading window at the bottom"
-        )
-       );
-      LaunchPadConfig.CheckForUpdate = this.Config.Bind(
-        new ConfigDefinition("Startup", "CheckForUpdate"),
-        !GameManager.IsBatchMode, // Default to false on DS
-        new ConfigDescription(
-          "Automatically check for mod loader updates on startup."
-        )
-      );
-      LaunchPadConfig.AutoUpdateOnStart = this.Config.Bind(
-        new ConfigDefinition("Startup", "AutoUpdateOnStart"),
-        !GameManager.IsBatchMode, // Default to false on DS
-        new ConfigDescription(
-          "Automatically update mod loader on startup. Ignored if CheckForUpdate is not also enabled."
-        )
-      );
-      LaunchPadConfig.AutoLoadWaitTime = this.Config.Bind(
-        new ConfigDefinition("Startup", "AutoLoadWaitTime"),
-        3,
-        new ConfigDescription(
-          "How many seconds to wait before loading mods, then loading the game",
-          new AcceptableValueRange<int>(3, 30)
-        )
-      );
-      LaunchPadConfig.AutoSortOnStart = this.Config.Bind(
-        new ConfigDefinition("Startup", "AutoSort"),
-        true,
-        new ConfigDescription(
-          "Automatically sort based on LoadBefore/LoadAfter tags in mod data"
-        )
-      );
-      LaunchPadConfig.DisableSteam = this.Config.Bind(
-        new ConfigDefinition("Startup", "DisableSteam"),
-        false,
-         new ConfigDescription(
-          "Don't attempt to load steam workshop mods"
-        )
-      );
-      LaunchPadConfig.StrategyType = this.Config.Bind(
-        new ConfigDefinition("Mod Loading", "LoadStrategyType"),
-        LoadStrategyType.Linear,
-        new ConfigDescription(
-          "Linear type loads mods one by one in sequential order. More types of mod loading will be added later."
-        )
-      );
-      LaunchPadConfig.StrategyMode = this.Config.Bind(
-        new ConfigDefinition("Mod Loading", "LoadStrategyMode"),
-        LoadStrategyMode.Serial,
-        new ConfigDescription(
-          "Parallel mode loads faster for a large number of mods, but may fail in extremely rare cases. Switch to serial mode if running into loading issues."
-        )
-      );
-      LaunchPadConfig.SavePathOverride = this.Config.Bind(
-        new ConfigDefinition("Mod Loading", "SavePathOverride"),
-        "",
-        new ConfigDescription(
-          "This setting allows you to override the default path that config and save files are stored. Notice, due to how this path is implemented in the base game, this setting can only be applied on server start.  Changing it while in game will not have an effect until after a restart."
-        )
-      );
-      LaunchPadConfig.AutoScrollLogs = this.Config.Bind(
-        new ConfigDefinition("Logging", "AutoScrollLogs"),
-        true,
-        new ConfigDescription(
-          "This setting will automatically scroll when new lines are present if enabled."
-        )
-      );
-      LaunchPadConfig.LogSeverities = this.Config.Bind(
-        new ConfigDefinition("Logging", "LogSeverities"),
-        LogSeverity.All,
-        new ConfigDescription(
-          "This setting will filter what log severities will appear in the logging window."
-        )
-      );
-      LaunchPadConfig.PostUpdateCleanup = this.Config.Bind(
-        new ConfigDefinition("Internal", "PostUpdateCleanup"),
-        true,
-        new ConfigDescription(
-          "This setting is automatically managed and should probably not be manually changed. Remove update backup files on start."
-        )
-      );
-      LaunchPadConfig.OneTimeBoosterInstall = this.Config.Bind(
-        new ConfigDefinition("Internal", "OneTimeBoosterInstall"),
-        true,
-        new ConfigDescription(
-          "This setting is automatically managed and should probably not be manually changed. Perform one-time download of LaunchPadBooster to update from version that didn't include it."
-        )
-      );
-
-      LaunchPadConfig.SortedConfig = new SortedConfigFile(this.Config);
+      LaunchPadConfig.Run(Config);
     }
   }
 

--- a/StationeersLaunchPad/LaunchPadUpdater.cs
+++ b/StationeersLaunchPad/LaunchPadUpdater.cs
@@ -187,6 +187,9 @@ namespace StationeersLaunchPad
         AllowUpdate = true;
         return;
       }
+      // if autoupdate is not enabled on server, just move on after the out-of-date message
+      if (GameManager.IsBatchMode)
+        return;
 
       var description = Github.FormatDescription(release.Description);
       await LaunchPadAlertGUI.Show("Update Available", $"Update version {release.TagName} is available, would you like to automatically download and update?\n\n{description}",

--- a/StationeersLaunchPad/LoadStrategy.cs
+++ b/StationeersLaunchPad/LoadStrategy.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 
 namespace StationeersLaunchPad {
   public enum LoadStrategyType

--- a/StationeersLaunchPad/LoadedMod.cs
+++ b/StationeersLaunchPad/LoadedMod.cs
@@ -108,7 +108,7 @@ namespace StationeersLaunchPad
         this.Entrypoints.AddRange(ModLoader.FindBepInExEntrypoints(this.Assemblies));
         this.Entrypoints.AddRange(ModLoader.FindDefaultEntrypoints(this.Assemblies));
 
-        this.Logger.LogInfo("Found Entrypoints");
+        this.Logger.LogInfo($"Found {this.Entrypoints.Count} Entrypoints");
       });
     }
 

--- a/StationeersLaunchPad/LogLine.cs
+++ b/StationeersLaunchPad/LogLine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace StationeersLaunchPad
 {
@@ -31,6 +32,9 @@ namespace StationeersLaunchPad
 
     public bool IsException => !string.IsNullOrEmpty(this.Source) || !string.IsNullOrEmpty(this.StackTrace);
 
+    public readonly string FullString;
+    public readonly string CompactString;
+
     public LogLine(string prefix, string message, LogSeverity severity)
     {
       this.Prefix = prefix;
@@ -38,6 +42,9 @@ namespace StationeersLaunchPad
       this.Source = string.Empty;
       this.StackTrace = string.Empty;
       this.Severity = severity;
+
+      this.FullString = $"[{this.Prefix} - {this.Severity}]: {this.Message}";
+      this.CompactString = $"[{this.Prefix}]: {this.Message}";
     }
 
     public LogLine(string prefix, Exception exception)
@@ -47,8 +54,20 @@ namespace StationeersLaunchPad
       this.Source = exception.Source ?? string.Empty;
       this.StackTrace = exception.StackTrace ?? string.Empty;
       this.Severity = LogSeverity.Exception;
+
+      var sb = new StringBuilder();
+      while (exception != null)
+      {
+        sb.AppendLine(exception.Message);
+        sb.AppendLine(exception.StackTrace);
+        exception = exception.InnerException;
+      }
+      var fullStackTrace = sb.ToString().Trim();
+
+      this.FullString = $"[{this.Prefix} - {this.Source}]: {fullStackTrace}";
+      this.CompactString = $"[{this.Prefix}]: {fullStackTrace}";
     }
 
-    public override string ToString() => this.IsException ? $"[{this.Prefix} - {this.Source} - {this.StackTrace}]: {this.Message}" : $"[{this.Prefix} - {this.Severity}]: {this.Message}";
+    public override string ToString() => FullString;
   }
 }

--- a/StationeersLaunchPad/LogWrapper.cs
+++ b/StationeersLaunchPad/LogWrapper.cs
@@ -12,9 +12,23 @@ namespace StationeersLaunchPad
       this.Inner = inner;
     }
 
+    private bool IsLaunchpadLog()
+    {
+      var st = new StackTrace(2);
+      for (var i = 0; i < st.FrameCount; i++)
+      {
+        var frame = st.GetFrame(i);
+        if (frame.GetMethod().DeclaringType == typeof(Logger))
+          return true;
+      }
+      return false;
+    }
+
     public void LogException(Exception exception, UnityEngine.Object context)
     {
       this.Inner.LogException(exception, context);
+      if (IsLaunchpadLog())
+        return;
       if (ModLoader.TryGetExecutingMod(out var mod))
         mod.Logger.LogException(exception, false);
       else if (ModLoader.TryGetStackTraceMod(new StackTrace(exception), out var mod2))
@@ -24,6 +38,8 @@ namespace StationeersLaunchPad
     public void LogFormat(LogType logType, UnityEngine.Object context, string format, params object[] args)
     {
       this.Inner.LogFormat(logType, context, format, args);
+      if (IsLaunchpadLog())
+        return;
       if (ModLoader.TryGetExecutingMod(out var mod))
         mod.Logger.LogInfoFormat(false, format, args);
     }


### PR DESCRIPTION
- Initialize BepInEx config after waiting a frame so dedicated server gets proper defaults
- Skip wait time on dedicated server
- Exit instead of hanging indefinitely when load errors occur on dedicated server
- Don't rewrite modconfig.xml on every BepInEx config change
- Add compact log display option
- Move exception message to top and show inner exceptions in log display
- Don't double log exceptions thrown during mod initialization
- Download workshop mods when not installed or out of date