### PR TITLE
Catch error if steam is not available

### DIFF
--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -369,6 +369,7 @@ namespace StationeersLaunchPad
         {
           var transport = LaunchPadPatches.GetMetaServerTransport();
           transport.InitClient();
+          SteamDisabled = !SteamClient.IsValid;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
When starting the game like this:
- Linux
- No steam process running
- Game started with `WINEDLLOVERRIDES="winhttp=n,b" proton-ge run rocketstation.exe`

I get the error below during startup. Launchpad then crashes and does not load any mods.

```
[Global]: Listing Local Mods
[Global]: Listing Workshop Mods
[Global]: Error occurred during initialization. Mods will not be loaded.
NullReferenceException: Object reference not set to an instance of an object
  at Steamworks.SteamClient.get_SteamId () [0x00005] in <19bd4cc6a4004258bf538b05ac1133d6>:0 
  at Steamworks.Ugc.Query.LimitUser (Steamworks.SteamId steamid) [0x0000f] in <19bd4cc6a4004258bf538b05ac1133d6>:0 
  at Steamworks.Ugc.Query.WhereUserSubscribed (Steamworks.SteamId user) [0x00008] in <19bd4cc6a4004258bf538b05ac1133d6>:0 
  at StationeersLaunchPad.LaunchPadConfig.FetchWorkshopPage (System.Int32 page) [0x00027] in StationeersLaunchPad/StationeersLaunchPad/LaunchPadConfig.cs:561 
  at Cysharp.Threading.Tasks.UniTask+ExceptionResultSource`1[T].GetResult (System.Int16 token) [0x00000] in <a846ac54e84846a2a558afbf05fd02e8>:0 
  at Cysharp.Threading.Tasks.UniTask+WhenAllPromise`1[T].TryInvokeContinuation (Cysharp.Threading.Tasks.UniTask+WhenAllPromise`1[T] self, Cysharp.Threading.Tasks.UniTask`1+Awaiter[T]& awaiter, System.Int32 i) [0x00000] in <a846ac54e84846a2a558afbf05fd02e8>:0 
--- End of stack trace from previous location where exception was thrown ---

  at Cysharp.Threading.Tasks.UniTask+WhenAllPromise`1[T].GetResult (System.Int16 token) [0x00006] in <a846ac54e84846a2a558afbf05fd02e8>:0 
  at StationeersLaunchPad.LaunchPadConfig.LoadWorkshopItems () [0x000a7] in StationeersLaunchPad/StationeersLaunchPad/LaunchPadConfig.cs:517 
  at Cysharp.Threading.Tasks.UniTask+ExceptionResultSource.GetResult (System.Int16 token) [0x00000] in <a846ac54e84846a2a558afbf05fd02e8>:0 
  at StationeersLaunchPad.LaunchPadConfig.Load () [0x001d1] in StationeersLaunchPad/StationeersLaunchPad/LaunchPadConfig.cs:313 
```

Catching the exception fixes this, although I guess there are more graceful ways of detecting if steam is available.
