### PR TITLE
Add mod profile system for saving/switching mod configurations

### DIFF
--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -56,6 +56,8 @@ public static class LaunchPadConfig
   public static SplashBehaviour SplashBehaviour;
 
   private static ModList modList = ModList.NewEmpty();
+  
+  private static ProfileManager profileManager = new();
 
   private static LoadStage Stage = LoadStage.Initializing;
   public static bool ModsLoaded => Stage > LoadStage.Configuring;
@@ -92,7 +94,7 @@ public static class LaunchPadConfig
     }
     else
     {
-      var changed = ManualLoadWindow.Draw(Stage, modList, AutoSort);
+      var changed = ManualLoadWindow.Draw(Stage, modList, AutoSort, profileManager);
       HandleChange(changed);
     }
 
@@ -121,6 +123,7 @@ public static class LaunchPadConfig
     {
       await StageSearching(firstLoad);
       firstLoad = false;
+      await ApplyStartupProfile();
       await StageConfiguring();
     }
     while (Stage == LoadStage.Searching);
@@ -256,12 +259,28 @@ public static class LaunchPadConfig
 
       if (depNotice && Platform.PauseOnDepNotice)
         StopAutoLoad();
+      
+      if (firstLoad)
+        profileManager.Initialize();
 
       Logger.Global.LogInfo("Mod Config Initialized");
     }
     catch (Exception ex)
     {
       OnStartupError(ex);
+    }
+  }
+
+  private static async UniTask ApplyStartupProfile()
+  {
+    if (Stage == LoadStage.Failed) return;
+
+    var startupProfile = profileManager.GetStartupProfile();
+
+    if (profileManager.AllProfiles.Count == 0) return;
+    if (startupProfile != null)
+    {
+      profileManager.LoadProfile(startupProfile.Name, modList);
     }
   }
 
@@ -334,6 +353,8 @@ public static class LaunchPadConfig
       if (AutoSort)
         modList.SortByDeps();
       ModConfigUtil.SaveConfig(modList.ToModConfig());
+      if (modsChanged && profileManager.ActiveProfileName != null)
+        profileManager.MarkDiverged();
     }
     var next = changed.HasFlag(ManualLoadWindow.ChangeFlags.NextStep);
     if (next)

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -97,7 +97,8 @@ public static class LaunchPadConfig
       var changed = ManualLoadWindow.Draw(Stage, modList, AutoSort, profileManager);
       HandleChange(changed);
     }
-
+    
+    ProfileStartupDialog.Draw();
     AlertPopup.Draw();
   }
 
@@ -281,6 +282,19 @@ public static class LaunchPadConfig
     if (startupProfile != null)
     {
       profileManager.LoadProfile(startupProfile.Name, modList);
+      return;
+    }
+
+    var (result, chosen) = await ProfileStartupDialog.Show(profileManager.AllProfiles);
+    switch (result)
+    {
+      case ProfileStartupResult.Chosen:
+        profileManager.LoadProfile(chosen, modList);
+        break;
+      case ProfileStartupResult.ManageProfiles:
+        StopAutoLoad();
+        ManualLoadWindow.OpenProfilesTab();
+        break;
     }
   }
 

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -117,6 +117,62 @@ public class ModList
     mods = newMods;
   }
 
