### PR TITLE
Build against game core dlls. Add compatibility layer for unitask

### DIFF
--- a/Stationeers.VS.References.props
+++ b/Stationeers.VS.References.props
@@ -1,10 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <!-- System DLL's -->
-    <Reference Include="System.IO.Compression">
-      <HintPath>$(StationeersManagedDirectory)\System.IO.Compression.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <SystemDll Include="$(StationeersManagedDirectory)\mscorlib.dll" />
+    <SystemDll Include="$(StationeersManagedDirectory)\netstandard.dll" />
+    <SystemDll Include="$(StationeersManagedDirectory)\System*.dll" />
+    <SystemRefs Include="@(SystemDll->'%(Filename)')">
+      <HintPath>$(StationeersManagedDirectory)\%(Identity).dll</HintPath>
+    </SystemRefs>
+    <Reference Include="@(SystemRefs)" />
 
     <!-- BepInEx DLL's -->
     <Reference Include="BepInEx">
@@ -62,7 +65,7 @@
       <HintPath>$(StationeersManagedDirectory)\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-	<Reference Include="UnityEngine.CoreModule">
+    <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(StationeersManagedDirectory)\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>

--- a/Stationeers.VS.props
+++ b/Stationeers.VS.props
@@ -7,6 +7,7 @@
     <LangVersion>9.0</LangVersion>
     <ErrorReport>none</ErrorReport>
     <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -32,6 +33,12 @@
     <BIEPluginsDirectory>$(BIEDirectory)\plugins</BIEPluginsDirectory>
 
     <SLPPluginPath>$(BIEPluginsDirectory)\StationeersLaunchPad</SLPPluginPath>
+
+    <NoStandardLibraries>true</NoStandardLibraries>
+    <NoStdLib>true</NoStdLib>
+    <NoConfig>true</NoConfig>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <NoWarn>$(NoWarn);MSB3277</NoWarn> <!-- unity ships dlls with conflicting references -->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -80,7 +80,7 @@ namespace StationeersLaunchPad
       if (!GameManager.IsBatchMode)
       {
         AutoStopwatch.Restart();
-        await UniTask.WaitWhile(() => LoadState == LoadState.Configuring && !AutoLoadReady);
+        await UniTaskX.WaitWhile(() => LoadState == LoadState.Configuring && !AutoLoadReady);
       }
 
       if (LoadState == LoadState.Configuring)
@@ -98,7 +98,7 @@ namespace StationeersLaunchPad
       if (!GameManager.IsBatchMode)
       {
         AutoStopwatch.Restart();
-        await UniTask.WaitWhile(() => LoadState < LoadState.Running && !AutoLoadReady);
+        await UniTaskX.WaitWhile(() => LoadState < LoadState.Running && !AutoLoadReady);
       }
 
       StartGame();
@@ -142,7 +142,7 @@ namespace StationeersLaunchPad
         LoadState = LoadState.Initializing;
 
         Logger.Global.LogInfo("Initializing...");
-        await UniTask.Run(() => Initialize());
+        await UniTask.RunOnThreadPool(() => Initialize());
 
         LoadState = LoadState.Searching;
 

--- a/StationeersLaunchPad/UniTaskX.cs
+++ b/StationeersLaunchPad/UniTaskX.cs
@@ -1,0 +1,63 @@
+
+using Cysharp.Threading.Tasks;
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+namespace StationeersLaunchPad
+{
+  public static class UniTaskX
+  {
+    private delegate UniTask WaitWhile1(Func<bool> predicate, PlayerLoopTiming timing, CancellationToken cancellationToken);
+    private delegate UniTask WaitWhile2(Func<bool> predicate, PlayerLoopTiming timing, CancellationToken cancellationToken, bool cancelImmediately);
+    private static WaitWhile1 WaitWhileFn;
+    public static UniTask WaitWhile(Func<bool> predicate, PlayerLoopTiming timing = PlayerLoopTiming.Update, CancellationToken cancellationToken = default)
+    {
+      static WaitWhile1 wrap(WaitWhile2 fn) => (p, t, c) => fn(p, t, c, false);
+      WaitWhileFn ??= MakeCompatDelegate<WaitWhile1, WaitWhile2>("WaitWhile", wrap);
+      return WaitWhileFn(predicate, timing, cancellationToken);
+    }
+
+    private static bool SignaturesMatch(MethodInfo f1, MethodInfo f2)
+    {
+      if (f1.ReturnType != f2.ReturnType)
+        return false;
+      var ps1 = f1.GetParameters();
+      var ps2 = f2.GetParameters();
+      if (ps1.Length != ps2.Length)
+        return false;
+      for (var i = 0; i < ps1.Length; i++)
+      {
+        var p1 = ps1[i];
+        var p2 = ps2[i];
+        if (p1.ParameterType != p2.ParameterType)
+          return false;
+        if (p1.IsOut != p2.IsOut)
+          return false;
+        if (p1.IsRetval != p2.IsRetval)
+          return false;
+      }
+      return true;
+    }
+
+    private static F MakeCompatDelegate<F, F2>(string name, Func<F2, F> wrap)
+      where F : Delegate
+      where F2 : Delegate
+    {
+      var methods = typeof(UniTask).GetMethods(BindingFlags.Public | BindingFlags.Static);
+      var fmethod = typeof(F).GetMethod("Invoke");
+      var f2method = typeof(F2).GetMethod("Invoke");
+
+      var fmatch = methods.FirstOrDefault(f => f.Name == name && SignaturesMatch(f, fmethod));
+      if (fmatch != null)
+        return (F) fmatch.CreateDelegate(typeof(F));
+
+      var f2match = methods.FirstOrDefault(f => f.Name == name && SignaturesMatch(f, f2method))
+        ?? throw new InvalidOperationException($"Could not find UniTask.{name} matching {typeof(F)} or {typeof(F2)}");
+
+      var f2 = (F2) f2match.CreateDelegate(typeof(F2));
+      return wrap(f2);
+    }
+  }
+}


### PR DESCRIPTION
After updating my dev environment to .NET 10, the build was failing due to various core classes missing. This switches the build to directly build against the core dlls (mscorlib, netstandard, System*.dll) shipped with the game, instead of building against net48 or netstandard2.1 (both of which failed on the new .NET build tools).

Also adds in the `UniTaskX` utility class for handling the UniTask version change currently on beta. 