### PR TITLE
Use solution root as base path for pdb

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <Deterministic>true</Deterministic>
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
     <MSBuildProjectExtensionsPath>$(SolutionDir)obj\</MSBuildProjectExtensionsPath>
     <BaseIntermediateOutputPath>$(SolutionDir)obj\</BaseIntermediateOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
This change should update the pdb so that exceptions in _player.log_ reference `./StationeersLaunchPad/Logging/LogWrapper.cs` instead of `C:/Users/Tom/Documents/StationeersLaunchPad/StationeersLaunchPad/Logging/LogWrapper.cs`