+  public void ApplyProfile(ProfileData profile)
+  {
+    var modsByPath = new Dictionary<string, ModInfo>(StringComparer.OrdinalIgnoreCase);
+    var modsByHandle = new Dictionary<ulong, ModInfo>();
+
+    foreach (var mod in mods)
+    {
+      if (mod.Source == ModSourceType.Core && string.IsNullOrEmpty(mod.DirectoryPath))
+        modsByPath["Core"] = mod;
+      else if (!string.IsNullOrEmpty(mod.DirectoryPath))
+        modsByPath[NormalizePath(mod.DirectoryPath)] = mod;
+
+      if (mod.WorkshopHandle != 0)
+        modsByHandle[mod.WorkshopHandle] = mod;
+    }
+
+    foreach (var mod in mods)
+      mod.Enabled = false;
+
+    var ordered = new List<ModInfo>();
+    var matched = new HashSet<ModInfo>();
+
+    foreach (var entry in profile.Mods)
+    {
+      ModInfo mod = null;
+
+      // Core sentinel: empty path and zero handle
+      if (string.IsNullOrEmpty(entry.DirectoryPath) && entry.WorkshopHandle == 0)
+        modsByPath.TryGetValue("Core", out mod);
+      else if (!string.IsNullOrEmpty(entry.DirectoryPath))
+        modsByPath.TryGetValue(NormalizePath(entry.DirectoryPath), out mod);
+
+      if (mod == null && entry.WorkshopHandle != 0)
+        modsByHandle.TryGetValue(entry.WorkshopHandle, out mod);
+
+      if (mod == null)
+      {
+        Logger.Global.LogWarning($"Profile mod not found: path='{entry.DirectoryPath}' handle={entry.WorkshopHandle}");
+        continue;
+      }
+
+      mod.Enabled = entry.Enabled;
+      if (!matched.Contains(mod))
+      {
+        ordered.Add(mod);
+        matched.Add(mod);
+      }
+    }
+    
+    foreach (var mod in mods)
+      if (!matched.Contains(mod))
+        ordered.Add(mod);
+
+    mods = ordered;
+  }
+
   // returns true if the mod was moved (even if it wasn't moved all the way to the target index)
   public bool MoveModTo(ModInfo mod, int index, bool keepOrder)
   {

--- a/StationeersLaunchPad/Metadata/ProfileData.cs
+++ b/StationeersLaunchPad/Metadata/ProfileData.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace StationeersLaunchPad.Metadata;
+
+[XmlRoot("ModProfile")]
+public class ProfileData
+{
+    [XmlAttribute("Name")]
+    public string Name;
+    
+    [XmlAttribute("Description")]
+    public string Description = "";
+    
+    [XmlElement("Mod")]
+    public List<ProfileModEntry> Mods = [];
+}
+
+public class ProfileModEntry
+{
+    [XmlAttribute("DirectoryPath")]
+    public string DirectoryPath;
+    
+    [XmlAttribute("WorkshopHandle")]
+    public ulong WorkshopHandle;
+    
+    [XmlAttribute("Enabled")]
+    public bool Enabled;
+}

--- a/StationeersLaunchPad/Metadata/ProfileData.cs
+++ b/StationeersLaunchPad/Metadata/ProfileData.cs
@@ -9,7 +9,7 @@ public class ProfileData
     [XmlAttribute("Name")]
     public string Name;
     
-    [XmlAttribute("Description")]
+    [XmlElement("Description")]
     public string Description = "";
     
     [XmlElement("Mod")]

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StationeersLaunchPad.Metadata;
+
+public class ProfileManager
+{
+    private List<ProfileData> profiles = [];
+
+    public IReadOnlyList<ProfileData> AllProfiles => profiles;
+    public string ActiveProfileName { get; private set; }
+    public bool HasDiverged { get; private set; }
+
+    public bool ProfileExists(string profileName) =>
+        profiles.Any(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+
+    public void Initialize()
+    {
+        profiles = ProfileStorage.LoadAll();
+        ActiveProfileName = ProfileStorage.LoadActiveName();
+
+        if (ActiveProfileName != null && !ProfileExists(ActiveProfileName))
+        {
+            ActiveProfileName = null;
+            ProfileStorage.ClearActiveName();
+        }
+    }
+
+    public bool CreateProfile(string profileName, ModList modList)
+    {
+        if (string.IsNullOrWhiteSpace(profileName) || ProfileExists(profileName))
+            return false;
+
+        var profile = CaptureModList(profileName, modList);
+        ProfileStorage.Save(profile);
+        profiles.Add(profile);
+        return true;
+    }
+
+    public bool LoadProfile(string profileName, ModList modList)
+    {
+        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        if (profile == null)
+            return false;
+        
+        modList.ApplyProfile(profile);
+        ActiveProfileName = profile.Name;
+        HasDiverged = false;
+        ProfileStorage.SaveActiveName(ActiveProfileName);
+        ModConfigUtil.SaveConfig(modList.ToModConfig());
+        return true;
+    }
+
+    public bool DeleteProfile(string profileName)
+    {
+        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        if (profile == null)
+            return false;
+
+        profiles.Remove(profile);
+        ProfileStorage.Delete(profileName);
+
+        if (ActiveProfileName != null && ActiveProfileName.Equals(profileName, StringComparison.OrdinalIgnoreCase))
+        {
+            ActiveProfileName = null;
+            ProfileStorage.ClearActiveName();
+        }
+
+        return true;
+    }
+
+    public bool RenameProfile(string oldProfileName, string newProfileName)
+    {
+        if (string.IsNullOrWhiteSpace(newProfileName))
+            return false;
+        
+        var existingProfile = profiles.FirstOrDefault(p => p.Name.Equals(oldProfileName, StringComparison.OrdinalIgnoreCase));
+        if (existingProfile == null)
+            return false;
+
+        if (profiles.Any(p => p != existingProfile && p.Name.Equals(newProfileName, StringComparison.OrdinalIgnoreCase)))
+            return false;
+        
+        var renamedProfile = ProfileStorage.Rename(oldProfileName, newProfileName);
+        if (renamedProfile == null)
+            return false;
+        
+        var index = profiles.IndexOf(renamedProfile);
+        profiles[index] = renamedProfile;
+
+        if (ActiveProfileName != null && ActiveProfileName.Equals(oldProfileName, StringComparison.OrdinalIgnoreCase))
+        {
+            ActiveProfileName = renamedProfile.Name;
+            ProfileStorage.SaveActiveName(ActiveProfileName);
+        }
+
+        return true;
+    }
+
+    public bool UpdateProfile(string profileName, ModList modList)
+    {
+        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        if (profile == null)
+            return false;
+
+        var updatedProfile = CaptureModList(profileName, modList);
+        profile.Description = updatedProfile.Description;
+        profile.Mods = updatedProfile.Mods;
+        ProfileStorage.Save(profile);
+        return true;
+    }
+
+    public void MarkDiverged() => HasDiverged = true;
+
+    public ProfileData GetStartupProfile()
+    {
+        return profiles.Count switch
+        {
+            0 => null,
+            1 => profiles[0],
+            _ => null,
+        };
+    }
+    
+    private static ProfileData CaptureModList(string profileName, ModList modList)
+    {
+        var profile = new ProfileData { Name = profileName };
+        foreach (var mod in modList.AllMods)
+        {
+            profile.Mods.Add(new ProfileModEntry
+            {
+                DirectoryPath = mod.DirectoryPath ?? "",
+                WorkshopHandle = mod.WorkshopHandle,
+                Enabled = mod.Enabled,
+            });
+        }
+
+        return profile;
+    }
+}

--- a/StationeersLaunchPad/Metadata/ProfileStorage.cs
+++ b/StationeersLaunchPad/Metadata/ProfileStorage.cs
@@ -13,7 +13,7 @@ public class ActiveProfileConfig
     public string Name;
 }
 
-public class ProfileStorage
+public static class ProfileStorage
 {
     public static string ProfilesDirectory => Path.Join(LaunchPadPaths.SavePath, "profiles");
     public static string ActiveConfigPath => Path.Join(LaunchPadPaths.SavePath, "active.xml");
@@ -114,7 +114,7 @@ public class ProfileStorage
         }
         catch (Exception e)
         {
-            Logger.Global.LogError($"Failed to load active profile config: {e.Message}");
+            Logger.Global.LogWarning($"Failed to load active profile config: {e.Message}");
             return null;
         }
     }

