### PR TITLE
Refactor github utility to handle any github repo

### DIFF
--- a/StationeersLaunchPad/Github.cs
+++ b/StationeersLaunchPad/Github.cs
@@ -5,50 +5,21 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text.RegularExpressions;
 using UnityEngine.Networking;
 
 namespace StationeersLaunchPad
 {
   public class Github
   {
-    public const string RepoUrl = "https://github.com/StationeersLaunchPad/StationeersLaunchPad";
-    public const string BoosterRepoUrl = "https://github.com/StationeersLaunchPad/LaunchPadBooster";
-    public const string ReleaseUrlBase = "https://api.github.com/repos/StationeersLaunchPad/StationeersLaunchPad/releases";
-    public static string TagReleaseUrl(string tag) => $"{ReleaseUrlBase}/tags/{tag}";
-    public static string LatestReleaseUrl => $"{ReleaseUrlBase}/latest";
+    public static readonly Repo LaunchPadRepo = new("StationeersLaunchPad", "StationeersLaunchPad");
 
-    public static UniTask<Release> FetchLatestRelease() => FetchRelease("latest", LatestReleaseUrl);
-    public static UniTask<Release> FetchTagRelease(string version) => FetchRelease(version, TagReleaseUrl(version));
+    private const string UserPattern = @"\w+(?:\-\w+)*";
+    private const string RepoPattern = @"[\w\.\-]+";
+    private static readonly Regex PullPrefixRegex = new($"https://github.com/({UserPattern})/({RepoPattern})/pull/");
+    private static readonly Regex ComparePrefixRegex = new($"https://github.com/({UserPattern})/({RepoPattern})/compare/");
 
-    private static async UniTask<Release> FetchRelease(string version, string url)
-    {
-      try
-      {
-        using (var request = UnityWebRequest.Get(url))
-        {
-          request.timeout = 10; // 10 seconds because we are only fetching a json file
-
-          Logger.Global.LogDebug($"Fetching {version} release info");
-          var result = await request.SendWebRequest();
-
-          if (result.result != UnityWebRequest.Result.Success)
-          {
-            Logger.Global.LogError($"Failed to fetch {version} release info! result: {result.result}, error: {result.error}");
-            return null;
-          }
-
-          return JsonConvert.DeserializeObject<Release>(result.downloadHandler.text);
-        }
-      }
-      catch (Exception ex)
-      {
-        Logger.Global.LogException(ex);
-        Logger.Global.LogError($"Failed to fetch {version} release info. Skipping update");
-        return null;
-      }
-    }
-
-    public static async UniTask<ZipArchive> FetchZipArchive(Asset asset)
+    private static async UniTask<ZipArchive> FetchZipToMemory(Asset asset)
     {
       using (var downloadRequest = UnityWebRequest.Get(asset.BrowserDownloadUrl))
       {
@@ -73,8 +44,88 @@ namespace StationeersLaunchPad
       }
     }
 
+    private static async UniTask<T> FetchJSON<T>(string url) where T : class
+    {
+      try
+      {
+        using (var request = UnityWebRequest.Get(url))
+        {
+          request.timeout = 10; // 10 seconds because we are only fetching a json file
+
+          Logger.Global.LogDebug($"Fetching {url}");
+          var result = await request.SendWebRequest();
+
+          if (result.result != UnityWebRequest.Result.Success)
+          {
+            Logger.Global.LogError($"Failed to fetch {url}. result: {result.result}, error: {result.error}");
+            return null;
+          }
+
+          return JsonConvert.DeserializeObject<T>(result.downloadHandler.text);
+        }
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+        Logger.Global.LogError($"Failed to fetch {url}. Skipping update");
+        return null;
+      }
+    }
+
+    public class Repo
+    {
+      public readonly string Owner;
+      public readonly string Name;
+
+      public Repo(string owner, string name)
+      {
+        this.Owner = owner;
+        this.Name = name;
+      }
+
+      public string WebURL => $"https://github.com/{Owner}/{Name}";
+      public string ReleaseListURL => $"https://api.github.com/repos/{Owner}/{Name}/releases";
+      public string LatestReleaseURL => $"{this.ReleaseListURL}/latest";
+      public string TagReleaseURL(string tag) => $"{this.ReleaseListURL}/tags/{tag}";
+
+      public async UniTask<List<Release>> FetchReleaseList()
+      {
+        var releases = await FetchJSON<List<Release>>(this.ReleaseListURL) ?? new();
+        foreach (var release in releases)
+          this.InitRelease(release);
+        return releases;
+      }
+
+      public async UniTask<Release> FetchLatestRelease()
+      {
+        var release = await FetchJSON<Release>(this.LatestReleaseURL);
+        InitRelease(release);
+        return release;
+      }
+
+      public async UniTask<Release> FetchTagRelease(string tag)
+      {
+        var release = await FetchJSON<Release>(this.TagReleaseURL(tag));
+        InitRelease(release);
+        return release;
+      }
+
+      private void InitRelease(Release release)
+      {
+        if (release == null)
+          return;
+        release.Repo = this;
+        if (release.Assets != null)
+        {
+          foreach (var asset in release.Assets)
+            asset.Release = release;
+        }
+      }
+    }
+
     public class Release
     {
+      [JsonIgnore] public Repo Repo;
       [JsonProperty("name")] public string Name;
       [JsonProperty("tag_name")] public string TagName;
       [JsonProperty("target_commitish")] public string BranchName;
@@ -93,10 +144,49 @@ namespace StationeersLaunchPad
       [JsonProperty("html_url")] public string HtmlUrl;
       [JsonProperty("tarball_url")] public string TarballUrl;
       [JsonProperty("zipball_url")] public string ZipballUrl;
+
+      public string FormatDescription()
+      {
+        var text = Description;
+        var matches = PullPrefixRegex.Matches(text);
+        for (var i = 0; i < matches.Count; i++)
+        {
+          var match = matches[i];
+          var relName = this.RelativeName(match.Groups[1].Value, match.Groups[2].Value);
+          text = text.Replace(match.Value, $"{relName}#");
+        }
+        matches = ComparePrefixRegex.Matches(text);
+        for (var i = 0; i < matches.Count; i++)
+        {
+          var match = matches[i];
+          var relName = this.RelativeName(match.Groups[1].Value, match.Groups[2].Value);
+          text = text.Replace(match.Value, relName);
+        }
+        var lines = text
+          .TrimEnd('v', 'V', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.')
+          .Split('\n')
+          .ToList();
+
+        var desc = "";
+        for (var i = 1; i < lines.Count - 2; i++)
+        {
+          desc += lines[i] + "\n";
+        }
+
+        return $"Whats Changed?\n{desc}";
+      }
+
+      private string RelativeName(string owner, string name) => (owner, name) switch
+      {
+        _ when owner == Repo.Owner && name == Repo.Name => "",
+        _ when owner == Repo.Owner => name,
+        _ => $"{owner}/{name}",
+      };
     }
 
     public class Asset
     {
+      [JsonIgnore] public Release Release;
       [JsonProperty("name")] public string Name;
       [JsonProperty("id")] public int Id;
       [JsonProperty("size")] public int Size;
@@ -110,6 +200,8 @@ namespace StationeersLaunchPad
       [JsonProperty("url")] public string Url;
       [JsonProperty("digest")] public string Digest;
       [JsonProperty("browser_download_url")] public string BrowserDownloadUrl;
+
+      public UniTask<ZipArchive> FetchToMemory() => FetchZipToMemory(this);
     }
 
     public class User
@@ -120,25 +212,6 @@ namespace StationeersLaunchPad
       [JsonProperty("url")] public string Url;
       [JsonProperty("avatar_url")] public string AvatarUrl;
       [JsonProperty("html_url")] public string HtmlUrl;
-    }
-
-    public static string FormatDescription(string description)
-    {
-      var text = description
-        .Replace($"{RepoUrl}/pull/", "#")
-        .Replace($"{RepoUrl}/compare/", "")
-        .Replace($"{BoosterRepoUrl}/pull/", "LaunchPadBooster#")
-        .TrimEnd('v', 'V', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.')
-        .Split('\n')
-        .ToList();
-
-      var desc = "";
-      for (var i = 1; i < text.Count - 2; i++)
-      {
-        desc += text[i] + "\n";
-      }
-
-      return $"Whats Changed?\n{desc}";
     }
   }
 }

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -776,17 +776,26 @@ namespace StationeersLaunchPad
 
     private async static UniTask<bool> RunUpdate()
     {
-      Logger.Global.LogInfo("Checking Version");
-      var release = await LaunchPadUpdater.GetUpdateRelease();
-      if (release == null || !await LaunchPadUpdater.CheckShouldUpdate(release))
-        return false;
+      try
+      {
+        Logger.Global.LogInfo("Checking Version");
+        var release = await LaunchPadUpdater.GetUpdateRelease();
+        if (release == null || !await LaunchPadUpdater.CheckShouldUpdate(release))
+          return false;
 
-      if (!await LaunchPadUpdater.UpdateToRelease(release))
-        return false;
+        if (!await LaunchPadUpdater.UpdateToRelease(release))
+          return false;
 
-      Logger.Global.LogError($"StationeersLaunchPad updated to {release.TagName}, please restart your game!");
-      PostUpdateCleanup.Value = true;
-      return true;
+        Logger.Global.LogError($"StationeersLaunchPad updated to {release.TagName}, please restart your game!");
+        PostUpdateCleanup.Value = true;
+        return true;
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogError("An error occurred during update.");
+        Logger.Global.LogException(ex);
+        return false;
+      }
     }
 
     private static void RestartGame()

--- a/StationeersLaunchPad/LaunchPadConsoleGUI.cs
+++ b/StationeersLaunchPad/LaunchPadConsoleGUI.cs
@@ -44,8 +44,8 @@ namespace StationeersLaunchPad
 
       ImGuiHelper.DrawIfHovering(() =>
       {
-        ImGuiHelper.TextTooltip("Click to copy logs.");
-        if (ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        ImGuiHelper.TextTooltip("Right-click to copy logs.");
+        if (ImGui.IsMouseClicked(ImGuiMouseButton.Right))
         {
           logger.CopyToClipboard();
           logger.Log("Logs copied to clipboard.");

--- a/StationeersLaunchPad/LaunchPadUpdater.cs
+++ b/StationeersLaunchPad/LaunchPadUpdater.cs
@@ -60,7 +60,7 @@ namespace StationeersLaunchPad
         }
         var targetTag = $"v{LaunchPadPlugin.pluginVersion}";
         Logger.Global.Log($"Installing LaunchPadBooster from release {targetTag}");
-        var release = await Github.FetchTagRelease(targetTag);
+        var release = await Github.LaunchPadRepo.FetchTagRelease(targetTag);
         if (release == null)
         {
           LaunchPadConfig.AutoLoad = false;
@@ -77,7 +77,7 @@ namespace StationeersLaunchPad
           return;
         }
 
-        using (var archive = await Github.FetchZipArchive(asset))
+        using (var archive = await asset.FetchToMemory())
         {
           var entry = archive.Entries.First(entry => entry.Name == boosterName);
           if (entry == null)
@@ -107,7 +107,7 @@ namespace StationeersLaunchPad
         return null;
       }
 
-      var latestRelease = await Github.FetchLatestRelease();
+      var latestRelease = await Github.LaunchPadRepo.FetchLatestRelease();
       // If we failed to get a release for whatever reason, just bail
       if (latestRelease == null)
         return null;
@@ -152,7 +152,7 @@ namespace StationeersLaunchPad
         return true;
       }
 
-      var description = Github.FormatDescription(release.Description);
+      var description = release.FormatDescription();
       await LaunchPadAlertGUI.Show("Update Available", $"StationeersLaunchPad {release.TagName} is available, would you like to automatically download and update?\n\n{description}",
         new Vector2(800, 400),
         LaunchPadAlertGUI.DefaultPosition,
@@ -173,7 +173,7 @@ namespace StationeersLaunchPad
         return false;
       }
 
-      using (var archive = await Github.FetchZipArchive(asset))
+      using (var archive = await asset.FetchToMemory())
       {
         var sequence = UpdateSequence.Make(
           LaunchPadPaths.InstallDir,


### PR DESCRIPTION
This removes the hardcoded URLs for the launchpad repo and instead operates off a `Repo` object setup with a specific owner and name.

Adds an extra try-catch around update code, as I found while testing that a bug in the github data handling would prevent launchpad from loading at all.

Also snuck in a change to make the log copy work off right-click instead of left-click, as I kept accidentally copying the logs while trying to drag the scroll bar.