### PR TITLE
Mod list sorting, search, readability and JSON export/import in the loader UI

### DIFF
--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 using Assets.Scripts;
 using Assets.Scripts.Serialization;
 using Assets.Scripts.Util;
@@ -402,6 +403,88 @@ public static class LaunchPadConfig
       if (!Platform.IsServer)
         ProcessUtil.OpenExplorerSelectFile(pkgpath);
       return $"exported {pkgpath}";
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      return ex.ToString();
+    }
+  }
+
+  // Whether importing a mod list is currently allowed (only before mods start loading).
+  public static bool CanImportModList => Stage is LoadStage.Searching or LoadStage.Configuring;
+
+  // Writes the current mod list (names, ids, source, enabled state and load order) to a JSON file.
+  public static string ExportModListJson(string path = null)
+  {
+    try
+    {
+      if (string.IsNullOrEmpty(path))
+        path = LaunchPadPaths.ModListJsonPath;
+      else
+      {
+        if (!Path.IsPathRooted(path))
+          path = Path.Combine(LaunchPadPaths.SavePath, path);
+        if (!path.ToLower().EndsWith(".json"))
+          path += ".json";
+      }
+
+      var json = JsonConvert.SerializeObject(modList.ToJsonModel(), Formatting.Indented);
+      File.WriteAllText(path, json);
+
+      Logger.Global.LogInfo($"Exported mod list to {path}");
+      if (!Platform.IsServer)
+        ProcessUtil.OpenExplorerSelectFile(path);
+      return $"exported {path}";
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      return ex.ToString();
+    }
+  }
+
+  // Reads a JSON mod list and applies its enabled state and load order to the installed mods.
+  public static string ImportModListJson(string path = null)
+  {
+    try
+    {
+      if (!CanImportModList)
+        return "mod list can only be imported before mods are loaded";
+
+      if (string.IsNullOrEmpty(path))
+        path = LaunchPadPaths.ModListJsonPath;
+      else if (!Path.IsPathRooted(path))
+        path = Path.Combine(LaunchPadPaths.SavePath, path);
+
+      if (!File.Exists(path))
+      {
+        Logger.Global.LogError($"mod list file not found: {path}");
+        return $"file not found: {path}";
+      }
+
+      var model = JsonConvert.DeserializeObject<ModListJson>(File.ReadAllText(path));
+      if (model == null)
+      {
+        Logger.Global.LogError($"invalid mod list file: {path}");
+        return "invalid mod list file";
+      }
+
+      var result = modList.ApplyJsonModel(model);
+
+      // Re-run the same validation/persistence the UI does after a manual change.
+      modList.CheckDependencies();
+      modList.DisableDuplicates();
+      if (AutoSort)
+        modList.SortByDeps();
+      ModConfigUtil.SaveConfig(modList.ToModConfig());
+
+      Logger.Global.LogInfo(
+        $"Imported mod list from {path}: {result.Matched} matched, {result.Disabled} disabled, {result.Missing.Count} not installed");
+      foreach (var name in result.Missing)
+        Logger.Global.LogWarning($"- not installed: {name}");
+
+      return $"imported {result.Matched} mods ({result.Missing.Count} not installed)";
     }
     catch (Exception ex)
     {

--- a/StationeersLaunchPad/LaunchPadPaths.cs
+++ b/StationeersLaunchPad/LaunchPadPaths.cs
@@ -17,6 +17,7 @@ public static class LaunchPadPaths
       ? StationSaveUtils.DefaultPath
       : Settings.CurrentData.SavePath;
   public static string ConfigPath => WorkshopMenu.ConfigPath;
+  public static string ModListJsonPath => Path.Join(SavePath, "modlist.json");
 
   public static string ModReposConfigPath => Path.Join(StationSaveUtils.DefaultPath, "modrepos.xml");
   public static string ModReposPath => Path.Join(StationSaveUtils.DefaultPath, "modrepos");

--- a/StationeersLaunchPad/Metadata/ModInfo.cs
+++ b/StationeersLaunchPad/Metadata/ModInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,10 +25,16 @@ public class ModInfo
   public ModAboutEx About => Def.About;
   public ModSourceType Source => Def.Type;
   public string Name => About.Name;
+  public string Author => About?.Author ?? "";
   public string DirectoryPath => Def.DirectoryPath;
   public string DirectoryName => new DirectoryInfo(DirectoryPath).Name;
   public ulong WorkshopHandle => Def.WorkshopHandle;
   public string ModID => About.ModID ?? "";
+
+  // Release/update timestamps used for sorting. For Workshop mods these come from
+  // Steam metadata; for Local/Repo mods they fall back to the mod folder timestamps.
+  public DateTime? Released => Def.Created;
+  public DateTime? Updated => Def.Updated;
 
   public string AboutPath => Path.Combine(DirectoryPath, "About");
   public string AboutXmlPath => Path.Combine(AboutPath, "About.xml");

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -376,6 +376,96 @@ public class ModList
     return changed;
   }
 
+  public ModListJson ToJsonModel()
+  {
+    var model = new ModListJson
+    {
+      Version = LaunchPadInfo.VERSION,
+      ExportedAt = DateTime.Now,
+    };
+    var order = 0;
+    foreach (var mod in mods)
+    {
+      model.Mods.Add(new ModListJsonEntry
+      {
+        Name = mod.Name,
+        ModID = mod.ModID,
+        WorkshopHandle = mod.WorkshopHandle,
+        Source = mod.Source.ToString(),
+        Enabled = mod.Enabled,
+        Order = order++,
+      });
+    }
+    return model;
+  }
+
+  // Applies an imported mod list: reorders installed mods to match the file, applies their
+  // enabled state, disables mods not present in the file (except Core), and reports any
+  // entries that are not installed locally.
+  public ModListImportResult ApplyJsonModel(ModListJson model)
+  {
+    var result = new ModListImportResult();
+    if (model?.Mods == null)
+      return result;
+
+    var byHandle = new Dictionary<ulong, ModInfo>();
+    var byModID = new Dictionary<string, ModInfo>(StringComparer.OrdinalIgnoreCase);
+    foreach (var mod in mods)
+    {
+      if (mod.WorkshopHandle > 1)
+        byHandle[mod.WorkshopHandle] = mod;
+      if (!string.IsNullOrEmpty(mod.ModID))
+        byModID[mod.ModID] = mod;
+    }
+
+    var used = new HashSet<ModInfo>();
+    var newOrder = new List<ModInfo>();
+
+    foreach (var entry in model.Mods)
+    {
+      ModInfo match = null;
+      if (entry.WorkshopHandle > 1)
+        byHandle.TryGetValue(entry.WorkshopHandle, out match);
+      if (match == null && !string.IsNullOrEmpty(entry.ModID))
+        byModID.TryGetValue(entry.ModID, out match);
+      if (match == null && !string.IsNullOrEmpty(entry.Name))
+        match = mods.FirstOrDefault(m =>
+          !used.Contains(m) &&
+          string.Equals(m.Name, entry.Name, StringComparison.OrdinalIgnoreCase));
+
+      if (match == null)
+      {
+        result.Missing.Add(string.IsNullOrEmpty(entry.Name) ? entry.ModID ?? "(unknown)" : entry.Name);
+        continue;
+      }
+      if (used.Contains(match))
+        continue;
+
+      if (match.Source != ModSourceType.Core)
+        match.Enabled = entry.Enabled;
+      used.Add(match);
+      newOrder.Add(match);
+      result.Matched++;
+    }
+
+    // Append mods that weren't in the imported file, disabling them (except Core) so the
+    // resulting set matches the file as closely as the installed mods allow.
+    foreach (var mod in mods)
+    {
+      if (used.Contains(mod))
+        continue;
+      if (mod.Source != ModSourceType.Core && mod.Enabled)
+      {
+        mod.Enabled = false;
+        result.Disabled++;
+      }
+      newOrder.Add(mod);
+    }
+
+    mods = newOrder;
+    return result;
+  }
+
   private static string NormalizePath(string path) =>
     path?.Replace("\\", "/").Trim().ToLowerInvariant() ?? string.Empty;
 }

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -312,6 +312,70 @@ public class ModList
     return true;
   }
 