--- a/StationeersLaunchPad/Metadata/ProfileStorage.cs
+++ b/StationeersLaunchPad/Metadata/ProfileStorage.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+using Assets.Scripts.Serialization;
+
+namespace StationeersLaunchPad.Metadata;
+
+[XmlRoot("ActiveProfile")]
+public class ActiveProfileConfig
+{
+    [XmlAttribute("Name")]
+    public string Name;
+}
+
+public class ProfileStorage
+{
+    public static string ProfilesDirectory => Path.Join(LaunchPadPaths.SavePath, "profiles");
+    public static string ActiveConfigPath => Path.Join(LaunchPadPaths.SavePath, "active.xml");
+
+    public static List<ProfileData> LoadAll()
+    {
+        var dir = ProfilesDirectory;
+        if (!Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+            return [];
+        }
+
+        var profiles = new List<ProfileData>();
+
+        foreach (var file in Directory.GetFiles(dir, "*.xml"))
+        {
+            try
+            {
+                var profile = XmlSerialization.Deserialize<ProfileData>(file);
+                if (profile != null)
+                    profiles.Add(profile);
+                else
+                    Logger.Global.LogWarning($"Skipping corrupt profile file: {file}");
+            }
+            catch (Exception e)
+            {
+                Logger.Global.LogWarning($"Skipping corrupt profile file: {file} ({e.Message})");
+            }
+        }
+
+        return profiles;
+    }
+
+    public static ProfileData Load(string profileName)
+    {
+        var path = GetProfilePath(profileName);
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            return XmlSerialization.Deserialize<ProfileData>(path);
+        }
+        catch (Exception e)
+        {
+            Logger.Global.LogWarning($"Failed to load profile '{profileName}': {e.Message}");
+            return null;
+        }
+    }
+
+    public static void Save(ProfileData profile)
+    {
+        var dir = ProfilesDirectory;
+        if (!Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var path = GetProfilePath(profile.Name);
+        if (!profile.SaveXml(path))
+            Logger.Global.LogError($"Failed to save profile to {path}");
+    }
+
+    public static void Delete(string profileName)
+    {
+        var path = GetProfilePath(profileName);
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception e)
+        {
+            Logger.Global.LogError($"Failed to delete profile '{profileName}': {e.Message}");
+        }
+    }
+
+    public static ProfileData Rename(string oldProfileName, string newProfileName)
+    {
+        var profile = Load(oldProfileName);
+        if (profile == null)
+            return null;
+        
+        profile.Name = newProfileName;
+        Save(profile);
+        Delete(oldProfileName);
+        return profile;
+    }
+
+    public static string LoadActiveName()
+    {
+        if (!File.Exists(ActiveConfigPath))
+            return null;
+
+        try
+        {
+            var config = XmlSerialization.Deserialize<ActiveProfileConfig>(ActiveConfigPath);
+            return config?.Name;
+        }
+        catch (Exception e)
+        {
+            Logger.Global.LogError($"Failed to load active profile config: {e.Message}");
+            return null;
+        }
+    }
+
+    public static void SaveActiveName(string profileName)
+    {
+        var dir = ProfilesDirectory;
+        if (!Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var config = new ActiveProfileConfig { Name = profileName };
+        if (!config.SaveXml(ActiveConfigPath))
+            Logger.Global.LogError($"Failed to save active profile config to {ActiveConfigPath}");
+    }
+
+    public static void ClearActiveName()
+    {
+        try
+        {
+            if (File.Exists(ActiveConfigPath))
+                File.Delete(ActiveConfigPath);
+        }
+        catch (Exception e)
+        {
+            Logger.Global.LogError($"Failed to clear active profile config: {e.Message}");
+        }
+    }
+
+    private static string GetProfilePath(string profileName)
+    {
+        var sanitized = Platform.MakeValidFileName(profileName).ToLowerInvariant();
+        return Path.Join(ProfilesDirectory, $"{sanitized}.xml");
+    }
+}

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -22,10 +22,11 @@ public static class ManualLoadWindow
   private static ModInfo selectedInfo = null;
   private static LoadedMod selectedMod = null;
   private static bool openInfo = false;
