### PR TITLE
Queue SLP commands until needed load stage is reached

### DIFF
--- a/StationeersLaunchPad/Commands/Command.cs
+++ b/StationeersLaunchPad/Commands/Command.cs
@@ -1,5 +1,6 @@
 
 using Assets.Scripts;
+using Cysharp.Threading.Tasks;
 using StationeersLaunchPad.UI;
 using System;
 using System.Collections.Generic;
@@ -10,31 +11,88 @@ using Util.Commands;
 
 namespace StationeersLaunchPad.Commands
 {
+  public enum CommandStage
+  {
+    PreInit, // before SLP is initialized (shouldn't run any commands yet)
+    Init, // wait for SLP initialization
+    ConfigLoaded, // wait for mod config to be loaded (mod/repo list)
+    ModsLoaded, // wait for mods to be loaded
+    GameRunning, // wait for game to be running
+  };
+
   public class SLPCommand : CommandBase
   {
     public static readonly SLPCommand Instance = new();
 
-    public static bool StartupRun = false;
-    public static readonly List<string[]> StartupCommands = new();
+    private static bool inCommandExec = false;
+    private static bool inCommandAsync = false;
 
-    public static void RunStartup()
+    public static CommandStage Stage { get; private set; } = CommandStage.PreInit;
+    public static bool CommandRunning => inCommandExec || inCommandAsync;
+    private static readonly Queue<string[]> CommandQueue = new();
+
+    public static CommandStage QueuedStage
     {
-      StartupRun = true;
-      var instance = new SLPCommand();
-      foreach (var cmd in StartupCommands)
+      get
       {
-        try
-        {
-          var res = instance.ExecuteStartup(cmd);
-          if (!string.IsNullOrEmpty(res))
-            Compat.ConsoleWindowPrint($"slp: {res}");
-        }
-        catch (Exception ex)
-        {
-          ConsoleWindow.PrintError($"Exception: {ex}", true);
-        }
+        if (CommandQueue.Count == 0)
+          return CommandStage.Init;
+        return CurrentRoot.Stage(CommandQueue.Peek());
       }
-      StartupCommands.Clear();
+    }
+
+    public static string RunCommand(string[] args)
+    {
+      if (CommandRunning || CommandQueue.Count > 0 || CurrentRoot.Stage(args) > Stage)
+      {
+        CommandQueue.Enqueue(args);
+        return null;
+      }
+      return DoExecute(args);
+    }
+
+    public static async UniTask AsyncCommand(UniTask cmd)
+    {
+      try
+      {
+        inCommandAsync = true;
+        await cmd;
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogException(ex);
+      }
+      finally
+      {
+        inCommandAsync = false;
+      }
+      TryRunNext();
+    }
+
+    private static void TryRunNext()
+    {
+      while (!CommandRunning && CommandQueue.Count > 0 && QueuedStage <= Stage)
+      {
+        var res = DoExecute(CommandQueue.Dequeue());
+        if (res != null)
+          SubCommand.Print(res);
+      }
+    }
+
+    // move the stage backwards and don't try to immediately run commands
+    public static void RevertStage(CommandStage stage)
+    {
+      if (stage > Stage)
+        throw new InvalidOperationException($"{stage} > {Stage}");
+      Stage = stage;
+    }
+
+    public static async UniTask MoveToStage(CommandStage stage)
+    {
+      Stage = stage;
+      TryRunNext();
+      while (CommandRunning)
+        await UniTask.Yield();
     }
 
     public override string HelpText => RootCommand.Instance.UsageDescription;
@@ -43,25 +101,30 @@ namespace StationeersLaunchPad.Commands
 
     public override bool IsLaunchCmd => true;
 
-    public override string Execute(string[] args) => Execute(args, false);
-    public string ExecuteStartup(string[] args) => Execute(args, true);
+    public override string Execute(string[] args) => RunCommand(args);
 
-    private string Execute(string[] args, bool startup)
+    private static string DoExecute(string[] args)
     {
-      if (!StartupRun)
+      inCommandExec = true;
+      try
       {
-        StartupCommands.Add(args);
-        return null;
+        return CurrentRoot.Execute(args);
       }
-      return (startup ? RootCommand.StartupInstance : RootCommand.Instance).Execute(args);
+      finally
+      {
+        inCommandExec = false;
+      }
     }
+
+    private static RootCommand CurrentRoot =>
+      Stage < CommandStage.GameRunning ? RootCommand.StartupInstance : RootCommand.Instance;
   }
 
   public abstract class SubCommand
   {
-    protected static void Print(string message)
+    public static void Print(string message)
     {
-      if (LaunchPadConfig.GameRunning)
+      if (SLPCommand.Stage >= CommandStage.GameRunning)
         Compat.ConsoleWindowPrint(message);
       Logger.Global.Log(message);
     }
@@ -113,6 +176,13 @@ namespace StationeersLaunchPad.Commands
       return LongUsage;
     }
 
+    public CommandStage Stage(ReadOnlySpan<string> args)
+    {
+      if (args.Length == 0 || !ChildrenMap.TryGetValue(args[0].ToLower(), out var child))
+        return LeafStage;
+      return child.Stage(args[1..]);
+    }
+
     protected bool RunChild(ReadOnlySpan<string> args, out string result)
     {
       if (args.Length == 0)
@@ -129,6 +199,7 @@ namespace StationeersLaunchPad.Commands
       return true;
     }
 
+    protected virtual CommandStage LeafStage => CommandStage.Init;
     protected virtual bool RunLeaf(ReadOnlySpan<string> args, out string result)
     {
       result = null;
@@ -284,6 +355,7 @@ namespace StationeersLaunchPad.Commands
     public LogsCommand() : base("logs") { }
     public override string UsageDescription => "-- open mods log window";
 
+    protected override CommandStage LeafStage => CommandStage.Init;
     protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
     {
       LogPanel.OpenStandaloneLogs();
@@ -299,6 +371,7 @@ namespace StationeersLaunchPad.Commands
     public override string UsageDescription =>
       "[<path.zip>] -- generate mod package for dedicated server or debugging";
 
+    protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
     protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
     {
       if (!ArgP(args).Positional(out var pkgpath, null).Validate())
@@ -316,6 +389,7 @@ namespace StationeersLaunchPad.Commands
     public ExitCommand() : base("exit") { }
     public override string UsageDescription => "-- exit the game";
 
+    protected override CommandStage LeafStage => CommandStage.Init;
     protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
     {
       Application.Quit();

--- a/StationeersLaunchPad/Commands/Config.cs
+++ b/StationeersLaunchPad/Commands/Config.cs
@@ -26,6 +26,7 @@ namespace StationeersLaunchPad.Commands
       public ListCommand() : base("list") { }
       public override string UsageDescription => "[<searchtext>]";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Positional(out var filter, "").Validate())
@@ -63,6 +64,7 @@ namespace StationeersLaunchPad.Commands
       public SetCommand() : base("set") { }
       public override string UsageDescription => "<name> <value>";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Positional(out var name).Positional(out var value).Validate())

--- a/StationeersLaunchPad/Commands/RepoMods.cs
+++ b/StationeersLaunchPad/Commands/RepoMods.cs
@@ -23,6 +23,7 @@ namespace StationeersLaunchPad.Commands
       public ListCommand() : base("list") { }
       public override string UsageDescription => "-- list installed repo mods";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Validate())
@@ -49,6 +50,7 @@ namespace StationeersLaunchPad.Commands
       public override string UsageDescription =>
         "<ModID> [version=<Version>] [branch=<Branch>] [repo=<RepoID>]";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Named("version", out var version)
@@ -109,7 +111,7 @@ namespace StationeersLaunchPad.Commands
         if (version != null)
           mod.MaxVersion = version;
 
-        Add(mod).Forget();
+        SLPCommand.AsyncCommand(Add(mod)).Forget();
 
         result = null;
         return true;
@@ -135,6 +137,7 @@ namespace StationeersLaunchPad.Commands
       public override string UsageDescription =>
         "<ModID> [version=<Version>] [branch=<Branch>] [repo=<RepoID>]";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Named("version", out var version)

--- a/StationeersLaunchPad/Commands/Repos.cs
+++ b/StationeersLaunchPad/Commands/Repos.cs
@@ -23,6 +23,7 @@ namespace StationeersLaunchPad.Commands
       public ListCommand() : base("list") { }
       public override string UsageDescription => "[<searchtext>] -- list connected repos";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Positional(out var filter, null).Validate())
@@ -59,6 +60,7 @@ namespace StationeersLaunchPad.Commands
       public override string UsageDescription =>
         "<RepoURL> [novalidate] -- connect to a repo";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Flag("novalidate", out var novalidate)
@@ -75,7 +77,7 @@ namespace StationeersLaunchPad.Commands
           return true;
         }
 