+  // Fields by which the mod list can be sorted in the loader UI.
+  public enum ModSortField { LoadOrder, Name, Author, Released, Updated }
+
+  public static IComparer<ModInfo> GetComparer(ModSortField field, bool descending)
+  {
+    Comparison<ModInfo> cmp = field switch
+    {
+      ModSortField.Name => (a, b) =>
+        string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase),
+      ModSortField.Author => (a, b) =>
+      {
+        var r = string.Compare(a.Author, b.Author, StringComparison.OrdinalIgnoreCase);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      ModSortField.Released => (a, b) =>
+      {
+        var r = Nullable.Compare(a.Released, b.Released);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      ModSortField.Updated => (a, b) =>
+      {
+        var r = Nullable.Compare(a.Updated, b.Updated);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      _ => (a, b) => 0,
+    };
+    return Comparer<ModInfo>.Create(descending ? (a, b) => cmp(b, a) : cmp);
+  }
+
+  // Returns the mods sorted for display, without touching the underlying load order.
+  public List<ModInfo> Sorted(ModSortField field, bool descending)
+  {
+    var list = new List<ModInfo>(mods);
+    if (field != ModSortField.LoadOrder)
+      list.Sort(GetComparer(field, descending));
+    return list;
+  }
+
+  // Rewrites the actual load order to match the given sort. Returns true if anything moved.
+  public bool ApplySort(ModSortField field, bool descending)
+  {
+    if (field == ModSortField.LoadOrder)
+      return false;
+    return SetOrder(Sorted(field, descending));
+  }
+
+  // Replaces the load order with the given permutation of the current mods.
+  // Returns true only when the order actually changed.
+  public bool SetOrder(List<ModInfo> ordered)
+  {
+    if (ordered == null || ordered.Count != mods.Count)
+      return false;
+    var changed = false;
+    for (var i = 0; i < mods.Count; i++)
+      if (!ReferenceEquals(mods[i], ordered[i]))
+      {
+        changed = true;
+        break;
+      }
+    if (changed)
+      mods = ordered;
+    return changed;
+  }
+
   private static string NormalizePath(string path) =>
     path?.Replace("\\", "/").Trim().ToLowerInvariant() ?? string.Empty;
 }

--- a/StationeersLaunchPad/Metadata/ModListJson.cs
+++ b/StationeersLaunchPad/Metadata/ModListJson.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace StationeersLaunchPad.Metadata;
+
+// Serializable description of a single mod entry in an exported mod list.
+public class ModListJsonEntry
+{
+  public string Name;
+  public string ModID;
+  public ulong WorkshopHandle;
+  public string Source;
+  public bool Enabled;
+  public int Order;
+}
+
+// Serializable snapshot of the current mod list, written/read as JSON via the loader UI.
+public class ModListJson
+{
+  public string ExportedBy = LaunchPadInfo.NAME;
+  public string Version;
+  public DateTime ExportedAt;
+  public List<ModListJsonEntry> Mods = [];
+}
+
+// Summary of what happened while importing a mod list.
+public class ModListImportResult
+{
+  public int Matched;
+  public int Disabled;
+  public readonly List<string> Missing = [];
+}

--- a/StationeersLaunchPad/Sources/ModSource.cs
+++ b/StationeersLaunchPad/Sources/ModSource.cs
@@ -1,5 +1,7 @@
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Cysharp.Threading.Tasks;
 using StationeersLaunchPad.Metadata;
 using StationeersLaunchPad.Repos;
@@ -51,4 +53,18 @@ public abstract class ModDefinition(ModAboutEx about)
   public abstract ulong WorkshopHandle { get; }
   public abstract string DirectoryPath { get; }
   public abstract ModData ToModData(bool enabled);
+
+  // Release/update timestamps used by the mod loader UI for sorting.
+  // Workshop mods override these with Steam metadata; otherwise we fall back to
+  // the mod folder's filesystem creation/last-write time. Returns null when unknown.
+  public virtual DateTime? Created => GetDirTime(lastWrite: false);
+  public virtual DateTime? Updated => GetDirTime(lastWrite: true);
+
+  protected DateTime? GetDirTime(bool lastWrite)
+  {
+    var path = DirectoryPath;
+    if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+      return null;
+    return lastWrite ? Directory.GetLastWriteTime(path) : Directory.GetCreationTime(path);
+  }
 }