+  private static bool openProfilesTab = false;
   private static ModInfo draggingMod = null;
   private static bool dragged = false;
 
-  public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort)
+  public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort, ProfileManager profileManager = null)
   {
     Platform.SetBackgroundEnabled(false);
     var changed = ChangeFlags.None;
@@ -87,6 +88,9 @@ public static class ManualLoadWindow
         // If we changed launchpad config and haven't loaded mods yet, mark mods changed to apply disable/sort behaviour
         if (DrawLaunchPadConfigTab() && stage <= LoadStage.Configuring)
           changed |= ChangeFlags.Mods;
+
+        if (profileManager != null)
+          changed |= DrawProfilesTab(stage, modList, profileManager); 
 
         ImGui.EndTabBar();
       }
@@ -437,6 +441,25 @@ public static class ManualLoadWindow
       changed = ConfigPanel.DrawConfigFile(Configs.Sorted, category => category != "Internal");
       ImGui.EndTabItem();
     }
+    return changed;
+  }
+
+  private static ChangeFlags DrawProfilesTab(LoadStage stage, ModList modList, ProfileManager profileManager)
+  {
+    var disabled = stage != LoadStage.Configuring;
+    ImGui.BeginDisabled(disabled);
+    var open = ImGui.BeginTabItem("Profiles", openProfilesTab ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None);
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      disabled ? "Profiles are only available during the Configuring stage" : "Manage mod profiles",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled
+    );
+    openProfilesTab = false;
+    if (!open)
+      return ChangeFlags.None;
+    
+    var changed = ProfileSelectorPanel.Draw(profileManager, modList, stage);
+    ImGui.EndTabItem();
     return changed;
   }
 }

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -26,6 +26,8 @@ public static class ManualLoadWindow
   private static ModInfo draggingMod = null;
   private static bool dragged = false;
 
