### PR TITLE
Refactor mod metadata loading

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,9 @@ root = true
 #### Core EditorConfig Options ####
 
 # Indentation and spacing
-indent_size = 4
+indent_size = 2
 indent_style = space
-tab_width = 4
+tab_width = 2
 
 # New line preferences
 end_of_line = crlf
@@ -121,7 +121,7 @@ csharp_style_prefer_readonly_struct = false
 csharp_style_prefer_readonly_struct_member = true
 
 # Code-block preferences
-csharp_prefer_braces = when_multiline:suggestion
+csharp_prefer_braces = when_multiline
 csharp_prefer_simple_using_statement = false:suggestion
 csharp_prefer_system_threading_lock = true:suggestion
 csharp_style_namespace_declarations = block_scoped:suggestion
@@ -200,8 +200,8 @@ csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
 # Wrapping preferences
-csharp_preserve_single_line_blocks = false
-csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
 
 #### Naming styles ####
 

--- a/StationeersLaunchPad/ExplorerUtil.cs
+++ b/StationeersLaunchPad/ExplorerUtil.cs
@@ -1,0 +1,33 @@
+
+using System;
+using System.Diagnostics;
+
+namespace StationeersLaunchPad
+{
+  public static class ExplorerUtil
+  {
+    public static void Open(string dirPath)
+    {
+      try
+      {
+        Process.Start("explorer.exe", $"\"{dirPath}\"");
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+      }
+    }
+
+    public static void OpenDirectorySelect(string filePath)
+    {
+      try
+      {
+        Process.Start("explorer", $"/select,\"{filePath}\"");
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+      }
+    }
+  }
+}

--- a/StationeersLaunchPad/LaunchPadConfigGUI.cs
+++ b/StationeersLaunchPad/LaunchPadConfigGUI.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx.Configuration;
 using ImGuiNET;
+using StationeersLaunchPad.Sources;
 using System;
 using System.Reflection;
 using UI.ImGuiUi;