--- a/StationeersLaunchPad/Sources/Workshop.cs
+++ b/StationeersLaunchPad/Sources/Workshop.cs
@@ -45,6 +45,8 @@ public class WorkshopModDefinition(Item item, ModAboutEx about) : ModDefinition(
   public override ModSourceType Type => ModSourceType.Workshop;
   public override ulong WorkshopHandle => Item.Id;
   public override string DirectoryPath => Item.Directory;
+  public override System.DateTime? Created => Item.Created;
+  public override System.DateTime? Updated => Item.Updated;
   public override ModData ToModData(bool enabled) => new WorkshopModData(
     SteamTransport.ItemWrapper.WrapWorkshopItem(Item, "About/About.xml"),
     enabled

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using ImGuiNET;
 using StationeersLaunchPad.Loading;
 using StationeersLaunchPad.Metadata;
@@ -24,6 +26,19 @@ public static class ManualLoadWindow
   private static bool openInfo = false;
   private static ModInfo draggingMod = null;
   private static bool dragged = false;
+
+  // Mod list sorting/filtering state (see DrawModListTools / DrawSearchAndCount)
+  private static ModList.ModSortField sortField = ModList.ModSortField.LoadOrder;
+  private static bool sortDescending = false;
+  private static bool sortApplyToLoadOrder = false;
+  private static string searchText = "";
+
+  private static readonly string[] SortFieldLabels =
+    { "Load order", "Name", "Author", "Released", "Updated" };
+
+  // Subtle background tint for alternating list rows (zebra striping).
+  private static uint RowAltColor =>
+    ImGui.ColorConvertFloat4ToU32(new Color(1f, 1f, 1f, 0.045f));
 
   public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort)
   {
@@ -70,7 +85,13 @@ public static class ManualLoadWindow
       }
       else if (stage is LoadStage.Loading or LoadStage.Loaded)
       {
+        DrawModListToolbar(modList, loaded: true);
+        ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetStyle().ItemSpacing.y);
+        ImGui.Separator();
+        leftRect = leftRect.From(ImGui.GetCursorScreenPos());
+        ImGui.BeginChild("##loadtable", leftRect.Size);
         DrawLoadTable(modList);
+        ImGui.EndChild();
       }
       ImGui.EndChild();
 