+  public static void OpenProfilesTab() => openProfilesTab = true;
+  
   public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort, ProfileManager profileManager = null)
   {
     Platform.SetBackgroundEnabled(false);

--- a/StationeersLaunchPad/UI/ProfileSelectorPanel.cs
+++ b/StationeersLaunchPad/UI/ProfileSelectorPanel.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace StationeersLaunchPad.UI;
 
-public class ProfileSelectorPanel
+public static class ProfileSelectorPanel
 {
     private static int selectedIndex = -1;
     private static string pendingName = "";

--- a/StationeersLaunchPad/UI/ProfileSelectorPanel.cs
+++ b/StationeersLaunchPad/UI/ProfileSelectorPanel.cs
@@ -1,0 +1,159 @@
+﻿using Cysharp.Threading.Tasks;
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+using UnityEngine;
+
+namespace StationeersLaunchPad.UI;
+
+public class ProfileSelectorPanel
+{
+    private static int selectedIndex = -1;
+    private static string pendingName = "";
+    private static bool showCreateInput = false;
+    private static bool showRenameInput = false;
+
+    public static ManualLoadWindow.ChangeFlags Draw(ProfileManager profileManager, ModList modList, LoadStage stage)
+    {
+        var changed = ManualLoadWindow.ChangeFlags.None;
+        var disabled = stage != LoadStage.Configuring;
+
+        ImGui.BeginDisabled(disabled);
+
+        var profiles = profileManager.AllProfiles;
+
+        if (selectedIndex >= profiles.Count)
+            selectedIndex = profiles.Count - 1;
+
+        var listHeight = ImGui.GetContentRegionAvail().y - ImGui.GetTextLineHeightWithSpacing() * 4f;
+        ImGui.BeginChild("##profilelist", new Vector2(0, listHeight));
+        for (var i = 0; i < profiles.Count; i++)
+        {
+            ImGui.PushID(i);
+            var profile = profiles[i];
+            var isActive = profile.Name == profileManager.ActiveProfileName;
+            var isSelected = i == selectedIndex;
+
+            if (isActive)
+                ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.4f, 1f, 0.4f, 1f));
+
+            var label = isActive
+                ? $"{profile.Name}{(profileManager.HasDiverged ? " *" : " [active]")}"
+                : profile.Name;
+
+            if (ImGui.Selectable(label, isSelected))
+                selectedIndex = i;
+
+            if (isActive)
+                ImGui.PopStyleColor();
+
+            ImGuiHelper.ItemTooltip(isActive
+                ? (profileManager.HasDiverged ? "Active profile (modified)" : "Active profile")
+                : profile.Name);
+
+            ImGui.PopID();
+        }
+        ImGui.EndChild();
+
+        ImGui.Separator();
+
+        var hasSelection = selectedIndex >= 0 && selectedIndex < profiles.Count;
+        var selectedProfile = hasSelection ? profiles[selectedIndex] : null;
+
+        if (ImGui.Button("Create"))
+        {
+            pendingName = "";
+            showCreateInput = true;
+            showRenameInput = false;
+        }
+
+        ImGui.SameLine();
+        ImGui.BeginDisabled(!hasSelection);
+
+        if (ImGui.Button("Load"))
+        {
+            if (profileManager.LoadProfile(selectedProfile!.Name, modList))
+                changed |= ManualLoadWindow.ChangeFlags.Mods;
+        }
+        ImGuiHelper.ItemTooltip("Apply this profile to the current mod list");
+
+        ImGui.SameLine();
+        if (ImGui.Button("Update"))
+        {
+            profileManager.UpdateProfile(selectedProfile!.Name, modList);
+        }
+        ImGuiHelper.ItemTooltip("Overwrite this profile with the current mod list");
+
+        ImGui.SameLine();
+        if (ImGui.Button("Rename"))
+        {
+            pendingName = selectedProfile!.Name;
+            showRenameInput = true;
+            showCreateInput = false;
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button("Delete"))
+        {
+            ConfirmDelete(profileManager, selectedProfile!.Name).Forget();
+        }
+
+        ImGui.EndDisabled();
+
+        if (showCreateInput)
+        {
+            ImGui.Separator();
+            ImGui.SetNextItemWidth(200f);
+            ImGui.InputText("##createname", ref pendingName, 128);
+            ImGui.SameLine();
+            if (ImGui.Button("OK##create"))
+            {
+                if (profileManager.CreateProfile(pendingName, modList))
+                {
+                    selectedIndex = profileManager.AllProfiles.Count - 1;
+                    showCreateInput = false;
+                }
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel##create"))
+                showCreateInput = false;
+        }
+
+        if (showRenameInput && hasSelection)
+        {
+            ImGui.Separator();
+            ImGui.SetNextItemWidth(200f);
+            ImGui.InputText("##renameinput", ref pendingName, 128);
+            ImGui.SameLine();
+            if (ImGui.Button("OK##rename"))
+            {
+                if (profileManager.RenameProfile(selectedProfile!.Name, pendingName))
+                    showRenameInput = false;
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel##rename"))
+                showRenameInput = false;
+        }
+
+        ImGui.EndDisabled();
+
+        return changed;
+    }
+
+    private static async UniTaskVoid ConfirmDelete(ProfileManager profileManager, string name)
+    {
+        var confirmed = false;
+        await AlertPopup.Show(
+            "Delete Profile",
+            $"Delete profile '{name}'? This cannot be undone.",
+            AlertPopup.DefaultSize,
+            AlertPopup.DefaultPosition,
+            ("Delete", () => { confirmed = true; return true; }),
+            ("Cancel", () => true)
+        );
+        if (confirmed)
+        {
+            profileManager.DeleteProfile(name);
+            selectedIndex = -1;
+        }
+    }
+}

--- a/StationeersLaunchPad/UI/ProfileStartupDialog.cs
+++ b/StationeersLaunchPad/UI/ProfileStartupDialog.cs
@@ -1,0 +1,115 @@
+﻿using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+using UI.ImGuiUi;
+using UnityEngine;
+
+namespace StationeersLaunchPad.UI;
+
+public enum ProfileStartupResult
+{
+    Chosen,
+    Skipped,
+    ManageProfiles,
+}
+
+public class ProfileStartupDialog
+{
+    private static int selectedIndex = 0;
+    private static string chosenName = null;
+    private static List<ProfileData> profiles;
+    private static ProfileStartupResult result;
+    
+    public static bool IsActive { get; private set; }
+
+    public static async UniTask<(ProfileStartupResult result, string name)> Show(IReadOnlyList<ProfileData> profileList)
+    {
+        selectedIndex = 0;
+        chosenName = null;
+        profiles = new List<ProfileData>(profileList);
+        result = ProfileStartupResult.Skipped;
+        IsActive = true;
+
+        while (IsActive)
+            await UniTask.Yield();
+
+        return (result, chosenName);
+    }
+
+    public static void Draw()
+    {
+        if (!IsActive)
+            return;
+        
+        ImGuiHelper.Draw(DrawDialog);
+    }
+
+    private static void DrawDialog()
+    {
+        var size = new Vector2(620, 400);
+        var center = ImguiHelper.ScreenCenter;
+        ImGui.SetNextWindowSize(size);
+        ImGui.SetNextWindowPos(center - size / 2);
+        ImGui.SetNextWindowFocus();
+        ImGui.Begin(
+            "Select Startup Profile##profilestartup",
+            ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings
+        );
+        
+        ImGuiHelper.TextWrapped("Multiple mod profiles found. Select a profile to load, or manage profiles manually.");
+        
+        ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.Spacing();
+
+        var spacing = ImGui.GetStyle().ItemSpacing;
+        var available = ImGui.GetContentRegionAvail();
+        var buttonRowHeight = 35f + spacing.y * 2 + 1f;
+        var listHeight = available.y - buttonRowHeight;
+
+        ImGui.BeginChild("##profilestatuplist", new Vector2(available.x, listHeight));
+        for (var i = 0; i < profiles.Count; i++)
+        {
+            ImGui.PushID(i);
+            if (ImGui.Selectable(profiles[i].Name, i == selectedIndex))
+                selectedIndex = i;
+            if (!string.IsNullOrWhiteSpace(profiles[i].Description))
+                ImGuiHelper.ItemTooltip(profiles[i].Description);
+            ImGui.PopID();
+        }
+        ImGui.EndChild();
+        
+        ImGui.Separator();
+        ImGui.Spacing();
+
+        var buttonWidth = (available.x - spacing.x * 2) / 3f;
+        var buttonSize = new Vector2(buttonWidth, 35f);
+
+        if (ImGui.Button("Load Selected", buttonSize))
+        {
+            chosenName = profiles[selectedIndex].Name;
+            result = ProfileStartupResult.Chosen;
+            IsActive = false;
+        }
+        
+        ImGui.SameLine();
+
+        if (ImGui.Button("Manage Profiles", buttonSize))
+        {
+            result = ProfileStartupResult.ManageProfiles;
+            IsActive = false;
+        }
+        ImGuiHelper.ItemTooltip("Open the Profiles tab to create, edit, or delete profiles");
+        
+        ImGui.SameLine();
+
+        if (ImGui.Button("Skip", buttonSize))
+        {
+            result = ProfileStartupResult.Skipped;
+            IsActive = false;
+        }
+
+        ImGui.End();
+    }
+}

--- a/StationeersLaunchPad/UI/ProfileStartupDialog.cs
+++ b/StationeersLaunchPad/UI/ProfileStartupDialog.cs
@@ -68,7 +68,7 @@ public class ProfileStartupDialog
         var buttonRowHeight = 35f + spacing.y * 2 + 1f;
         var listHeight = available.y - buttonRowHeight;
 
-        ImGui.BeginChild("##profilestatuplist", new Vector2(available.x, listHeight));
+        ImGui.BeginChild("##profilestartuplist", new Vector2(available.x, listHeight));
         for (var i = 0; i < profiles.Count; i++)
         {
             ImGui.PushID(i);


### PR DESCRIPTION
## Mod Profiles

Adds a profile system that lets players save and switch between different mod configurations.

### What it does

- Save the current mod list (order, enabled/disabled state) as a named profile
- Load a profile to restore that exact mod configuration
- Create, rename, delete, and update profiles
- Profiles are stored as individual XML files under `{SavePath}/profiles/`
- Active profile tracking via a separate `active_profile.xml` in the save directory
- Visual indicator in the UI when the active profile has been modified since loading
- On startup: auto-applies if there's exactly one profile, shows a selection dialog if there are multiple

### Files changed

**New files:**
- `Metadata/ProfileData.cs` — data models (`ProfileData`, `ProfileModEntry`)
- `Metadata/ProfileStorage.cs` — XML persistence (load/save/delete/rename profiles, active profile tracking)
- `Metadata/ProfileManager.cs` — business logic (create, load, delete, rename, update, divergence tracking, startup selection)
- `UI/ProfileSelectorPanel.cs` — profile management panel (list, buttons, inline name input)
- `UI/ProfileStartupDialog.cs` — startup dialog for choosing a profile when multiple exist

**Modified files:**
- `Metadata/ModList.cs` — added `ApplyProfile()` to apply a profile's mod state to the current mod list
- `UI/ManualLoadWindow.cs` — added "Profiles" tab, wired up `ProfileSelectorPanel`, added `OpenProfilesTab()` for startup dialog navigation
- `LaunchPadConfig.cs` — integrated `ProfileManager` initialization, startup profile selection, divergence detection on mod changes

### How profiles are stored

Each profile is a standalone XML file:
```xml
<ModProfile Name="MyBuild">
  <Description></Description>
  <Mod DirectoryPath="path/to/mod" WorkshopHandle="0" Enabled="true" />
</ModProfile>
```

The active profile is tracked separately so loading it doesn't require scanning all profiles.

### Testing

- [X] Creating profiles successfully store in `{SavePath}/profiles`
- [X] Renaming profiles successfully updates the name in `{SavePath}/profiles` from `before.xml` to `after.xml`
- [X] Deleting profiles successfully removes the xml files from `{SavePath}/profiles`
- [X] Selecting profile updates the `active_profile.xml` in `{SavePath}`
- [X] Deleting active profile clears the `active_profile.xml` setting
- [X] Loading profile from ProfileStartupDialog updates the modList after SLP loads
- [X] Loading profile from ManualLoadWindow updates the modList after SLP loads
- [X] ModList is not modified when selecting **Skip** on ProfileStartupDialog
- [X] Profiles tab shows an Asterisk after modifying the ModList while in ManualLoadWindow
- [X] ProfileStartupDialog does not appear when no profiles exist
- [X] ProfileStartupDialog does not appear when only 1 profile exists
- [X] ProfileStartupDialog does appear when 2 or more profiles exist
- [X] Creation of a Profile with a duplicate name fails
- [X] Renaming of a Profile with a duplicate name fails
- [X] Updating a Profile with a new ModList updates the mods in `{SavePath}/profiles/{profile}.xml`

### Issues

https://github.com/StationeersLaunchPad/StationeersLaunchPad/issues/116