-        Add(repo, !novalidate).Forget();
+        SLPCommand.AsyncCommand(Add(repo, !novalidate)).Forget();
         result = null;
         return true;
       }
@@ -106,6 +108,7 @@ namespace StationeersLaunchPad.Commands
       public RemoveCommand() : base("remove") { }
       public override string UsageDescription => "<RepoID|Index> -- remove a connected repo";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Positional(out var repoID).Validate())
@@ -137,6 +140,7 @@ namespace StationeersLaunchPad.Commands
       public override string UsageDescription =>
         "[mod=<ModID>] [repo=<RepoID>] [branch=<Branch>] [version/minversion/maxversion=<Version>] -- search connected mod repos";
 
+      protected override CommandStage LeafStage => CommandStage.ConfigLoaded;
       protected override bool RunLeaf(ReadOnlySpan<string> args, out string result)
       {
         if (!ArgP(args).Named("mod", out var mod)

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -81,9 +81,9 @@ namespace StationeersLaunchPad
       if (Stage != LoadStage.Configuring)
         return;
       Logger.Global.LogInfo("Reloading Mod List");
-      StopAutoLoad();
       Stage = LoadStage.Searching;
       CurWait.Skip();
+      SLPCommand.RevertStage(CommandStage.Init);
     }
 
     public static void Draw()
@@ -124,7 +124,6 @@ namespace StationeersLaunchPad
       {
         await StageSearching(firstLoad);
         firstLoad = false;
-        SLPCommand.RunStartup();
         await StageConfiguring();
       }
       while (Stage == LoadStage.Searching);
@@ -132,6 +131,7 @@ namespace StationeersLaunchPad
       await StageFinal();
 
       StartGame();
+      await SLPCommand.MoveToStage(CommandStage.GameRunning);
     }
 
     private static void OnStartupError(Exception ex)