@@ -237,10 +258,153 @@ public static class ManualLoadWindow
       }
     }
 
+    changed |= DrawModListToolbar(modList, loaded: false);
+
     ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetStyle().ItemSpacing.y);
     ImGui.Separator();
 
     return changed;
+  }
+
+  // Full toolbar above the mod list: sort controls, search box, counters and column headers.
+  private static ChangeFlags DrawModListToolbar(ModList modList, bool loaded)
+  {
+    var changed = DrawModListTools(modList, loaded);
+    DrawSearchAndCount(modList, loaded);
+    DrawColumnHeader(loaded);
+    return changed;
+  }
+
+  // Sort selector: field combo, direction toggle and an optional "apply to load order" switch.
+  // When loaded is true the mods are already loaded, so the load-order switch is hidden and
+  // sorting only changes how the list is displayed.
+  private static ChangeFlags DrawModListTools(ModList modList, bool loaded)
+  {
+    var changed = ChangeFlags.None;
+
+    ImGui.AlignTextToFramePadding();
+    ImGuiHelper.Text("Sort:");
+
+    ImGui.SameLine();
+    ImGui.SetNextItemWidth(140f);
+    var cur = (int)sortField;
+    if (ImGui.Combo("##sortfield", ref cur, SortFieldLabels, SortFieldLabels.Length))
+    {
+      sortField = (ModList.ModSortField)cur;
+      if (!loaded && sortApplyToLoadOrder && modList.ApplySort(sortField, sortDescending))
+        changed |= ChangeFlags.Mods;
+    }
+    ImGuiHelper.ItemTooltip(
+      "Order the mod list by load order, name, author, release date or last update.\n" +
+      "Release/update dates come from Steam for Workshop mods; for local mods the mod " +
+      "folder timestamps are used as a fallback.");
+
+    ImGui.SameLine();
+    if (ImGui.Button(sortDescending ? "Desc" : "Asc"))
+    {
+      sortDescending = !sortDescending;
+      if (!loaded && sortApplyToLoadOrder && modList.ApplySort(sortField, sortDescending))
+        changed |= ChangeFlags.Mods;
+    }
+    ImGuiHelper.ItemTooltip("Toggle ascending/descending order.");
+
+    if (!loaded)
+    {
+      ImGui.SameLine();
+      if (ImGui.Checkbox("Apply to load order", ref sortApplyToLoadOrder)
+          && sortApplyToLoadOrder
+          && modList.ApplySort(sortField, sortDescending))
+        changed |= ChangeFlags.Mods;
+      ImGuiHelper.ItemTooltip(
+        "On: sorting also rewrites the real mod load order (drag & drop is disabled while a sort is active).\n" +
+        "Off: sorting only changes how the list is displayed; the load order is left untouched.");
+    }
+
+    return changed;
+  }
+
+  private static string SortValueText(ModInfo mod) => sortField switch
+  {
+    ModList.ModSortField.Author => string.IsNullOrEmpty(mod.Author) ? "-" : mod.Author,
+    ModList.ModSortField.Released => mod.Released?.ToString("yyyy-MM-dd") ?? "-",
+    ModList.ModSortField.Updated => mod.Updated?.ToString("yyyy-MM-dd") ?? "-",
+    _ => null,
+  };
+
+  // True when the mod matches the current search text (by name or author).
+  private static bool MatchesSearch(ModInfo mod)
+  {
+    if (string.IsNullOrWhiteSpace(searchText))
+      return true;
+    var q = searchText.Trim();
+    return (mod.Name?.IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0)
+        || (mod.Author?.IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0);
+  }
+
+  // Search box + counters row.
+  private static void DrawSearchAndCount(ModList modList, bool loaded)
+  {
+    ImGui.AlignTextToFramePadding();
+    ImGuiHelper.Text("Search:");
+
+    ImGui.SameLine();
+    ImGui.SetNextItemWidth(200f);
+    ImGui.InputTextWithHint("##modsearch", "name or author...", ref searchText, 256);
+
+    if (!string.IsNullOrEmpty(searchText))
+    {
+      ImGui.SameLine();
+      if (ImGui.Button("Clear##search"))
+        searchText = "";
+    }
+
+    int total = 0, enabled = 0, shown = 0;
+    if (loaded)
+    {
+      total = enabled = ModLoader.LoadedMods.Count;
+      shown = ModLoader.LoadedMods.Count(m => MatchesSearch(m.Info));
+    }
+    else
+    {
+      foreach (var mod in modList.AllMods)
+      {
+        if (mod.Source == ModSourceType.Core)
+          continue;
+        total++;
+        if (mod.Enabled)
+          enabled++;
+        if (MatchesSearch(mod))
+          shown++;
+      }
+    }
+
+    ImGui.SameLine();
+    ImGuiHelper.TextDisabled("|", true);
+    ImGui.SameLine();
+    var countText = loaded ? $"Loaded: {total}" : $"Enabled: {enabled} / {total}";
+    if (!string.IsNullOrWhiteSpace(searchText))
+      countText += $"   (showing {shown})";
+    ImGuiHelper.TextDisabled(countText);
+  }
+
+  // Fixed (non-scrolling) column headers aligned with the table columns below.
+  private static void DrawColumnHeader(bool loaded)
+  {
+    var spacing = ImGui.GetStyle().ItemSpacing.x * 2;
+    var c0 = loaded
+      ? ImGui.CalcTextSize("XXX").x + spacing
+      : ImGui.GetTextLineHeightWithSpacing() + spacing;
+    var c1 = ImGui.CalcTextSize($"{ModSourceType.Workshop}").x + spacing;
+
+    var available = ImGuiHelper.AvailableRect();
+    var row = available.TableRow(ImGui.GetTextLineHeightWithSpacing(), stackalloc[] { c0, c1 });
+
+    ImGuiHelper.TextCentered(row.Column(1), "Source");
+
+    var nameHeader = "Name";
+    if (sortField != ModList.ModSortField.LoadOrder)
+      nameHeader = $"Name   (by {SortFieldLabels[(int)sortField]} {(sortDescending ? "v" : "^")})";
+    ImGuiHelper.Text(row.Column(2), nameHeader);
   }
 
   private static bool DrawModSelectTable(ModList modList, bool edit = false, bool autoSort = false)
