### PR TITLE
Fix autosort skipping out of order mods and then crashing

### DIFF
--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -205,7 +205,7 @@ namespace StationeersLaunchPad
       }
       else
       {
-        var changed = LaunchPadLoaderGUI.DrawManualLoad(LoadState, modList);
+        var changed = LaunchPadLoaderGUI.DrawManualLoad(LoadState, modList, AutoSort);
         HandleChange(changed);
       }
 
@@ -222,7 +222,7 @@ namespace StationeersLaunchPad
       var sortChanged = changed.HasFlag(LaunchPadLoaderGUI.ChangeFlags.AutoSort);
       var modsChanged = changed.HasFlag(LaunchPadLoaderGUI.ChangeFlags.Mods);
       if (sortChanged)
-        AutoSort = Configs.AutoLoadOnStart.Value;
+        AutoSort = Configs.AutoSortOnStart.Value;
       if (sortChanged || modsChanged)
       {
         modList.CheckDependencies();

--- a/StationeersLaunchPad/LaunchPadLoaderGUI.cs
+++ b/StationeersLaunchPad/LaunchPadLoaderGUI.cs
@@ -64,7 +64,7 @@ namespace StationeersLaunchPad
       return stopAuto;
     }
 
-    public static ChangeFlags DrawManualLoad(LoadState loadState, ModList modList)
+    public static ChangeFlags DrawManualLoad(LoadState loadState, ModList modList, bool autoSort)
     {
       var changed = ChangeFlags.None;
 
@@ -146,7 +146,7 @@ namespace StationeersLaunchPad
               ImGui.Separator();
             }
 
-            if (DrawConfigTable(modList, loadState == LoadState.Configuring))
+            if (DrawConfigTable(modList, loadState == LoadState.Configuring, autoSort))
               changed |= ChangeFlags.Mods;
             break;
           }
@@ -223,7 +223,7 @@ namespace StationeersLaunchPad
       return changed;
     }
 
-    private static bool DrawConfigTable(ModList modList, bool edit = false)
+    private static bool DrawConfigTable(ModList modList, bool edit = false, bool autoSort = false)
     {
       var changed = false;
       if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
@@ -299,7 +299,7 @@ namespace StationeersLaunchPad
       if (edit && draggingIndex != -1 && hoveringIndex != -1 && draggingIndex != hoveringIndex)
       {
         dragged = true;
-        if (modList.MoveModTo(draggingMod, hoveringIndex))
+        if (modList.MoveModTo(draggingMod, hoveringIndex, autoSort))
           changed = true;
       }
       return changed;

--- a/StationeersLaunchPad/ModList.cs
+++ b/StationeersLaunchPad/ModList.cs
@@ -204,7 +204,7 @@ namespace StationeersLaunchPad
     }
 
     // returns true if the mod was moved (even if it wasn't moved all the way to the target index)
-    public bool MoveModTo(ModInfo mod, int index)
+    public bool MoveModTo(ModInfo mod, int index, bool keepOrder)
     {
       var curIndex = mods.IndexOf(mod);
       if (curIndex == -1)
@@ -223,7 +223,7 @@ namespace StationeersLaunchPad
         var next = idx + dir;
         if (next < 0 || next >= this.mods.Count)
           return false;
-        if (deps.Contains(this.mods[next]) && !shift(next))
+        if (keepOrder && deps.Contains(this.mods[next]) && !shift(next))
           return false;
         (this.mods[idx], this.mods[next]) = (this.mods[next], this.mods[idx]);
         return true;
@@ -366,7 +366,7 @@ namespace StationeersLaunchPad
         }
         if (mod.Enabled && !areDepsAdded(mod))
         {
-          if (firstSkipped != -1)
+          if (firstSkipped == -1)
             firstSkipped = idx;
           idx++;
           continue;


### PR DESCRIPTION
additional fixes:
- fixes AutoSort state not set properly when using checkbox above mod list (due to reading AutoLoad config instead of AutoSort)
- fixes drag reordering mods would push mods with order constraints even when AutoSort was disabled