@@ -178,6 +178,10 @@ namespace StationeersLaunchPad
         StopAutoLoad();
         SteamDisabled = true;
       }
+
+      WorldManager.OnGameDataLoaded += () => SLPRefCheck.RunRefCheck().Forget();
+
+      await SLPCommand.MoveToStage(CommandStage.Init);
     }
 
     private static async UniTask StageUpdating()
@@ -269,6 +273,13 @@ namespace StationeersLaunchPad
       Stage = LoadStage.Configuring;
 
       CurWait = new(Configs.AutoLoadWaitTime.Value, AutoLoad);
+
+      await SLPCommand.MoveToStage(CommandStage.ConfigLoaded);
+
+      // if we have a command queued, don't wait
+      if (!CurWait.Done && SLPCommand.QueuedStage > CommandStage.ConfigLoaded)
+        CurWait.Skip();
+
       await Platform.Wait(CurWait);
     }
 
@@ -305,11 +316,14 @@ namespace StationeersLaunchPad
       if (Stage != LoadStage.Failed)
         Stage = LoadStage.Loaded;
 
+      await SLPCommand.MoveToStage(CommandStage.ModsLoaded);
+
       CurWait = new(Configs.AutoLoadWaitTime.Value, AutoLoad);
+      // if we have a command queued, don't wait
+      if (!CurWait.Done && SLPCommand.QueuedStage > CommandStage.ModsLoaded)
+        CurWait.Skip();
       await Platform.Wait(CurWait);
       await SLPRefCheck.RunRefCheck();
-
-      WorldManager.OnGameDataLoaded += () => SLPRefCheck.RunRefCheck().Forget();
     }
 
     public static ModInfo MatchMod(ModData modData) =>

--- a/StationeersLaunchPad/UI/StartupConsole.cs
+++ b/StationeersLaunchPad/UI/StartupConsole.cs
@@ -30,7 +30,7 @@ namespace StationeersLaunchPad.UI
         Logger.Global.LogInfo($"> {input}");
         try
         {
-          res = RootCommand.StartupInstance.Execute(args);
+          res = SLPCommand.RunCommand(args);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
- async commands cause other slp commands to be queued until they finish
- auto moves to next stage when there is a queued command

These changes allow launch arguments to run a series of dependent commands
```
# add a repo, install a mod from it, then exit
rocketstation.exe -slp repos add <url> -slp repomods add <modid> -slp exit
```