### PR TITLE
Repo Mods Infrastructure

### DIFF
--- a/StationeersLaunchPad/DataUtils.cs
+++ b/StationeersLaunchPad/DataUtils.cs
@@ -1,0 +1,49 @@
+
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+
+namespace StationeersLaunchPad
+{
+  public static class DataUtils
+  {
+    private static readonly StringComparer Invariant =
+      CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(
+        CompareOptions.OrdinalIgnoreCase);
+
+    public unsafe static int CompareToInvariant(
+      this ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+    {
+      if (left.Length == 0)
+        return right.Length > 0 ? -1 : 0;
+      if (right.Length == 0)
+        return 1;
+      fixed (char* lraw = &left[0], rraw = &right[0])
+      {
+        return Invariant.Compare(
+          new string(lraw, 0, left.Length),
+          new string(rraw, 0, right.Length)
+        );
+      }
+    }
+
+    public static string DigestSHA256(byte[] data)
+    {
+      const string hexChars = "0123456789abcdef";
+      const string prefix = "sha256:";
+
+      using var sha256 = SHA256.Create();
+      var rawDigest = sha256.ComputeHash(data);
+      var digest = new char[rawDigest.Length * 2 + prefix.Length];
+      prefix.AsSpan().CopyTo(digest);
+      for (var i = 0; i < rawDigest.Length; i++)
+      {
+        var b = rawDigest[i];
+        var j = prefix.Length + i * 2;
+        digest[j] = hexChars[(b >> 4) & 0xF];
+        digest[j + 1] = hexChars[b & 0xF];
+      }
+      return new(digest);
+    }
+  }
+}

--- a/StationeersLaunchPad/LaunchPadPaths.cs
+++ b/StationeersLaunchPad/LaunchPadPaths.cs
@@ -15,6 +15,13 @@ namespace StationeersLaunchPad
     public static string SavePath => string.IsNullOrEmpty(Settings.CurrentData.SavePath) ? StationSaveUtils.DefaultPath : Settings.CurrentData.SavePath;
     public static string ConfigPath => WorkshopMenu.ConfigPath;
 
+    public static string ModReposConfigPath =>
+      Path.Join(StationSaveUtils.DefaultPath, "modrepos.xml");
+    public static string ModReposPath =>
+      Path.Join(StationSaveUtils.DefaultPath, "modrepos");
+    public static string RepoModsPath =>
+      Path.Join(StationSaveUtils.DefaultPath, "repomods");
+
     private static DirectoryInfo _cachedInstallDir;
     public static DirectoryInfo InstallDir
     {

--- a/StationeersLaunchPad/Metadata/ModConfig.cs
+++ b/StationeersLaunchPad/Metadata/ModConfig.cs
@@ -9,7 +9,7 @@ namespace StationeersLaunchPad.Metadata
     public static ModConfig LoadConfig()
     {
       var config = File.Exists(LaunchPadPaths.ConfigPath)
-            ? XmlSerialization.Deserialize<ModConfig>(LaunchPadPaths.ConfigPath)
+            ? XmlSerialization.Deserialize<ModConfig>(LaunchPadPaths.ConfigPath) ?? new()
             : new ModConfig();
       config.CreateCoreMod();
       return config;

--- a/StationeersLaunchPad/Platform.cs
+++ b/StationeersLaunchPad/Platform.cs
@@ -1,6 +1,7 @@
 
 using Cysharp.Threading.Tasks;
 using StationeersLaunchPad.UI;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEngine;
@@ -20,6 +21,21 @@ namespace StationeersLaunchPad
           Application.platform
             is RuntimePlatform.WindowsServer
             or RuntimePlatform.LinuxServer;
+
+    private static HashSet<char> InvalidFileChars;
+    public static string MakeValidFileName(string name, char replacement = '_')
+    {
+      if (InvalidFileChars == null)
+      {
+        InvalidFileChars = new();
+        foreach (var c in Path.GetInvalidFileNameChars())
+          InvalidFileChars.Add(c);
+      }
+      var res = new char[name.Length];
+      for (var i = 0; i < name.Length; i++)
+        res[i] = InvalidFileChars.Contains(name[i]) ? replacement : name[i];
+      return new(res);
+    }
 
     public static bool IsServer => Current.PlatformIsServer;
     protected abstract bool PlatformIsServer { get; }

--- a/StationeersLaunchPad/Repos/Config.cs
+++ b/StationeersLaunchPad/Repos/Config.cs
@@ -1,0 +1,58 @@
+
+using Cysharp.Threading.Tasks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+
+namespace StationeersLaunchPad.Repos
+{
+  [XmlRoot("ModRepos")]
+  public class ModReposConfig
+  {
+    [XmlElement("GitHub", typeof(GitHubRepoDef))]
+    [XmlElement("Http", typeof(HttpRepoDef))]
+    public List<ModRepoDef> Repos = new();
+
+    [XmlElement("RepoMod", typeof(RepoModDef))]
+    public List<RepoModDef> Mods = new();
+  }
+
+  public struct RepoFetchResult
+  {
+    public byte[] Data;
+    public bool UseCache;
+    public string CacheKey;
+  }
+  public abstract class ModRepoDef
+  {
+    [XmlAttribute("DirName")] public string DirName;
+    [XmlAttribute("LastFetch")] public DateTime LastFetch;
+    [XmlAttribute("Digest")] public string Digest;
+
+    [XmlIgnore]
+    public ModRepoData Data;
+
+    public string LocalDirPath => Path.Join(LaunchPadPaths.ModReposPath, DirName);
+    public string LocalDataPath => Path.Join(LocalDirPath, "modrepo.xml");
+
+    public abstract string ID { get; }
+
+    public abstract UniTask<RepoFetchResult> FetchRemote();
+    public abstract void SetCacheKey(string cacheKey);
+  }
+
+  public class RepoModDef
+  {
+    [XmlAttribute("ModID")] public string ModID;
+    [XmlAttribute("Branch")] public string Branch;
+    [XmlAttribute("MinVersion")] public string MinVersion;
+    [XmlAttribute("MaxVersion")] public string MaxVersion;
+    [XmlAttribute("Repo")] public string RepoID;
+
+    [XmlAttribute("Version")] public string Version;
+    [XmlAttribute("DirName")] public string DirName;
+
+    [XmlIgnore] public string PrevDirName;
+  }
+}

--- a/StationeersLaunchPad/Repos/Data.cs
+++ b/StationeersLaunchPad/Repos/Data.cs
@@ -1,0 +1,46 @@
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace StationeersLaunchPad.Repos
+{
+  [XmlRoot("ModRepo")]
+  public class ModRepoData
+  {
+    [XmlElement("ModVersion", typeof(ModVersionData))]
+    public List<ModVersionData> ModVersions = new();
+  }
+
+  public class ModVersionData
+  {
+    [XmlAttribute("ModID")] public string ModID;
+    [XmlAttribute("Version")] public string Version;
+    [XmlAttribute("Name")] public string Name;
+    [XmlAttribute("Author")] public string Author;
+    [XmlAttribute("Url")] public string Url;
+    [XmlAttribute("Digest")] public string Digest;
+
+    [XmlElement("Branch")]
+    public List<StringData> Branches = new();
+    [XmlElement("Tag")]
+    public List<StringData> Tags = new();
+    [XmlElement("Dep")]
+    public List<ModVersionDepData> Deps = new();
+  }
+
+  public class StringData
+  {
+    [XmlAttribute("Value")] public string Value;
+
+    public static implicit operator StringData(string value) =>
+      new() { Value = value };
+    public static implicit operator string(StringData data) =>
+      data.Value;
+  }
+
+  public class ModVersionDepData
+  {
+    [XmlAttribute("ModID")]
+    public string ModID;
+  }
+}

--- a/StationeersLaunchPad/Repos/GitHub.cs
+++ b/StationeersLaunchPad/Repos/GitHub.cs
@@ -1,0 +1,22 @@
+
+using Cysharp.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace StationeersLaunchPad.Repos
+{
+  public class GitHubRepoDef : ModRepoDef
+  {
+    [XmlAttribute("Owner")] public string Owner;
+    [XmlAttribute("Name")] public string Name;
+    [XmlAttribute("ETag")] public string ETag;
+
+    [XmlIgnore]
+    public override string ID => $"github.com/{Owner}/{Name}";
+
+    public override UniTask<RepoFetchResult> FetchRemote() => HttpRepoDef.FetchHttp(
+      $"https://raw.githubusercontent.com/{Owner}/{Name}/refs/heads/modrepo/modrepo.xml",
+      ETag
+    );
+    public override void SetCacheKey(string cacheKey) => ETag = cacheKey;
+  }
+}

--- a/StationeersLaunchPad/Repos/Http.cs
+++ b/StationeersLaunchPad/Repos/Http.cs
@@ -1,0 +1,59 @@
+
+using Cysharp.Threading.Tasks;
+using System;
+using System.Xml.Serialization;
+using UnityEngine.Networking;
+
+namespace StationeersLaunchPad.Repos
+{
+  public class HttpRepoDef : ModRepoDef
+  {
+    [XmlAttribute("Url")] public string Url;
+    [XmlAttribute("ETag")] public string ETag;
+
+    [XmlIgnore]
+    public override string ID => Url;
+
+    public override UniTask<RepoFetchResult> FetchRemote() => FetchHttp(Url, ETag);
+    public override void SetCacheKey(string cacheKey) => ETag = cacheKey;
+
+    public static async UniTask<RepoFetchResult> FetchHttp(string url, string etag)
+    {
+      Logger.Global.LogDebug($"Fetching {url}");
+      try
+      {
+        using var req = UnityWebRequest.Get(url);
+        req.timeout = Configs.RepoFetchTimeout.Value;
+        if (!string.IsNullOrEmpty(etag))
+          req.SetRequestHeader("If-None-Match", etag);
+
+        var res = await req.SendWebRequest();
+        if (res.result != UnityWebRequest.Result.Success)
+        {
+          Logger.Global.LogError($"Failed to fetch {url}: {res.error}");
+          return new();
+        }
+
+        if (res.responseCode == 304)
+          return new() { UseCache = true };
+
+        if (res.responseCode != 200)
+        {
+          Logger.Global.LogError($"Failed to fetch {url}: status {res.responseCode}");
+          return new();
+        }
+
+        return new()
+        {
+          Data = res.downloadHandler.data,
+          CacheKey = res.GetResponseHeader("ETag"),
+        };
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+        return new();
+      }
+    }
+  }
+}

--- a/StationeersLaunchPad/Repos/Index.cs
+++ b/StationeersLaunchPad/Repos/Index.cs
@@ -1,0 +1,238 @@
+
+using System;
+using System.Collections.Generic;
+
+namespace StationeersLaunchPad.Repos
+{
+  public class ModRepoIndex
+  {
+    public static ModRepoIndex Build(ModReposConfig config)
+    {
+      var entries = new List<IndexEntry>();
+      static IndexEntry makeEntry(string repoID, ModVersionData modv, string branch) =>
+        new()
+        {
+          ModID = modv.ModID,
+          RepoID = repoID,
+          Branch = branch,
+          Version = modv.Version,
+          Mod = modv,
+          NextRepo = -1,
+          NextMod = -1,
+          NextBranch = -1,
+        };
+      foreach (var repo in config.Repos)
+      {
+        if (repo.Data == null)
+          continue;
+        var repoID = repo.ID;
+        foreach (var modv in repo.Data.ModVersions)
+        {
+          // if no branches listed, assume empty branch
+          if ((modv.Branches?.Count ?? 0) == 0)
+          {
+            entries.Add(makeEntry(repoID, modv, ""));
+            continue;
+          }
+          foreach (var branch in modv.Branches)
+            entries.Add(makeEntry(repoID, modv, branch));
+        }
+      }
+
+      if (entries.Count == 0)
+        return new(entries);
+
+      entries.Sort();
+
+      var nextMod = entries.Count;
+      var nextRepo = entries.Count;
+      var nextBranch = entries.Count;
+      var last = entries[^1];
+      for (var i = entries.Count; --i >= 0;)
+      {
+        var entry = entries[i];
+        if (entry.ModID != last.ModID)
+          nextMod = nextRepo = nextBranch = i + 1;
+        else if (entry.RepoID != last.RepoID)
+          nextRepo = nextBranch = i + 1;
+        else if (entry.Branch != last.Branch)
+          nextBranch = i + 1;
+
+        entry.NextMod = nextMod;
+        entry.NextRepo = nextRepo;
+        entry.NextBranch = nextBranch;
+        last = entries[i] = entry;
+      }
+      return new(entries);
+    }
+
+    private readonly List<IndexEntry> entries;
+    private ModRepoIndex(List<IndexEntry> entries) => this.entries = entries;
+
+    public IndexIter ModIDs() => MakeIter(IndexLevel.Mod);
+    public IndexIter ModRepos(string modID) => MakeIter(IndexLevel.Repo, modID);
+    public IndexIter Branches(string modID, string repoID) =>
+      MakeIter(IndexLevel.Branch, modID, repoID);
+    public IndexIter Versions(string modID, string repoID, string branch) =>
+      MakeIter(IndexLevel.Version, modID, repoID, branch);
+
+    public ModVersionData GetLatest(
+      string modID, string repoID, string branch,
+      string minVersion, string maxVersion)
+    {
+      var start = entries.BinarySearch(new()
+      {
+        ModID = modID,
+        RepoID = repoID,
+        Branch = branch,
+        Version = minVersion
+      });
+      if (start < 0)
+        start = ~start;
+      if (start >= entries.Count)
+        return null;
+
+      var first = entries[start];
+      if (first.ModID != modID || first.RepoID != repoID || first.Branch != branch)
+        return null;
+
+      var end = first.NextBranch;
+      var latest = end - 1;
+      if (!string.IsNullOrEmpty(maxVersion))
+      {
+        var maxEntry = new IndexEntry()
+        {
+          ModID = modID,
+          RepoID = repoID,
+          Branch = branch,
+          Version = maxVersion,
+        };
+        latest = entries.BinarySearch(maxEntry);
+        if (latest < 0)
+          latest = ~latest;
+        if (latest >= end || maxEntry.CompareTo(entries[latest]) > 0)
+          latest--;
+      }
+      if (latest < start || latest >= end)
+        return null;
+      return entries[latest].Mod;
+    }
+
+    private IndexIter MakeIter(IndexLevel level, string modID = null,
+      string repoID = null, string branch = null)
+    {
+      if (level == IndexLevel.Mod)
+        return new(this, level, 0, entries.Count);
+      var start = entries.BinarySearch(
+        new() { ModID = modID, RepoID = repoID, Branch = branch });
+      if (start < 0)
+        start = ~start;
+      if (start >= entries.Count)
+        return default;
+      var entry = entries[start];
+      if (entry.ModID != modID)
+        return default;
+      if (level >= IndexLevel.Repo && entry.RepoID != repoID)
+        return default;
+      if (level >= IndexLevel.Branch && entry.Branch != branch)
+        return default;
+      return new(this, level, start, level switch
+      {
+        IndexLevel.Repo => entry.NextMod,
+        IndexLevel.Branch => entry.NextRepo,
+        IndexLevel.Version => entry.NextBranch,
+        _ => throw new InvalidOperationException($"{level}"),
+      });
+    }
+
+    public enum IndexLevel { Mod, Repo, Branch, Version }
+    private struct IndexEntry : IEquatable<IndexEntry>, IComparable<IndexEntry>
+    {
+      // key
+      public string ModID;
+      public string RepoID;
+      public string Branch;
+      public string Version;
+
+      // value
+      public ModVersionData Mod;
+
+      // next indices for each level
+      public int NextMod;
+      public int NextRepo;
+      public int NextBranch;
+
+      public int CompareTo(IndexEntry other)
+      {
+        int cmp;
+        if ((cmp = string.Compare(ModID, other.ModID)) != 0) return cmp;
+        if ((cmp = string.Compare(RepoID, other.RepoID)) != 0) return cmp;
+        if ((cmp = string.Compare(Branch, other.Branch)) != 0) return cmp;
+        return StationeersLaunchPad.Version.Compare(Version, other.Version);
+      }
+
+      public bool Equals(IndexEntry other) =>
+        string.Equals(ModID, other.ModID) &&
+        string.Equals(RepoID, other.RepoID) &&
+        string.Equals(Branch, other.Branch) &&
+        string.Equals(Version, other.Version);
+
+      public override bool Equals(object other) =>
+        other is IndexEntry kother && Equals(kother);
+      public override int GetHashCode() =>
+        HashCode.Combine(ModID, ModID, Branch, Version);
+    }
+
+    public struct IndexIter
+    {
+      private readonly List<IndexEntry> entries;
+      private readonly IndexLevel level;
+      private readonly int end;
+      private int index;
+      private bool first;
+
+      public IndexIter(ModRepoIndex index, IndexLevel level, int start, int end)
+      {
+        this.entries = index.entries;
+        this.level = level;
+        this.end = end;
+        this.index = start;
+        first = true;
+      }
+
+      public IndexIter GetEnumerator() => this;
+
+      public bool MoveNext()
+      {
+        if (first)
+        {
+          first = false;
+          return index < end;
+        }
+        if (index >= end)
+          return false;
+        var entry = entries[index];
+        index = level switch
+        {
+          IndexLevel.Mod => entry.NextMod,
+          IndexLevel.Repo => entry.NextRepo,
+          IndexLevel.Branch => entry.NextBranch,
+          IndexLevel.Version => index + 1,
+          _ => throw new InvalidOperationException($"{level}"),
+        };
+        return index < end;
+      }
+
+      public string Current => level switch
+      {
+        IndexLevel.Mod => entries[index].ModID,
+        IndexLevel.Repo => entries[index].RepoID,
+        IndexLevel.Branch => entries[index].Branch,
+        IndexLevel.Version => entries[index].Version,
+        _ => throw new InvalidOperationException($"{level}"),
+      };
+
+      public ModVersionData CurrentMod => entries[index].Mod;
+    }
+  }
+}

--- a/StationeersLaunchPad/Repos/Repos.cs
+++ b/StationeersLaunchPad/Repos/Repos.cs
@@ -1,0 +1,331 @@
+
+using Assets.Scripts.Serialization;
+using Cysharp.Threading.Tasks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Xml.Serialization;
+using UnityEngine.Networking;
+
+namespace StationeersLaunchPad.Repos
+{
+  public static class ModRepos
+  {
+    public static void SaveConfig(ModReposConfig config)
+    {
+      if (!config.SaveXml(LaunchPadPaths.ModReposConfigPath))
+        Logger.Global.LogError($"failed to save {LaunchPadPaths.ModReposConfigPath}");
+    }
+
+    public static async UniTask<ModReposConfig> LoadConfig()
+    {
+      await UniTask.SwitchToThreadPool();
+
+      ModReposConfig config;
+      if (File.Exists(LaunchPadPaths.ModReposConfigPath))
+        config = XmlSerialization.Deserialize<ModReposConfig>(
+          LaunchPadPaths.ModReposConfigPath) ?? new();
+      else
+        config = new();
+
+      var dirs = new DirAssignment();
+      foreach (var repo in config.Repos)
+        repo.DirName = dirs.Assign(repo.DirName, repo.ID);
+
+      Logger.Global.LogDebug("Loading local repo cache");
+      await UniTask.WhenAll(config.Repos.Select(repo =>
+        UniTask.RunOnThreadPool(() => LoadRepoCache(repo))));
+
+      Logger.Global.LogDebug("Fetching repo updates");
+      await UniTask.WhenAll(config.Repos.Select(repo => UpdateRepoData(repo)));
+
+      return config;
+    }
+
+    private static readonly XmlSerializer DataSerializer =
+      new XmlSerializer(typeof(ModRepoData));
+    private static void LoadRepoCache(ModRepoDef repo)
+    {
+      repo.Data = null;
+      var path = repo.LocalDataPath;
+      if (string.IsNullOrEmpty(repo.Digest) || !File.Exists(path))
+      {
+        Logger.Global.LogDebug($"{repo.ID}: no cached file or digest");
+        return;
+      }
+
+      try
+      {
+        var rawData = File.ReadAllBytes(path);
+        var digest = DataUtils.DigestSHA256(rawData);
+        if (digest != repo.Digest)
+        {
+          Logger.Global.LogDebug($"{repo.ID}: digest mismatch");
+          return;
+        }
+
+        using var reader = new MemoryStream(rawData);
+        repo.Data = DataSerializer.Deserialize(reader) as ModRepoData;
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+        repo.Data = null;
+      }
+    }
+
+    public static async UniTask UpdateRepoData(ModRepoDef repo)
+    {
+      var lastFetchSeconds = DateTime.UtcNow.Subtract(repo.LastFetch).TotalSeconds;
+      if (repo.Data != null && lastFetchSeconds < Configs.RepoUpdateFrequency.Value)
+      {
+        Logger.Global.LogDebug($"{repo.ID}: up to date");
+        return;
+      }
+
+      if (repo.Data == null)
+      {
+        Logger.Global.LogDebug($"{repo.ID}: no data. clearing cache key");
+        repo.SetCacheKey(null);
+      }
+
+      var res = await repo.FetchRemote();
+      if (res.UseCache)
+      {
+        // no changes. just update LastFetch
+        repo.LastFetch = DateTime.UtcNow;
+        Logger.Global.LogDebug($"{repo.ID}: no change");
+        return;
+      }
+      if (res.Data == null)
+      {
+        // fetch failed, keep everything as-is
+        Logger.Global.LogDebug($"{repo.ID}: fetch failed");
+        return;
+      }
+
+      ModRepoData newData;
+      try
+      {
+        using var stream = new MemoryStream(res.Data);
+        newData = DataSerializer.Deserialize(stream) as ModRepoData;
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+        // on deserialize failure, keep existing data
+        return;
+      }
+
+      if (!Directory.Exists(repo.LocalDirPath))
+        Directory.CreateDirectory(repo.LocalDirPath);
+
+      try
+      {
+        File.WriteAllBytes(repo.LocalDataPath, res.Data);
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogError($"failed to save {repo.LocalDataPath}: {ex.Message}");
+        return;
+      }
+
+      repo.Data = newData;
+      repo.Digest = DataUtils.DigestSHA256(res.Data);
+      repo.LastFetch = DateTime.UtcNow;
+      repo.SetCacheKey(res.CacheKey);
+    }
+
+    public static async UniTask UpdateMods(ModReposConfig config)
+    {
+      var index = ModRepoIndex.Build(config);
+      var dirs = new DirAssignment();
+      foreach (var mod in config.Mods)
+      {
+        if (!dirs.CanAssign(mod.DirName))
+        {
+          mod.DirName = null;
+          continue;
+        }
+        var aboutPath = Path.Join(
+          LaunchPadPaths.RepoModsPath, mod.DirName, "About/About.xml");
+        if (!File.Exists(aboutPath))
+        {
+          mod.DirName = null;
+          continue;
+        }
+        if (!dirs.TryAssign(mod.DirName))
+          throw new InvalidOperationException();
+      }
+
+      var updateTasks = new List<UniTask>();
+
+      foreach (var mod in config.Mods)
+      {
+        mod.PrevDirName = mod.DirName;
+        var target = index.GetLatest(
+          mod.ModID, mod.RepoID, mod.Branch, mod.MinVersion, mod.MaxVersion);
+        if (target == null)
+        {
+          Logger.Global.LogWarning(
+            $"No valid versions for {mod.ModID}@{mod.Branch}[{mod.MinVersion},{mod.MaxVersion}] in {mod.RepoID}");
+          continue;
+        }
+        if (!string.IsNullOrEmpty(mod.DirName)
+          && Version.Compare(target.Version, mod.Version) <= 0)
+        {
+          Logger.Global.LogDebug($"{mod.ModID}@{mod.Branch}[{mod.Version}] in {mod.RepoID} up to date");
+          continue;
+        }
+        var newDir = dirs.Assign(null, $"{mod.ModID}_{mod.Branch}_{target.Version}");
+        updateTasks.Add(UpdateMod(mod, target, newDir));
+      }
+
+      if (updateTasks.Count > 0)
+        await UniTask.WhenAll(updateTasks);
+
+      var modDirs = new HashSet<string>();
+      foreach (var mod in config.Mods)
+        if (!string.IsNullOrEmpty(mod.DirName))
+          modDirs.Add(mod.DirName);
+
+      foreach (var dirName in Directory.GetDirectories(LaunchPadPaths.RepoModsPath))
+      {
+        var dir = new DirectoryInfo(dirName);
+        if (!dir.Exists || modDirs.Contains(dir.Name))
+          continue;
+        Logger.Global.LogDebug($"cleaning unused repo mod dir {dir.Name}");
+        try { dir.Delete(true); } catch { }
+      }
+    }
+
+    private static async UniTask UpdateMod(
+      RepoModDef mod, ModVersionData target, string dirName)
+    {
+      var curName = $"{mod.ModID}@{mod.Branch}[{mod.Version}]";
+      var targetName = $"{mod.ModID}@{mod.Branch}[{target.Version}]";
+      Logger.Global.LogInfo($"Updating {curName} to {target.Version}");
+      try
+      {
+        using var req = UnityWebRequest.Get(target.Url);
+        req.timeout = Configs.RepoModFetchTimeout.Value;
+        var res = await req.SendWebRequest();
+        if (res.responseCode != 200)
+        {
+          Logger.Global.LogError($"Error fetching {targetName} from {mod.RepoID}: status {res.responseCode}");
+          return;
+        }
+        var data = res.downloadHandler.data;
+
+        if (!string.IsNullOrEmpty(target.Digest))
+        {
+          var digest = DataUtils.DigestSHA256(data);
+          if (digest != target.Digest)
+          {
+            var msg = $"{targetName} from {mod.RepoID} does not match repo digest: {digest} != {target.Digest}. skipping update";
+            if (Configs.RepoModValidateDigest.Value)
+            {
+              Logger.Global.LogError(msg);
+              return;
+            }
+            Logger.Global.LogWarning(msg);
+          }
+        }
+
+        var dirPath = Path.Join(LaunchPadPaths.RepoModsPath, dirName);
+        if (Directory.Exists(dirPath))
+          try { Directory.Delete(dirPath, true); } catch { }
+
+        using var archive = new ZipArchive(new MemoryStream(data), ZipArchiveMode.Read);
+        archive.ExtractToDirectory(dirPath, true);
+
+        if (!File.Exists(Path.Join(dirPath, "About/About.xml")))
+        {
+          Logger.Global.LogError($"{mod.ModID}@{mod.Branch}[{target.Version}] from {mod.RepoID} does not contain an About/About.xml file. skipping update");
+          try { Directory.Delete(dirPath, true); } catch { }
+          return;
+        }
+        Logger.Global.LogInfo($"Updated {mod.ModID}@{mod.Branch}[{mod.Version}] to {target.Version}");
+        mod.Version = target.Version;
+        mod.DirName = dirName;
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogError($"Error updating {mod.ModID}@{mod.Branch}[{mod.Version}] to {target.Version}");
+        Logger.Global.LogException(ex);
+      }
+    }
+
+    public static void UpdateModPaths(ModReposConfig config, ModConfig modConfig)
+    {
+      var updates = new Dictionary<string, string>();
+      foreach (var mod in config.Mods)
+      {
+        if (string.IsNullOrEmpty(mod.DirName) || string.IsNullOrEmpty(mod.PrevDirName))
+          continue;
+        updates[Path.Join(LaunchPadPaths.RepoModsPath, mod.PrevDirName)] =
+          Path.Join(LaunchPadPaths.RepoModsPath, mod.DirName);
+      }
+
+      for (var i = 0; i < modConfig.Mods.Count; i++)
+      {
+        var mod = modConfig.Mods[i];
+        // if we updated this mod, switch it to the new directory
+        if (updates.TryGetValue(mod.DirectoryPath, out var newPath))
+          modConfig.Mods[i] = new LocalModData(newPath, mod.Enabled);
+      }
+    }
+
+    private static string ToDirName(string id)
+    {
+      var name = Platform.MakeValidFileName(id);
+      if (name.Length > 64)
+        name = name[..64];
+      return name;
+    }
+
+    private class DirAssignment
+    {
+      private readonly HashSet<string> used = new();
+
+      public string Assign(string current, string id)
+      {
+        if (!string.IsNullOrEmpty(current))
+        {
+          // if it has a valid existing dir that is unused, keep it
+          var existing = ToDirName(current);
+          if (current == existing && used.Add(current))
+            return current;
+        }
+        // try just using the cleaned id
+        current = ToDirName(id);
+        if (used.Add(current))
+          return current;
+        // on conflict start adding numbers to end
+        var baseName = current;
+        var index = 0;
+        while (!used.Add(current = $"{baseName}~{++index}")) ;
+        return current;
+      }
+
+      public bool TryAssign(string dir)
+      {
+        if (string.IsNullOrEmpty(dir))
+          return false;
+        if (dir != ToDirName(dir))
+          return false;
+        return used.Add(dir);
+      }
+
+      public bool CanAssign(string dir)
+      {
+        if (string.IsNullOrEmpty(dir))
+          return false;
+        if (dir != ToDirName(dir))
+          return false;
+        return !used.Contains(dir);
+      }
+    }
+  }
+}

--- a/StationeersLaunchPad/Sources/Core.cs
+++ b/StationeersLaunchPad/Sources/Core.cs
@@ -9,7 +9,7 @@ namespace StationeersLaunchPad.Sources
   {
     public static readonly CoreModSource Instance = new();
     private CoreModSource() { }
-    public override async UniTask<List<ModDefinition>> ListMods() =>
+    public override async UniTask<List<ModDefinition>> ListMods(ModSourceState state) =>
       new() { new CoreModDefinition() };
   }
 

--- a/StationeersLaunchPad/Sources/ModSource.cs
+++ b/StationeersLaunchPad/Sources/ModSource.cs
@@ -1,6 +1,7 @@
 
 using Cysharp.Threading.Tasks;
 using StationeersLaunchPad.Metadata;
+using StationeersLaunchPad.Repos;
 using System.Collections.Generic;
 
 namespace StationeersLaunchPad.Sources
@@ -9,24 +10,31 @@ namespace StationeersLaunchPad.Sources
   {
     Core,
     Local,
-    Workshop
+    Workshop,
+    Repo,
+  }
+
+  public struct ModSourceState
+  {
+    public bool SteamDisabled;
+    public ModReposConfig Repos;
   }
 
   public abstract class ModSource
   {
-    public abstract UniTask<List<ModDefinition>> ListMods();
+    public abstract UniTask<List<ModDefinition>> ListMods(ModSourceState state);
 
-    public static async UniTask<List<ModDefinition>> ListAll(bool includeWorkshop)
+    public static async UniTask<List<ModDefinition>> ListAll(ModSourceState state)
     {
       var listTasks = new List<UniTask<List<ModDefinition>>>()
       {
-        CoreModSource.Instance.ListMods(),
-        LocalModSource.Instance.ListMods(),
+        CoreModSource.Instance.ListMods(state),
+        LocalModSource.Instance.ListMods(state),
+        WorkshopModSource.Instance.ListMods(state),
+        RepoModSource.Instance.ListMods(state),
       };
-      if (includeWorkshop)
-        listTasks.Add(WorkshopModSource.Instance.ListMods());
-      var lists = await UniTask.WhenAll(listTasks);
 
+      var lists = await UniTask.WhenAll(listTasks);
       var mods = new List<ModDefinition>();
       foreach (var list in lists)
         mods.AddRange(list);

--- a/StationeersLaunchPad/Sources/Repo.cs
+++ b/StationeersLaunchPad/Sources/Repo.cs
@@ -1,0 +1,55 @@
+
+using Assets.Scripts.Serialization;
+using Cysharp.Threading.Tasks;
+using StationeersLaunchPad.Metadata;
+using StationeersLaunchPad.Repos;
+using System.Collections.Generic;
+using System.IO;
+
+namespace StationeersLaunchPad.Sources
+{
+  public class RepoModSource : ModSource
+  {
+    public static readonly RepoModSource Instance = new();
+    public override async UniTask<List<ModDefinition>> ListMods(ModSourceState state)
+    {
+      await UniTask.SwitchToThreadPool();
+      var mods = new List<ModDefinition>();
+
+      foreach (var mod in state.Repos.Mods)
+      {
+        if (string.IsNullOrEmpty(mod.DirName) || string.IsNullOrEmpty(mod.Version))
+          continue;
+        var aboutPath = Path.Join(
+          LaunchPadPaths.RepoModsPath, mod.DirName, "About/About.xml");
+        if (!File.Exists(aboutPath))
+          continue;
+        var about = XmlSerialization.Deserialize<ModAboutEx>(aboutPath, "ModMetadata") ??
+          new()
+          {
+            Name = $"[Invalid About.xml] {mod.ModID}",
+            Author = "",
+            Version = mod.Version,
+            Description = "",
+          };
+        mods.Add(new RepoModDefinition(mod, about));
+      }
+
+      return mods;
+    }
+  }
+
+  public class RepoModDefinition : ModDefinition
+  {
+    public readonly RepoModDef Mod;
+    public RepoModDefinition(RepoModDef mod, ModAboutEx about) : base(about) =>
+      Mod = mod;
+    public override ModSourceType Type => ModSourceType.Repo;
+    public override ulong WorkshopHandle => About.WorkshopHandle;
+    public override string DirectoryPath =>
+      Path.Join(LaunchPadPaths.RepoModsPath, Mod.DirName);
+
+    public override ModData ToModData(bool enabled) =>
+      new LocalModData(DirectoryPath, enabled);
+  }
+}

--- a/StationeersLaunchPad/Sources/Workshop.cs
+++ b/StationeersLaunchPad/Sources/Workshop.cs
@@ -13,9 +13,11 @@ namespace StationeersLaunchPad.Sources
   {
     public static readonly WorkshopModSource Instance = new();
     private WorkshopModSource() { }
-    public override async UniTask<List<ModDefinition>> ListMods()
+    public override async UniTask<List<ModDefinition>> ListMods(ModSourceState state)
     {
       var mods = new List<ModDefinition>();
+      if (state.SteamDisabled)
+        return mods;
 
       var items = await Steam.LoadWorkshopItems();
 

--- a/StationeersLaunchPad/UI/ModInfoPanel.cs
+++ b/StationeersLaunchPad/UI/ModInfoPanel.cs
@@ -1,7 +1,9 @@
 
 using ImGuiNET;
 using StationeersLaunchPad.Metadata;
+using StationeersLaunchPad.Sources;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace StationeersLaunchPad.UI
 {
@@ -29,10 +31,28 @@ namespace StationeersLaunchPad.UI
           Steam.OpenWorkshopPage(mod.WorkshopHandle);
       }
 
+      var rdef = mod.Def as RepoModDefinition;
+      if (rdef != null && rdef.Mod.RepoID.StartsWith("github.com/"))
+      {
+        ImGui.SameLine();
+        if (ImGui.Button("Open Repo"))
+          Application.OpenURL($"https://{rdef.Mod.RepoID}");
+      }
+
       DrawOneLine("Source:", mod.Source.ToString());
 
       if (!string.IsNullOrEmpty(mod.DirectoryPath))
         DrawOneLine("Path:", mod.DirectoryPath);
+
+      if (rdef != null)
+      {
+        DrawOneLine("Repo:", rdef.Mod.RepoID);
+        if (!string.IsNullOrEmpty(rdef.Mod.Branch))
+          DrawOneLine("\tBranch:", rdef.Mod.Branch);
+        DrawOneLine("\tMinVersion:", rdef.Mod.MinVersion);
+        if (!string.IsNullOrEmpty(rdef.Mod.MaxVersion))
+          DrawOneLine("\tMaxVersion:", rdef.Mod.MaxVersion);
+      }
 
       if (about == null)
       {

--- a/StationeersLaunchPad/Update/LaunchPadUpdater.cs
+++ b/StationeersLaunchPad/Update/LaunchPadUpdater.cs
@@ -49,10 +49,7 @@ namespace StationeersLaunchPad.Update
       if (latestRelease == null)
         return null;
 
-      var latestVersion = new Version(latestRelease.TagName.TrimStart('V', 'v'));
-      var currentVersion = new Version(LaunchPadInfo.VERSION.TrimStart('V', 'v'));
-
-      if (latestVersion <= currentVersion)
+      if (Version.Compare(latestRelease.TagName, LaunchPadInfo.VERSION) <= 0)
       {
         Logger.Global.LogInfo($"StationeersLaunchPad is up-to-date.");
         return null;

--- a/StationeersLaunchPad/Version.cs
+++ b/StationeersLaunchPad/Version.cs
@@ -1,0 +1,109 @@
+
+using System;
+
+namespace StationeersLaunchPad
+{
+  public static class Version
+  {
+    public const char SECTION_SEPARATOR = '.';
+    public const char PART_SEPARATOR = '-';
+
+    public static int Compare(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+    {
+      var lreader = new VersionReader(left);
+      var rreader = new VersionReader(right);
+
+      while (!lreader.Done && !rreader.Done)
+      {
+        var l = lreader.ReadPart();
+        var r = rreader.ReadPart();
+
+        var cmp = -l.Section.CompareTo(r.Section);
+        if (cmp != 0) return cmp;
+        cmp = l.Prefix.CompareToInvariant(r.Prefix);
+        if (cmp != 0) return cmp;
+        cmp = l.Value.CompareTo(r.Value);
+        if (cmp != 0) return cmp;
+        cmp = l.Suffix.CompareToInvariant(r.Suffix);
+        if (cmp != 0) return cmp;
+      }
+
+      if (!lreader.Done)
+        return 1;
+      if (!rreader.Done)
+        return -1;
+      return 0;
+    }
+
+    private ref struct Part
+    {
+      public int Section;
+      public ReadOnlySpan<char> Prefix;
+      public ulong Value;
+      public ReadOnlySpan<char> Suffix;
+
+      public override string ToString() =>
+        $"{Section} '{Prefix.ToString()}' {Value} '{Suffix.ToString()}'";
+    }
+
+    private ref struct VersionReader
+    {
+      private ReadOnlySpan<char> data;
+      private int section;
+      private bool newSection;
+
+      public VersionReader(ReadOnlySpan<char> data)
+      {
+        if (data.Length > 0 && data[0] is 'v' or 'V')
+          data = data[1..];
+        this.data = data;
+        section = 0;
+        newSection = true;
+      }
+
+      public bool Done => data.Length == 0 && !newSection;
+
+      public Part ReadPart()
+      {
+        newSection = false;
+        var len = 0;
+        while (len < data.Length && data[len] is not (SECTION_SEPARATOR or PART_SEPARATOR))
+          len++;
+
+        var curSection = section;
+        var spart = data[..len];
+        data = data[len..];
+        if (data.Length > 0)
+        {
+          if (data[0] is SECTION_SEPARATOR)
+          {
+            section++;
+            newSection = true;
+          }
+          data = data[1..];
+        }
+
+        var part = new Part { Section = curSection };
+        if (len > 0 && char.IsDigit(spart[0]))
+        {
+          var valLen = 1;
+          while (valLen < spart.Length && char.IsDigit(spart[valLen]))
+            valLen++;
+          ulong.TryParse(spart[..valLen], out part.Value);
+          part.Suffix = spart[valLen..];
+        }
+        else if (len > 0 && char.IsDigit(spart[^1]))
+        {
+          var valLen = 1;
+          while (valLen < len && char.IsDigit(data[len - valLen - 1]))
+            valLen++;
+          ulong.TryParse(spart[(len - valLen)..], out part.Value);
+          part.Prefix = spart[..(len - valLen)];
+        }
+        else
+          part.Prefix = spart;
+        return part;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the underlying mechanisms for handling repo mods as defined in #95. This exclusively works off the configuration files on-disk. There is no in-game UI or other way to view or edit this configuration.

- Load `modrepos.xml` config file from user folder
- Fetch updated `modrepo.xml` from connected repos (with minimum fetch frequency setting, and using ETag to skip when no updates)
- Store connected repo `modrepo.xml` cache in `modrepos/` folder in user folder
- Compare configured repo mods against available versions, and download updates if needed (currently always automatic, should be configurable before release)
- Include installed repo mods in configurable mod list