@@ -28,7 +29,7 @@ namespace StationeersLaunchPad
 
     public static void DrawConfigEditor(ModInfo modInfo)
     {
-      if (modInfo == null || modInfo.Source == ModSource.Core)
+      if (modInfo == null || modInfo.Source == ModSourceType.Core)
       {
         ImGuiHelper.TextDisabled("Select a mod to edit configuration");
         return;
@@ -44,7 +45,7 @@ namespace StationeersLaunchPad
       var configFiles = mod.GetSortedConfigs();
       if (configFiles == null || configFiles.Count == 0)
       {
-        ImGuiHelper.TextDisabled($"{modInfo.DisplayName} does not have any configuration");
+        ImGuiHelper.TextDisabled($"{modInfo.Name} does not have any configuration");
         return;
       }
 

--- a/StationeersLaunchPad/LaunchPadLoaderGUI.cs
+++ b/StationeersLaunchPad/LaunchPadLoaderGUI.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx;
 using ImGuiNET;
+using StationeersLaunchPad.Sources;
 using System;
 using UnityEngine;
 
@@ -188,11 +189,11 @@ namespace StationeersLaunchPad
 
               foreach (var mod in modList.AllMods)
               {
-                if (mod.Source is ModSource.Core)
+                if (mod.Source is ModSourceType.Core)
                   continue;
                 var flag = mod.Enabled ? hasEnabled : hasDisabled;
                 allState |= flag;
-                if (mod.Source is ModSource.Local)
+                if (mod.Source is ModSourceType.Local)
                   localState |= flag;
                 else
                   workshopState |= flag;
@@ -234,9 +235,9 @@ namespace StationeersLaunchPad
               {
                 foreach (var mod in modList.AllMods)
                 {
-                  if (mod.Source is ModSource.Core)
+                  if (mod.Source is ModSourceType.Core)
                     continue;
-                  var tgtFlags = mod.Source is ModSource.Workshop ? tgtWorkshop : tgtLocal;
+                  var tgtFlags = mod.Source is ModSourceType.Workshop ? tgtWorkshop : tgtLocal;
                   if (tgtFlags == hasBoth)
                     continue;
                   var tgt = (tgtFlags & hasEnabled) != 0;
@@ -337,7 +338,7 @@ namespace StationeersLaunchPad
         if (draggingMod != null && !dragged)
         {
           selectedInfo = draggingMod;
-          if (selectedInfo != null && selectedInfo.Source == ModSource.Core)
+          if (selectedInfo != null && selectedInfo.Source == ModSourceType.Core)
             selectedInfo = null;
           openInfo = selectedInfo != null;
         }
@@ -384,7 +385,7 @@ namespace StationeersLaunchPad
           ImGuiHelper.DrawSameLine(() => ImGuiHelper.Text($"{mod.Source}"));
 
           ImGui.TableNextColumn();
-          ImGuiHelper.Text($"{mod.DisplayName}");
+          ImGuiHelper.Text($"{mod.Name}");
 
           if (draggingMod != null)
             if (mod.SortBefore(draggingMod))
@@ -439,7 +440,7 @@ namespace StationeersLaunchPad
           ImGuiHelper.DrawSameLine(() => ImGuiHelper.Text($"{info.Source}"));
 
           ImGui.TableNextColumn();
-          ImGuiHelper.Text(info.DisplayName);
+          ImGuiHelper.Text(info.Name);
 
           ImGui.PopID();
           idx++;
@@ -452,7 +453,7 @@ namespace StationeersLaunchPad
     {
       var mod = info?.Loaded;
 
-      if (info.Source == ModSource.Core)
+      if (info.Source == ModSourceType.Core)
       {
         ImGuiHelper.Text("C");
         ImGuiHelper.ItemTooltip("This mod contains Stationeers' assemblies and data.");
@@ -511,16 +512,16 @@ namespace StationeersLaunchPad
 
       var about = selectedInfo.About;
 
-      ImGuiHelper.Text(selectedInfo.DisplayName);
+      ImGuiHelper.Text(selectedInfo.Name);
 
       if (ImGui.Button("Open Local Folder"))
-        selectedInfo.OpenLocalFolder();
+        ExplorerUtil.Open(selectedInfo.DirectoryPath);
 
       if (selectedInfo.WorkshopHandle > 1)
       {
         ImGui.SameLine();
         if (ImGui.Button("Open Workshop Page"))
-          selectedInfo.OpenWorkshopPage();
+          Steam.OpenWorkshopPage(selectedInfo.WorkshopHandle);
       }
 
       ImGui.Spacing();
@@ -528,12 +529,12 @@ namespace StationeersLaunchPad
       ImGui.SameLine();
       ImGuiHelper.Text(selectedInfo.Source.ToString());
 
-      if (!string.IsNullOrEmpty(selectedInfo.Path))
+      if (!string.IsNullOrEmpty(selectedInfo.DirectoryPath))
       {
         ImGui.Spacing();
         ImGuiHelper.Text("Path:");
         ImGui.SameLine();
-        ImGuiHelper.Text(selectedInfo.Path);
+        ImGuiHelper.Text(selectedInfo.DirectoryPath);
       }
 
       if (about == null)

--- a/StationeersLaunchPad/LaunchPadPatches.cs
+++ b/StationeersLaunchPad/LaunchPadPatches.cs
@@ -5,6 +5,7 @@ using Assets.Scripts.Networking.Transports;
 using Assets.Scripts.Serialization;
 using Assets.Scripts.UI;
 using HarmonyLib;
+using StationeersLaunchPad.Sources;
 using Steamworks;
 using System;
 using System.Collections.Generic;
@@ -247,10 +248,10 @@ namespace StationeersLaunchPad
       if (modInfo == null)
         return;
 
-      var modValid = modInfo.IsWorkshopValid();
-      if (!modValid.Item1 && modValid.Item2 != string.Empty)
+      var (valid, error) = Steam.ValidateForWorkshop(modInfo);
+      if (!valid && !string.IsNullOrEmpty(error))
       {
-        AlertPanel.Instance.ShowAlert(modValid.Item2, AlertState.Alert);
+        AlertPanel.Instance.ShowAlert(error, AlertState.Alert);
         __instance.SelectedModButtonRight?.SetActive(false);
         return;
       }
@@ -260,9 +261,9 @@ namespace StationeersLaunchPad
         return;
 
       var publishButton = __instance.SelectedModButtonRight?.GetComponentInChildren<TextMeshProUGUI>();
-      if (modInfo.Source == ModSource.Local && modAbout.WorkshopHandle == 0)
+      if (modInfo.Source == ModSourceType.Local && modAbout.WorkshopHandle == 0)
         publishButton.SetText("Publish");
-      else if (modInfo.Source == ModSource.Workshop)
+      else if (modInfo.Source == ModSourceType.Workshop)
         publishButton.SetText("Unsubscribe");
       else
         publishButton.SetText("Update");

--- a/StationeersLaunchPad/LoadStrategy.cs
+++ b/StationeersLaunchPad/LoadStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using Cysharp.Threading.Tasks;
+using StationeersLaunchPad.Sources;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -37,7 +38,7 @@ namespace StationeersLaunchPad
       this.modList = modList;
     }
 
-    protected IEnumerable<ModInfo> Mods => this.modList.EnabledMods.Where(mod => mod.Source != ModSource.Core);
+    protected IEnumerable<ModInfo> Mods => this.modList.EnabledMods.Where(mod => mod.Source != ModSourceType.Core);
 
     private bool failed = false;
 

--- a/StationeersLaunchPad/LoadedMod.cs
+++ b/StationeersLaunchPad/LoadedMod.cs
@@ -36,9 +36,9 @@ namespace StationeersLaunchPad
 
     public LoadedMod(ModInfo info)
     {
-      this.Logger = Logger.Global.CreateChild(info.DisplayName);
+      this.Logger = Logger.Global.CreateChild(info.Name);
       this.Info = info;
-      var resource = new DummyResource(info.Path);
+      var resource = new DummyResource(info.DirectoryPath);
       this.ContentHandler = new(resource, new List<IResource>().AsReadOnly(), this.Prefabs.AsReadOnly());
     }
 
@@ -114,7 +114,7 @@ namespace StationeersLaunchPad
       this.Logger.LogDebug("Loading Entrypoints");
 
       var gameObj = new GameObject();
-      gameObj.name = this.Info.DisplayName;
+      gameObj.name = this.Info.Name;
       GameObject.DontDestroyOnLoad(gameObj);
 
       // instantiate all entrypoints

--- a/StationeersLaunchPad/Sources/Core.cs
+++ b/StationeersLaunchPad/Sources/Core.cs
@@ -1,0 +1,37 @@
+
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace StationeersLaunchPad.Sources
+{
+  public class CoreModSource : ModSource
+  {
+    public static readonly CoreModSource Instance = new();
+    private CoreModSource() { }
+    public override async UniTask<List<ModDefinition>> ListMods() =>
+      new() { new CoreModDefinition() };
+  }
+
+  public class CoreModDefinition : ModDefinition
+  {
+    private static ModAbout GetModAbout()
+    {
+      var fromGame = new CoreModData().GetAboutData();
+      return new()
+      {
+        Name = fromGame.Name,
+        ModID = "core",
+        Author = fromGame.Author,
+        Description = fromGame.Description,
+        Version = fromGame.Version,
+      };
+    }
+
+    public CoreModDefinition() : base(GetModAbout()) { }
+    public override string Name => "Core";
+    public override ModSourceType Type => ModSourceType.Core;
+    public override ulong WorkshopHandle => 1;
+    public override string DirectoryPath => "";
+    public override ModData ToModData(bool enabled) => new CoreModData();
+  }
+}

--- a/StationeersLaunchPad/Sources/Local.cs
+++ b/StationeersLaunchPad/Sources/Local.cs
@@ -1,0 +1,60 @@
+
+using Assets.Scripts.Networking.Transports;
+using Assets.Scripts.Serialization;
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+using System.IO;
+
+namespace StationeersLaunchPad.Sources
+{
+  public class LocalModSource : ModSource
+  {
+    public static readonly LocalModSource Instance = new();
+    private LocalModSource() { }
+    public override UniTask<List<ModDefinition>> ListMods() =>
+      UniTask.RunOnThreadPool(() =>
+      {
+        var type = SteamTransport.WorkshopType.Mod;
+        var localDir = type.GetLocalDirInfo();
+        var fileName = type.GetLocalFileName();
+        var mods = new List<ModDefinition>();
+
+        if (!localDir.Exists)
+        {
+          Logger.Global.LogWarning("local mod folder not found");
+          return mods;
+        }
+
+        foreach (var dir in localDir.GetDirectories("*", SearchOption.AllDirectories))
+        {
+          foreach (var file in dir.GetFiles(fileName))
+          {
+            var modDir = dir.Parent;
+            var about = XmlSerialization.Deserialize<ModAbout>(
+              file.FullName, "ModMetadata") ?? new()
+              {
+                Name = $"[Invalid About.xml] {modDir.Name}",
+                Author = "",
+                Version = "",
+                Description = "",
+              };
+            mods.Add(new LocalModDefinition(modDir.FullName, about));
+          }
+        }
+        return mods;
+      });
+  }
+
+  public class LocalModDefinition : ModDefinition
+  {
+    public readonly string ModDirectory;
+    public LocalModDefinition(string modDir, ModAbout about) : base(about) =>
+      ModDirectory = modDir;
+    public override string Name => Path.GetDirectoryName(ModDirectory);
+    public override ModSourceType Type => ModSourceType.Local;
+    public override ulong WorkshopHandle => About.WorkshopHandle;
+    public override string DirectoryPath => ModDirectory;
+    public override ModData ToModData(bool enabled) =>
+      new LocalModData(ModDirectory, enabled);
+  }
+}

--- a/StationeersLaunchPad/Sources/ModSource.cs
+++ b/StationeersLaunchPad/Sources/ModSource.cs
@@ -1,0 +1,49 @@
+
+using Cysharp.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace StationeersLaunchPad.Sources
+{
+  public enum ModSourceType
+  {
+    Core,
+    Local,
+    Workshop
+  }
+
+  public abstract class ModSource
+  {
+    public abstract UniTask<List<ModDefinition>> ListMods();
+
+    public static async UniTask<List<ModDefinition>> ListAll(bool includeWorkshop)
+    {
+      var listTasks = new List<UniTask<List<ModDefinition>>>()
+      {
+        CoreModSource.Instance.ListMods(),
+        LocalModSource.Instance.ListMods(),
+      };
+      if (includeWorkshop)
+        listTasks.Add(WorkshopModSource.Instance.ListMods());
+      var lists = await UniTask.WhenAll(listTasks);
+
+      var mods = new List<ModDefinition>();
+      foreach (var list in lists)
+        mods.AddRange(list);
+      return mods;
+    }
+  }
+
+  // Contains only the base information about a mod, not any configuration related to it
+  public abstract class ModDefinition
+  {
+    public readonly ModAbout About;
+
+    public ModDefinition(ModAbout about) => About = about;
+
+    public abstract string Name { get; }
+    public abstract ModSourceType Type { get; }
+    public abstract ulong WorkshopHandle { get; }
+    public abstract string DirectoryPath { get; }
+    public abstract ModData ToModData(bool enabled);
+  }
+}

--- a/StationeersLaunchPad/Sources/Workshop.cs
+++ b/StationeersLaunchPad/Sources/Workshop.cs
@@ -1,0 +1,53 @@
+
+using Assets.Scripts.Networking.Transports;
+using Assets.Scripts.Serialization;
+using Cysharp.Threading.Tasks;
+using Steamworks.Ugc;
+using System.Collections.Generic;
+using System.IO;
+
+namespace StationeersLaunchPad.Sources
+{
+  public class WorkshopModSource : ModSource
+  {
+    public static readonly WorkshopModSource Instance = new();
+    private WorkshopModSource() { }
+    public override async UniTask<List<ModDefinition>> ListMods()
+    {
+      var mods = new List<ModDefinition>();
+
+      var items = await Steam.LoadWorkshopItems();
+
+      foreach (var item in items)
+      {
+        var about = XmlSerialization.Deserialize<ModAbout>(
+          Path.Join(item.Directory, "About/About.xml"), "ModMetadata") ?? new()
+          {
+            Name = $"[Invalid About.xml] {item.Title}",
+            Author = "",
+            Version = "",
+            Description = "",
+          };
+        mods.Add(new WorkshopModDefinition(item, about));
+      }
+
+      return mods;
+    }
+  }
+
+  public class WorkshopModDefinition : ModDefinition
+  {
+    public readonly Item Item;
+    public WorkshopModDefinition(Item item, ModAbout about) : base(about) =>
+      Item = item;
+
+    public override string Name => Item.Title;
+    public override ModSourceType Type => ModSourceType.Workshop;
+    public override ulong WorkshopHandle => Item.Id;
+    public override string DirectoryPath => Item.Directory;
+    public override ModData ToModData(bool enabled) => new WorkshopModData(
+      SteamTransport.ItemWrapper.WrapWorkshopItem(Item, "About/About.xml"),
+      enabled
+    );
+  }
+}

--- a/StationeersLaunchPad/Steam.cs
+++ b/StationeersLaunchPad/Steam.cs
@@ -1,16 +1,23 @@
 
 using Cysharp.Threading.Tasks;
+using StationeersLaunchPad.Sources;
 using Steamworks;
 using Steamworks.Ugc;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using UnityEngine;
 
 namespace StationeersLaunchPad
 {
   public static class Steam
   {
+    public const int MOD_NAME_SIZE_LIMIT = 128;
+    public const int MOD_DESCRIPTION_SIZE_LIMIT = 8000;
+    public const int MOD_CHANGELOG_SIZE_LIMIT = 8000;
+    public const int MOD_THUMBNAIL_SIZE_LIMIT = 1024 * 1024;
+
     public static async UniTask<List<Item>> LoadWorkshopItems()
     {
       var allItems = new List<Item>();
@@ -67,6 +74,46 @@ namespace StationeersLaunchPad
       return !result.HasValue || result.Value.ResultCount == 0
         ? Array.Empty<Item>()
         : result.Value.Entries.Where(item => item.Result != Result.FileNotFound).ToArray();
+    }
+
+    public static (bool, string) ValidateForWorkshop(ModInfo mod)
+    {
+      // if its core its fine, if its on the workshop in the first place its probably fine too
+      if (mod.Source != ModSourceType.Local)
+        return (true, string.Empty);
+
+      if (mod.About == null)
+        return (false, "Mod has invalid/no about data.");
+
+      if (mod.About.Name?.Length > MOD_NAME_SIZE_LIMIT)
+        return (false, $"Mod name is larger than {MOD_NAME_SIZE_LIMIT} characters, current size is {mod.About.Name?.Length} characters.");
+
+      if (mod.About.Description?.Length > MOD_DESCRIPTION_SIZE_LIMIT)
+        return (false, $"Mod description is larger than {MOD_DESCRIPTION_SIZE_LIMIT} characters, current size is {mod.About.Description?.Length} characters.");
+
+      if (mod.About.ChangeLog?.Length > MOD_CHANGELOG_SIZE_LIMIT)
+        return (false, $"Mod changelog is larger than {MOD_CHANGELOG_SIZE_LIMIT} characters, current size is {mod.About.ChangeLog?.Length} characters.");
+
+      if (!File.Exists(mod.ThumbnailPath))
+        return (false, $"Mod does not have a thumb.png in the About folder.");
+
+      var thumbnailInfo = new FileInfo(mod.ThumbnailPath);
+      if (thumbnailInfo?.Length > MOD_THUMBNAIL_SIZE_LIMIT)
+        return (false, $"Mod thumbnail size is larger than {MOD_THUMBNAIL_SIZE_LIMIT / 1024} kilobytes, current size is {thumbnailInfo?.Length / 1024} kilobytes.");
+
+      return (true, string.Empty);
+    }
+
+    public static void OpenWorkshopPage(ulong handle)
+    {
+      try
+      {
+        Application.OpenURL($"steam://url/CommunityFilePage/{handle}");
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+      }
     }
   }
 }


### PR DESCRIPTION
Separates mod metadata into a `ModDefinition` object.
Pull out mod listing into `ModSource` types.
Move some utilities into static classes instead of having instance methods on data objects