@@ -259,10 +423,19 @@ public static class ManualLoadWindow
       dragged = false;
     }
 
+    // Display order may differ from the real load order when a sort/search is active.
+    // Drag & drop reordering is only allowed when showing the full, unsorted load order.
+    var displayMods = modList.Sorted(sortField, sortDescending);
+    if (!string.IsNullOrWhiteSpace(searchText))
+      displayMods = displayMods.Where(MatchesSearch).ToList();
+    var canReorder = edit
+      && sortField == ModList.ModSortField.LoadOrder
+      && string.IsNullOrWhiteSpace(searchText);
+
     var hoveringIndex = -1;
     var draggingIndex = -1;
     if (draggingMod != null)
-      draggingIndex = modList.IndexOf(draggingMod);
+      draggingIndex = displayMods.IndexOf(draggingMod);
 
     var rowHeight = ImGui.GetTextLineHeightWithSpacing();
     var spacing = ImGui.GetStyle().ItemSpacing.x * 2;
@@ -280,9 +453,12 @@ public static class ManualLoadWindow
     ImGui.BeginDisabled(!edit);
 
     var idx = 0;
-    foreach (var mod in modList.AllMods)
+    foreach (var mod in displayMods)
     {
       ImGui.PushID(idx);
+
+      if ((idx & 1) == 1)
+        ImGui.GetWindowDrawList().AddRectFilled(row.Rect.TL, row.Rect.BR, RowAltColor);
 
       ImGui.SetCursorScreenPos(row.Column(0).TL);
       ImGui.BeginDisabled(mod.Source is ModSourceType.Core);
@@ -308,11 +484,19 @@ public static class ManualLoadWindow
 
       ImGuiHelper.Text(row.Column(2), $"{mod.Name}");
 
-      if (draggingMod != null)
+      if (draggingMod != null && canReorder)
+      {
         if (mod.SortBefore(draggingMod))
           ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled("Before"));
         else if (draggingMod.SortBefore(mod))
           ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled("After"));
