### PR TITLE
Add remove by index to repos/modrepos. Case-insensitive github repos

### DIFF
--- a/Stationeers.VS.props
+++ b/Stationeers.VS.props
@@ -5,8 +5,7 @@
     Condition="Exists('$(SolutionDir)Stationeers.VS.Extra.props')" />
 
   <PropertyGroup>
-    <TargetFramework>net4.8</TargetFramework>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <ErrorReport>none</ErrorReport>
     <LanguageTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</LanguageTargets>

--- a/StationeersLaunchPad/Metadata/ModAbout.cs
+++ b/StationeersLaunchPad/Metadata/ModAbout.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using System.Xml.Schema;
 using System.Xml.Serialization;
 
 namespace StationeersLaunchPad.Metadata
@@ -27,11 +28,11 @@ namespace StationeersLaunchPad.Metadata
     [XmlIgnore]
     public string InGameDescription;
 
-    [XmlElement("InGameDescription", IsNullable = true)]
-    public XmlCDataSection InGameDescriptionCData
+    [XmlElement("InGameDescription", IsNullable =true)]
+    public CDataString InGameDescriptionCData
     {
-      get => !string.IsNullOrEmpty(this.InGameDescription) ? new XmlDocument().CreateCDataSection(this.InGameDescription) : null;
-      set => this.InGameDescription = value?.Value;
+      get => string.IsNullOrEmpty(InGameDescription) ? null : new() { Value = InGameDescription};
+      set => InGameDescription = value?.Value;
     }
 
     [XmlElement("ChangeLog", IsNullable = true)]
@@ -126,5 +127,13 @@ namespace StationeersLaunchPad.Metadata
       get => Version; set => Version = value;
     }
     public bool ShouldSerialize_Legacy_Version() => false;
+  }
+
+  public class CDataString : IXmlSerializable
+  {
+    public string Value;
+    public XmlSchema GetSchema() => null;
+    public void ReadXml(XmlReader reader) => Value = reader.ReadElementContentAsString();
+    public void WriteXml(XmlWriter writer) => writer.WriteCData(Value);
   }
 }

--- a/StationeersLaunchPad/Repos/Config.cs
+++ b/StationeersLaunchPad/Repos/Config.cs
@@ -40,6 +40,7 @@ namespace StationeersLaunchPad.Repos
 
     public abstract UniTask<RepoFetchResult> FetchRemote();
     public abstract void SetCacheKey(string cacheKey);
+    public abstract bool HasCacheKey { get; }
   }
 
   public class RepoModDef
@@ -54,5 +55,9 @@ namespace StationeersLaunchPad.Repos
     [XmlAttribute("DirName")] public string DirName;
 
     [XmlIgnore] public string PrevDirName;
+    [XmlIgnore] public ModRepoDef Repo;
+
+    public string DisplayName =>
+      $"{ModID}@{Branch}[{Version}({MinVersion},{MaxVersion})] from {RepoID}";
   }
 }

--- a/StationeersLaunchPad/Repos/GitHub.cs
+++ b/StationeersLaunchPad/Repos/GitHub.cs
@@ -6,17 +6,18 @@ namespace StationeersLaunchPad.Repos
 {
   public class GitHubRepoDef : ModRepoDef
   {
-    [XmlAttribute("Owner")] public string Owner;
-    [XmlAttribute("Name")] public string Name;
+    [XmlAttribute("Owner")] public string Owner = "";
+    [XmlAttribute("Name")] public string Name = "";
     [XmlAttribute("ETag")] public string ETag;
 
     [XmlIgnore]
-    public override string ID => $"github.com/{Owner}/{Name}";
+    public override string ID => $"github.com/{Owner.ToLower()}/{Name.ToLower()}";
 
     public override UniTask<RepoFetchResult> FetchRemote() => HttpRepoDef.FetchHttp(
       $"https://raw.githubusercontent.com/{Owner}/{Name}/refs/heads/modrepo/modrepo.xml",
       ETag
     );
     public override void SetCacheKey(string cacheKey) => ETag = cacheKey;
+    public override bool HasCacheKey => !string.IsNullOrEmpty(ETag);
   }
 }

--- a/StationeersLaunchPad/Repos/Http.cs
+++ b/StationeersLaunchPad/Repos/Http.cs
@@ -16,6 +16,7 @@ namespace StationeersLaunchPad.Repos
 
     public override UniTask<RepoFetchResult> FetchRemote() => FetchHttp(Url, ETag);
     public override void SetCacheKey(string cacheKey) => ETag = cacheKey;
+    public override bool HasCacheKey => !string.IsNullOrEmpty(ETag);
 
     public static async UniTask<RepoFetchResult> FetchHttp(string url, string etag)
     {


### PR DESCRIPTION
Also:
- updates the build to target netstandard2.1
  - we were previously targeting net48 because the default reference assemblies for netstandard2.1 didn't include `System.Reflection.Emit`. now that we are explicitly referencing the stdlib shipped with the game, target the correct version so the build doesn't get weird when `dotnet build` decides to also include the reference assembles
- improved handling of InGameDescription so deserializing wouldn't fail when the present as a normal text node instead of CDATA