+      }
+      else
+      {
+        var sortValue = SortValueText(mod);
+        if (sortValue != null)
+          ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled(sortValue));
+      }
 
       ImGui.PopID();
 
@@ -322,7 +506,7 @@ public static class ManualLoadWindow
 
     ImGui.EndDisabled();
 
-    if (edit && draggingIndex != -1 && hoveringIndex != -1 && draggingIndex != hoveringIndex)
+    if (canReorder && draggingIndex != -1 && hoveringIndex != -1 && draggingIndex != hoveringIndex)
     {
       dragged = true;
       if (modList.MoveModTo(draggingMod, hoveringIndex, autoSort))
@@ -345,12 +529,28 @@ public static class ManualLoadWindow
       ImGui.CalcTextSize($"{ModSourceType.Workshop}").x + spacing
     });
 
+    // Apply the same view sorting/search as the pre-load list. The actual load order is
+    // fixed at this point, so this only changes how the loaded mods are displayed.
+    IEnumerable<LoadedMod> loadedMods = ModLoader.LoadedMods;
+    if (sortField != ModList.ModSortField.LoadOrder)
+    {
+      var cmp = ModList.GetComparer(sortField, sortDescending);
+      var sorted = new List<LoadedMod>(ModLoader.LoadedMods);
+      sorted.Sort((a, b) => cmp.Compare(a.Info, b.Info));
+      loadedMods = sorted;
+    }
+    if (!string.IsNullOrWhiteSpace(searchText))
+      loadedMods = loadedMods.Where(m => MatchesSearch(m.Info));
+
     var idx = 0;
-    foreach (var mod in ModLoader.LoadedMods)
+    foreach (var mod in loadedMods)
     {
       ImGui.PushID(idx);
       var info = mod.Info;
       var isSelected = selectedMod == mod;
+
+      if ((idx & 1) == 1)
+        ImGui.GetWindowDrawList().AddRectFilled(row.Rect.TL, row.Rect.BR, RowAltColor);
 
       ImGui.SetCursorScreenPos(row.Rect.TL);
       if (ImGui.Selectable("##scopeselect", isSelected, row.Rect.Size))
@@ -364,6 +564,10 @@ public static class ManualLoadWindow
       ImGuiHelper.TextCentered(row.Column(1), $"{info.Source}");
 
       ImGuiHelper.Text(row.Column(2), info.Name);
+
+      var sortValue = SortValueText(info);
+      if (sortValue != null)
+        ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled(sortValue));
 
       ImGui.PopID();
       idx++;

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -320,6 +320,26 @@ public static class ManualLoadWindow
         "Off: sorting only changes how the list is displayed; the load order is left untouched.");
     }
 
+    ImGui.SameLine();
+    ImGuiHelper.TextDisabled("|", true);
+
+    ImGui.SameLine();
+    if (ImGui.Button("Export List"))
+      LaunchPadConfig.ExportModListJson();
+    ImGuiHelper.ItemTooltip($"Save the current mod list (state + order) as JSON to:\n{LaunchPadPaths.ModListJsonPath}");
+
+    ImGui.SameLine();
+    ImGui.BeginDisabled(!LaunchPadConfig.CanImportModList);
+    if (ImGui.Button("Import List"))
+    {
+      LaunchPadConfig.ImportModListJson();
+      changed |= ChangeFlags.Mods;
+    }
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      $"Load a mod list from JSON and apply its enabled state and order:\n{LaunchPadPaths.ModListJsonPath}",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
+
     return changed;
   }
 


### PR DESCRIPTION
## Summary

Quality-of-life improvements to the manual mod loader window for managing larger mod lists, plus a portable JSON export/import for the mod list. UI plus the metadata/persistence needed to drive it; no changes to the existing load behaviour.

## Changes

**Sorting, search & readability**
- **Sorting** - by **Load order / Name / Author / Released / Updated**, ascending or descending. Display-only by default; an optional **Apply to load order** switch rewrites the actual load order. Drag & drop reordering stays available when no sort/search is active (disabled while one is, since the displayed order no longer maps 1:1 to the load order).
- **Search** - filter the list by name or author, with a Clear button.
- **Readability** - zebra striping, fixed (non-scrolling) column headers, and an `Enabled: N / M` counter (with a `(showing K)` result count while filtering).
- **Metadata** - `ModInfo.Author/Released/Updated`. Dates come from Steam (`Item.Created`/`Item.Updated`) for Workshop mods; local/repo mods fall back to mod-folder timestamps.

**JSON export/import**
- **Export List** - writes the current mod list (name, ModID, workshop handle, source, enabled state, load order) to `{SavePath}/modlist.json`.
- **Import List** - reads it back, re-applies enabled state + order to the installed mods, disables mods not in the file (except Core), and logs any entries that aren't installed. Available only before mods are loaded. Reuses the existing `Newtonsoft.Json` dependency (already used by `Github.cs`).

All of the UI applies to both the pre-load and post-load screens (sorting/search are display-only on the latter).

## Files changed

- `Metadata/ModInfo.cs` - `Author`/`Released`/`Updated`
- `Sources/ModSource.cs`, `Sources/Workshop.cs` - date sourcing (virtual base + Workshop override)
- `Metadata/ModList.cs` - sort comparer + `Sorted`/`ApplySort`/`SetOrder`; `ToJsonModel`/`ApplyJsonModel`
- `Metadata/ModListJson.cs` *(new)* - JSON DTOs + import result
- `LaunchPadPaths.cs`, `LaunchPadConfig.cs` - `modlist.json` path + `Export/ImportModListJson`
- `UI/ManualLoadWindow.cs` - toolbar (sort + search + counter + headers + export/import), zebra striping, filtered/sorted rendering

## Notes for reviewers

- Local/repo "Released/Updated" are folder-timestamp approximations (documented in the Sort tooltip).
- The sorted/filtered view is recomputed each frame (bounded, small N) - happy to cache behind a dirty flag if preferred.
- **Overlap with #139 (mod profiles):** the export/import shares intent with the profile system (capture/apply a mod set). It's deliberately a single portable file for *sharing* setups rather than managing named profiles. Happy to fold it into the profile system instead (e.g. "export/import a profile as JSON") if that's the preferred direction - or to split it back out into its own PR if you'd rather review the UI changes alone. Let me know.

## Testing

Builds against game refs (netstandard2.1, `TreatWarningsAsErrors` clean). Exercised in-game on a ~60-mod setup: all sort fields/directions, apply-to-load-order, search/filter + clear, counters, zebra/headers, drag & drop when unsorted, and round-trip export/import (54 mods matched, 0 not installed).
