### PR TITLE
UI & features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -430,3 +430,6 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+# Local UI design reference (not part of the mod)
+Redesign LaunchPad UI/
+ui_layout.xml

--- a/SLP.common.props
+++ b/SLP.common.props
@@ -49,6 +49,7 @@
     <GameReference Include="Assembly-CSharp" />
 
     <GameReference Include="Facepunch.Steamworks.Win64" />
+    <GameReference Include="Mono.Cecil" />
     <GameReference Include="Newtonsoft.Json" />
     <GameReference Include="UniTask" />
     <GameReference Include="UnityEngine" />

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 using Assets.Scripts;
 using Assets.Scripts.Serialization;
 using Assets.Scripts.Util;
@@ -97,6 +98,7 @@ public static class LaunchPadConfig
     }
 
     AlertPopup.Draw();
+    FilePicker.Draw();
   }
 
   public static async void Run()
@@ -257,6 +259,20 @@ public static class LaunchPadConfig
       if (depNotice && Platform.PauseOnDepNotice)
         StopAutoLoad();
 
+      // Statically scan mod assemblies for game-API mismatches (off the main thread).
+      var modSnapshot = modList.AllMods.ToList();
+      await UniTask.SwitchToThreadPool();
+      ModCompatScanner.ScanAll(modSnapshot);
+      await UniTask.SwitchToMainThread();
+
+      PreLoadCheck.Run(modList);
+
+      if (Platform.PauseOnDepNotice && PreLoadCheck.Current.Issues.Any(i => i.Category == "Incompatible"))
+      {
+        Logger.Global.LogWarning("Incompatible mods detected - pausing auto-load");
+        StopAutoLoad();
+      }
+
       Logger.Global.LogInfo("Mod Config Initialized");
     }
     catch (Exception ex)
@@ -309,6 +325,9 @@ public static class LaunchPadConfig
     if (Stage != LoadStage.Failed)
       Stage = LoadStage.Loaded;
 
+    // Remember which mods failed to load so the next launch can warn about them.
+    PreLoadCheck.SaveLoadResults();
+
     await SLPCommand.MoveToStage(CommandStage.ModsLoaded);
 
     CurWait = new(Configs.AutoLoadWaitTime.Value, AutoLoad);
@@ -334,6 +353,7 @@ public static class LaunchPadConfig
       if (AutoSort)
         modList.SortByDeps();
       ModConfigUtil.SaveConfig(modList.ToModConfig());
+      PreLoadCheck.Run(modList);
     }
     var next = changed.HasFlag(ManualLoadWindow.ChangeFlags.NextStep);
     if (next)
@@ -402,6 +422,89 @@ public static class LaunchPadConfig
       if (!Platform.IsServer)
         ProcessUtil.OpenExplorerSelectFile(pkgpath);
       return $"exported {pkgpath}";
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      return ex.ToString();
+    }
+  }
+
+  // Whether importing a mod list is currently allowed (only before mods start loading).
+  public static bool CanImportModList => Stage is LoadStage.Searching or LoadStage.Configuring;
+
+  // Writes the current mod list (names, ids, source, enabled state and load order) to a JSON file.
+  public static string ExportModListJson(string path = null)
+  {
+    try
+    {
+      if (string.IsNullOrEmpty(path))
+        path = LaunchPadPaths.ModListJsonPath;
+      else
+      {
+        if (!Path.IsPathRooted(path))
+          path = Path.Combine(LaunchPadPaths.SavePath, path);
+        if (!path.ToLower().EndsWith(".json"))
+          path += ".json";
+      }
+
+      var json = JsonConvert.SerializeObject(modList.ToJsonModel(), Formatting.Indented);
+      File.WriteAllText(path, json);
+
+      Logger.Global.LogInfo($"Exported mod list to {path}");
+      if (!Platform.IsServer)
+        ProcessUtil.OpenExplorerSelectFile(path);
+      return $"exported {path}";
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      return ex.ToString();
+    }
+  }
+
+  // Reads a JSON mod list and applies its enabled state and load order to the installed mods.
+  public static string ImportModListJson(string path = null)
+  {
+    try
+    {
+      if (!CanImportModList)
+        return "mod list can only be imported before mods are loaded";
+
+      if (string.IsNullOrEmpty(path))
+        path = LaunchPadPaths.ModListJsonPath;
+      else if (!Path.IsPathRooted(path))
+        path = Path.Combine(LaunchPadPaths.SavePath, path);
+
+      if (!File.Exists(path))
+      {
+        Logger.Global.LogError($"mod list file not found: {path}");
+        return $"file not found: {path}";
+      }
+
+      var model = JsonConvert.DeserializeObject<ModListJson>(File.ReadAllText(path));
+      if (model == null)
+      {
+        Logger.Global.LogError($"invalid mod list file: {path}");
+        return "invalid mod list file";
+      }
+
+      var result = modList.ApplyJsonModel(model);
+
+      // Re-run the same validation/persistence the UI does after a manual change.
+      modList.CheckDependencies();
+      modList.DisableDuplicates();
+      if (AutoSort)
+        modList.SortByDeps();
+      ModConfigUtil.SaveConfig(modList.ToModConfig());
+      PreLoadCheck.Run(modList);
+
+      Logger.Global.LogInfo(
+        $"Imported mod list from {path}: {result.Matched} matched, {result.Disabled} disabled, {result.Missing.Count} not installed");
+      foreach (var name in result.Missing)
+        Logger.Global.LogWarning($"- not installed: {name}");
+
+      return $"imported {result.Matched} mods ({result.Missing.Count} not installed)";
     }
     catch (Exception ex)
     {

--- a/StationeersLaunchPad/LaunchPadPaths.cs
+++ b/StationeersLaunchPad/LaunchPadPaths.cs
@@ -17,6 +17,7 @@ public static class LaunchPadPaths
       ? StationSaveUtils.DefaultPath
       : Settings.CurrentData.SavePath;
   public static string ConfigPath => WorkshopMenu.ConfigPath;
+  public static string ModListJsonPath => Path.Join(SavePath, "modlist.json");
 
   public static string ModReposConfigPath => Path.Join(StationSaveUtils.DefaultPath, "modrepos.xml");
   public static string ModReposPath => Path.Join(StationSaveUtils.DefaultPath, "modrepos");

--- a/StationeersLaunchPad/Metadata/ModCompatScanner.cs
+++ b/StationeersLaunchPad/Metadata/ModCompatScanner.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using StationeersLaunchPad.Sources;
+
+namespace StationeersLaunchPad.Metadata;
+
+// Statically scans mod assemblies (via Mono.Cecil, without executing them) for references to
+// game members (Assembly-CSharp) that no longer exist. Those are what throw
+// MissingMethodException / MissingFieldException at runtime, i.e. mods built against an older
+// game version. Conservative on purpose: only flags removed types, or methods/fields whose
+// name (and, for methods, parameter count) no longer exist, to limit false positives.
+public static class ModCompatScanner
+{
+  private static readonly string[] GameAssemblyNames =
+    { "Assembly-CSharp", "Assembly-CSharp-firstpass" };
+
+  // Assemblies we never scan (frameworks / the game / the loader itself).
+  private static readonly string[] SkipPrefixes =
+  {
+    "System", "Unity", "Mono.", "Mono.Cecil", "MonoMod", "0Harmony", "BepInEx",
+    "Newtonsoft", "Cysharp", "UniTask", "netstandard", "mscorlib", "Assembly-CSharp",
+    "StationeersLaunchPad", "LaunchPadBooster", "StationeersMods", "RG.ImGui", "ImGuiNET",
+  };
+
+  private static readonly object gate = new();
+  private static Dictionary<string, List<string>> results = new(StringComparer.OrdinalIgnoreCase);
+  private static readonly Dictionary<string, (long mtime, List<string> missing)> asmCache
+    = new(StringComparer.OrdinalIgnoreCase);
+  private static Assembly[] gameAsmCache;
+
+  public static bool HasScanned { get; private set; }
+
+  public static IReadOnlyList<string> GetMissing(ModInfo mod)
+  {
+    lock (gate)
+      return results.TryGetValue(mod.DirectoryPath ?? "", out var m) ? m : Array.Empty<string>();
+  }
+
+  // Scans the given mods. Intended to run off the main thread (it does file IO + reflection).
+  public static void ScanAll(IReadOnlyList<ModInfo> mods)
+  {
+    Assembly[] game;
+    try
+    {
+      game = GameAssemblies();
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogWarning($"compatibility scan unavailable: {ex.Message}");
+      return;
+    }
+
+    var newResults = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+    foreach (var mod in mods)
+    {
+      if (mod.Source == ModSourceType.Core || string.IsNullOrEmpty(mod.DirectoryPath))
+        continue;
+
+      var missing = new List<string>();
+      foreach (var asmPath in mod.Assemblies)
+      {
+        try { missing.AddRange(ScanAssembly(asmPath, game)); }
+        catch (Exception ex) { Logger.Global.LogDebug($"compat scan skipped {asmPath}: {ex.Message}"); }
+      }
+
+      if (missing.Count > 0)
+        newResults[mod.DirectoryPath] = missing.Distinct().ToList();
+    }
+
+    lock (gate)
+    {
+      results = newResults;
+      HasScanned = true;
+    }
+  }
+
+  private static List<string> ScanAssembly(string path, Assembly[] game)
+  {
+    var name = Path.GetFileNameWithoutExtension(path);
+    if (SkipPrefixes.Any(p => name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+      return [];
+
+    var mtime = File.GetLastWriteTimeUtc(path).Ticks;
+    lock (gate)
+      if (asmCache.TryGetValue(path, out var cached) && cached.mtime == mtime)
+        return cached.missing;
+
+    var missing = new List<string>();
+    var seen = new HashSet<string>();
+
+    using (var asm = AssemblyDefinition.ReadAssembly(path, new ReaderParameters
+    {
+      ReadingMode = ReadingMode.Deferred,
+      ReadSymbols = false,
+    }))
+    {
+      var module = asm.MainModule;
+      // Only mods that actually reference the game assembly can have game-API mismatches.
+      if (module.AssemblyReferences.Any(r => GameAssemblyNames.Contains(r.Name)))
+      {
+        foreach (var type in module.GetTypes())
+          foreach (var method in type.Methods)
+          {
+            if (!method.HasBody)
+              continue;
+            foreach (var instr in method.Body.Instructions)
+              CheckOperand(instr.Operand, game, missing, seen);
+          }
+      }
+    }
+
+    lock (gate)
+      asmCache[path] = (mtime, missing);
+    return missing;
+  }
+
+  private static void CheckOperand(object operand, Assembly[] game, List<string> missing, HashSet<string> seen)
+  {
+    switch (operand)
+    {
+      case MethodReference mr:
+      {
+        if (mr.Name is ".ctor" or ".cctor")
+          return;
+        if (mr is GenericInstanceMethod || mr.HasGenericParameters)
+          return;
+        if (!IsGameType(mr.DeclaringType))
+          return;
+
+        var typeName = CleanTypeName(mr.DeclaringType);
+        var gameType = ResolveType(game, typeName);
+        if (gameType == null)
+        {
+          Report(missing, seen, $"{typeName} (type removed)");
+          return;
+        }
+        if (!MethodExists(gameType, mr.Name, mr.Parameters.Count))
+          Report(missing, seen, $"{typeName}.{mr.Name}()");
+        return;
+      }
+      case FieldReference fr:
+      {
+        if (!IsGameType(fr.DeclaringType))
+          return;
+
+        var typeName = CleanTypeName(fr.DeclaringType);
+        var gameType = ResolveType(game, typeName);
+        if (gameType == null)
+        {
+          Report(missing, seen, $"{typeName} (type removed)");
+          return;
+        }
+        if (!FieldExists(gameType, fr.Name))
+          Report(missing, seen, $"{typeName}.{fr.Name}");
+        return;
+      }
+    }
+  }
+
+  private static void Report(List<string> missing, HashSet<string> seen, string member)
+  {
+    if (seen.Add(member))
+      missing.Add(member);
+  }
+
+  private static bool IsGameType(TypeReference type)
+  {
+    var scope = type?.Scope;
+    return scope != null && GameAssemblyNames.Contains(scope.Name);
+  }
+
+  private static string CleanTypeName(TypeReference type)
+  {
+    var name = type.FullName;
+    var generic = name.IndexOf('<');
+    if (generic >= 0)
+      name = name[..generic];
+    return name.Replace('/', '+');
+  }
+
+  private static Type ResolveType(Assembly[] game, string fullName)
+  {
+    foreach (var asm in game)
+    {
+      try
+      {
+        var t = asm.GetType(fullName, false);
+        if (t != null)
+          return t;
+      }
+      catch { }
+    }
+    return null;
+  }
+
+  private const BindingFlags AllMembers =
+    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+
+  private static bool MethodExists(Type type, string name, int paramCount)
+  {
+    try
+    {
+      return type.GetMethods(AllMembers).Any(m => m.Name == name && m.GetParameters().Length == paramCount);
+    }
+    catch { return true; } // on any uncertainty, don't flag
+  }
+
+  private static bool FieldExists(Type type, string name)
+  {
+    try
+    {
+      return type.GetFields(AllMembers).Any(f => f.Name == name);
+    }
+    catch { return true; }
+  }
+
+  private static Assembly[] GameAssemblies()
+  {
+    if (gameAsmCache != null)
+      return gameAsmCache;
+    gameAsmCache = AppDomain.CurrentDomain.GetAssemblies()
+      .Where(a => GameAssemblyNames.Contains(a.GetName().Name))
+      .ToArray();
+    if (gameAsmCache.Length == 0)
+      throw new InvalidOperationException("game assemblies not loaded");
+    return gameAsmCache;
+  }
+}

--- a/StationeersLaunchPad/Metadata/ModInfo.cs
+++ b/StationeersLaunchPad/Metadata/ModInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,10 +25,16 @@ public class ModInfo
   public ModAboutEx About => Def.About;
   public ModSourceType Source => Def.Type;
   public string Name => About.Name;
+  public string Author => About?.Author ?? "";
   public string DirectoryPath => Def.DirectoryPath;
   public string DirectoryName => new DirectoryInfo(DirectoryPath).Name;
   public ulong WorkshopHandle => Def.WorkshopHandle;
   public string ModID => About.ModID ?? "";
+
+  // Release/update timestamps used for sorting. For Workshop mods these come from
+  // Steam metadata; for Local/Repo mods they fall back to the mod folder timestamps.
+  public DateTime? Released => Def.Created;
+  public DateTime? Updated => Def.Updated;
 
   public string AboutPath => Path.Combine(DirectoryPath, "About");
   public string AboutXmlPath => Path.Combine(AboutPath, "About.xml");

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -212,6 +212,37 @@ public class ModList
     return disabledMods.Count > 0;
   }
 
+  // Enables any installed-but-disabled mods that an enabled mod depends on, following
+  // dependency chains transitively. Returns the number of mods that were enabled.
+  public int EnableDisabledDependencies()
+  {
+    var count = 0;
+    var changed = true;
+    while (changed)
+    {
+      changed = false;
+      foreach (var mod in mods)
+      {
+        if (!mod.Enabled || mod.Source == ModSourceType.Core)
+          continue;
+        foreach (var dep in mod.About?.DependsOn ?? [])
+        {
+          if (!dep.IsValid)
+            continue;
+          if (mods.Any(m => m != mod && m.Enabled && m.Satisfies(dep)))
+            continue;
+          var provider = mods.FirstOrDefault(m => m != mod && !m.Enabled && m.Satisfies(dep));
+          if (provider == null)
+            continue;
+          provider.Enabled = true;
+          count++;
+          changed = true;
+        }
+      }
+    }
+    return count;
+  }
+
   // returns true if all dependencies of enabled mods are satisfied
   public bool CheckDependencies()
   {
@@ -310,6 +341,160 @@ public class ModList
 
     mods = newOrder;
     return true;
+  }
+
+  // Fields by which the mod list can be sorted in the loader UI.
+  public enum ModSortField { LoadOrder, Name, Author, Released, Updated }
+
+  public static IComparer<ModInfo> GetComparer(ModSortField field, bool descending)
+  {
+    Comparison<ModInfo> cmp = field switch
+    {
+      ModSortField.Name => (a, b) =>
+        string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase),
+      ModSortField.Author => (a, b) =>
+      {
+        var r = string.Compare(a.Author, b.Author, StringComparison.OrdinalIgnoreCase);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      ModSortField.Released => (a, b) =>
+      {
+        var r = Nullable.Compare(a.Released, b.Released);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      ModSortField.Updated => (a, b) =>
+      {
+        var r = Nullable.Compare(a.Updated, b.Updated);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      _ => (a, b) => 0,
+    };
+    return Comparer<ModInfo>.Create(descending ? (a, b) => cmp(b, a) : cmp);
+  }
+
+  // Returns the mods sorted for display, without touching the underlying load order.
+  public List<ModInfo> Sorted(ModSortField field, bool descending)
+  {
+    var list = new List<ModInfo>(mods);
+    if (field != ModSortField.LoadOrder)
+      list.Sort(GetComparer(field, descending));
+    return list;
+  }
+
+  // Rewrites the actual load order to match the given sort. Returns true if anything moved.
+  public bool ApplySort(ModSortField field, bool descending)
+  {
+    if (field == ModSortField.LoadOrder)
+      return false;
+    return SetOrder(Sorted(field, descending));
+  }
+
+  // Replaces the load order with the given permutation of the current mods.
+  // Returns true only when the order actually changed.
+  public bool SetOrder(List<ModInfo> ordered)
+  {
+    if (ordered == null || ordered.Count != mods.Count)
+      return false;
+    var changed = false;
+    for (var i = 0; i < mods.Count; i++)
+      if (!ReferenceEquals(mods[i], ordered[i]))
+      {
+        changed = true;
+        break;
+      }
+    if (changed)
+      mods = ordered;
+    return changed;
+  }
+
+  public ModListJson ToJsonModel()
+  {
+    var model = new ModListJson
+    {
+      Version = LaunchPadInfo.VERSION,
+      ExportedAt = DateTime.Now,
+    };
+    var order = 0;
+    foreach (var mod in mods)
+    {
+      model.Mods.Add(new ModListJsonEntry
+      {
+        Name = mod.Name,
+        ModID = mod.ModID,
+        WorkshopHandle = mod.WorkshopHandle,
+        Source = mod.Source.ToString(),
+        Enabled = mod.Enabled,
+        Order = order++,
+      });
+    }
+    return model;
+  }
+
+  // Applies an imported mod list: reorders installed mods to match the file, applies their
+  // enabled state, disables mods not present in the file (except Core), and reports any
+  // entries that are not installed locally.
+  public ModListImportResult ApplyJsonModel(ModListJson model)
+  {
+    var result = new ModListImportResult();
+    if (model?.Mods == null)
+      return result;
+
+    var byHandle = new Dictionary<ulong, ModInfo>();
+    var byModID = new Dictionary<string, ModInfo>(StringComparer.OrdinalIgnoreCase);
+    foreach (var mod in mods)
+    {
+      if (mod.WorkshopHandle > 1)
+        byHandle[mod.WorkshopHandle] = mod;
+      if (!string.IsNullOrEmpty(mod.ModID))
+        byModID[mod.ModID] = mod;
+    }
+
+    var used = new HashSet<ModInfo>();
+    var newOrder = new List<ModInfo>();
+
+    foreach (var entry in model.Mods)
+    {
+      ModInfo match = null;
+      if (entry.WorkshopHandle > 1)
+        byHandle.TryGetValue(entry.WorkshopHandle, out match);
+      if (match == null && !string.IsNullOrEmpty(entry.ModID))
+        byModID.TryGetValue(entry.ModID, out match);
+      if (match == null && !string.IsNullOrEmpty(entry.Name))
+        match = mods.FirstOrDefault(m =>
+          !used.Contains(m) &&
+          string.Equals(m.Name, entry.Name, StringComparison.OrdinalIgnoreCase));
+
+      if (match == null)
+      {
+        result.Missing.Add(string.IsNullOrEmpty(entry.Name) ? entry.ModID ?? "(unknown)" : entry.Name);
+        continue;
+      }
+      if (used.Contains(match))
+        continue;
+
+      if (match.Source != ModSourceType.Core)
+        match.Enabled = entry.Enabled;
+      used.Add(match);
+      newOrder.Add(match);
+      result.Matched++;
+    }
+
+    // Append mods that weren't in the imported file, disabling them (except Core) so the
+    // resulting set matches the file as closely as the installed mods allow.
+    foreach (var mod in mods)
+    {
+      if (used.Contains(mod))
+        continue;
+      if (mod.Source != ModSourceType.Core && mod.Enabled)
+      {
+        mod.Enabled = false;
+        result.Disabled++;
+      }
+      newOrder.Add(mod);
+    }
+
+    mods = newOrder;
+    return result;
   }
 
   private static string NormalizePath(string path) =>

--- a/StationeersLaunchPad/Metadata/ModListJson.cs
+++ b/StationeersLaunchPad/Metadata/ModListJson.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace StationeersLaunchPad.Metadata;
+
+// Serializable description of a single mod entry in an exported mod list.
+public class ModListJsonEntry
+{
+  public string Name;
+  public string ModID;
+  public ulong WorkshopHandle;
+  public string Source;
+  public bool Enabled;
+  public int Order;
+}
+
+// Serializable snapshot of the current mod list, written/read as JSON via the loader UI.
+public class ModListJson
+{
+  public string ExportedBy = LaunchPadInfo.NAME;
+  public string Version;
+  public DateTime ExportedAt;
+  public List<ModListJsonEntry> Mods = [];
+}
+
+// Summary of what happened while importing a mod list.
+public class ModListImportResult
+{
+  public int Matched;
+  public int Disabled;
+  public readonly List<string> Missing = [];
+}

--- a/StationeersLaunchPad/Metadata/PreLoadCheck.cs
+++ b/StationeersLaunchPad/Metadata/PreLoadCheck.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Serialization;
+using Assets.Scripts.Serialization;
+using StationeersLaunchPad.Loading;
+using StationeersLaunchPad.Sources;
+using Steamworks;
+
+namespace StationeersLaunchPad.Metadata;
+
+public enum CheckSeverity { Info, Warning, Error }
+
+public class CheckIssue
+{
+  public CheckSeverity Severity;
+  public string Category;
+  public string Message;
+  public ModInfo Mod;
+}
+
+public class CheckResult
+{
+  public readonly List<CheckIssue> Issues = [];
+  public int Errors => Issues.Count(i => i.Severity == CheckSeverity.Error);
+  public int Warnings => Issues.Count(i => i.Severity == CheckSeverity.Warning);
+  public int Infos => Issues.Count(i => i.Severity == CheckSeverity.Info);
+  public bool Ok => Errors == 0 && Warnings == 0;
+
+  public void Add(CheckSeverity severity, string category, string message, ModInfo mod = null) =>
+    Issues.Add(new CheckIssue { Severity = severity, Category = category, Message = message, Mod = mod });
+}
+
+// Runs static, pre-load health checks over the configured mod list and surfaces the result
+// via Current. Cannot detect runtime incompatibilities (Harmony/API mismatches) - those only
+// appear when a mod is loaded - but remembers mods that failed loading in a previous session.
+public static class PreLoadCheck
+{
+  // A Workshop mod not updated in this long is flagged as "possibly outdated" (heuristic only).
+  private const int StaleMonths = 12;
+
+  public static CheckResult Current { get; private set; }
+
+  public static void Run(ModList modList)
+  {
+    var result = new CheckResult();
+    var all = modList.AllMods.ToList();
+    var enabled = all.Where(m => m.Enabled).ToList();
+
+    CheckCompatibility(enabled, result);
+    CheckDependencies(enabled, all, result);
+    CheckDuplicates(enabled, result);
+    CheckOrder(all, result);
+    CheckMetadata(enabled, result);
+    CheckWorkshop(enabled, result);
+    CheckPastFailures(enabled, result);
+
+    Current = result;
+  }
+
+  private static void CheckCompatibility(List<ModInfo> enabled, CheckResult result)
+  {
+    if (!ModCompatScanner.HasScanned)
+      return;
+    foreach (var mod in enabled)
+    {
+      if (mod.Source == ModSourceType.Core)
+        continue;
+      var missing = ModCompatScanner.GetMissing(mod);
+      if (missing.Count == 0)
+        continue;
+      var sample = string.Join(", ", missing.Take(3));
+      if (missing.Count > 3)
+        sample += $", +{missing.Count - 3} more";
+      result.Add(CheckSeverity.Error, "Incompatible",
+        $"{mod.Name} is incompatible with this game version (missing: {sample})", mod);
+    }
+  }
+
+  // Persists which mods failed to load this session so the next launch can warn about them.
+  public static void SaveLoadResults()
+  {
+    try
+    {
+      var failed = ModLoader.LoadedMods.Where(m => m.LoadFailed).Select(m => m.Info);
+      FailedModsStore.Save(failed);
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+    }
+  }
+
+  private static void CheckDependencies(List<ModInfo> enabled, List<ModInfo> all, CheckResult result)
+  {
+    foreach (var mod in enabled)
+    {
+      if (mod.Source == ModSourceType.Core)
+        continue;
+      foreach (var dep in mod.About?.DependsOn ?? [])
+      {
+        if (!dep.IsValid)
+          continue;
+        if (enabled.Any(m => m != mod && m.Satisfies(dep)))
+          continue;
+        if (all.Any(m => m != mod && m.Satisfies(dep)))
+          result.Add(CheckSeverity.Warning, "Disabled dependency",
+            $"{mod.Name} needs {dep}, which is installed but disabled", mod);
+        else
+          result.Add(CheckSeverity.Error, "Missing dependency",
+            $"{mod.Name} needs {dep}, which is not installed", mod);
+      }
+    }
+  }
+
+  private static void CheckDuplicates(List<ModInfo> enabled, CheckResult result)
+  {
+    foreach (var group in enabled
+      .Where(m => m.Source != ModSourceType.Core && m.WorkshopHandle > 1)
+      .GroupBy(m => m.WorkshopHandle)
+      .Where(g => g.Count() > 1))
+    {
+      var names = string.Join(", ", group.Select(m => $"{m.Source}"));
+      result.Add(CheckSeverity.Warning, "Duplicate mod",
+        $"{group.First().Name} is enabled from multiple sources ({names})", group.First());
+    }
+
+    foreach (var group in enabled
+      .Where(m => m.Source != ModSourceType.Core && !string.IsNullOrEmpty(m.ModID))
+      .GroupBy(m => m.ModID)
+      .Where(g => g.Count() > 1 && g.Select(m => m.WorkshopHandle).Distinct().Count() > 1))
+    {
+      result.Add(CheckSeverity.Warning, "Duplicate mod",
+        $"ModID '{group.Key}' is provided by {group.Count()} enabled mods", group.First());
+    }
+  }
+
+  private static void CheckOrder(List<ModInfo> all, CheckResult result)
+  {
+    if (OrderGraph.Build(all).HasCircular)
+      result.Add(CheckSeverity.Error, "Load order",
+        "Circular load order detected between mods (OrderBefore/OrderAfter)");
+  }
+
+  private static void CheckMetadata(List<ModInfo> enabled, CheckResult result)
+  {
+    foreach (var mod in enabled)
+      if (mod.Name?.StartsWith("[Invalid About.xml]") ?? false)
+        result.Add(CheckSeverity.Warning, "Invalid metadata",
+          $"{mod.DirectoryName} has an invalid or missing About.xml", mod);
+  }
+
+  private static void CheckWorkshop(List<ModInfo> enabled, CheckResult result)
+  {
+    var staleCutoff = DateTime.Now.AddMonths(-StaleMonths);
+
+    foreach (var mod in enabled)
+    {
+      if (mod.Def is not WorkshopModDefinition wdef)
+        continue;
+      var item = wdef.Item;
+
+      if (item.Result == Result.FileNotFound)
+        result.Add(CheckSeverity.Error, "Workshop",
+          $"{mod.Name} is no longer available on the Workshop", mod);
+      else if (string.IsNullOrEmpty(item.Directory) || !Directory.Exists(item.Directory))
+        result.Add(CheckSeverity.Error, "Workshop",
+          $"{mod.Name} is not downloaded (files missing)", mod);
+      else if (item.NeedsUpdate)
+        result.Add(CheckSeverity.Warning, "Workshop",
+          $"{mod.Name} has a Workshop update available", mod);
+
+      if (mod.Updated is { } updated && updated < staleCutoff)
+        result.Add(CheckSeverity.Info, "Possibly outdated",
+          $"{mod.Name} hasn't been updated since {updated:yyyy-MM-dd} (heuristic)", mod);
+    }
+  }
+
+  private static void CheckPastFailures(List<ModInfo> enabled, CheckResult result)
+  {
+    var record = FailedModsStore.Load();
+    if (record.Mods.Count == 0)
+      return;
+    foreach (var mod in enabled)
+      if (mod.Source != ModSourceType.Core && FailedModsStore.Matches(record, mod))
+        result.Add(CheckSeverity.Warning, "Previous failure",
+          $"{mod.Name} failed to load in a previous session", mod);
+  }
+}
+
+[XmlRoot("FailedMods")]
+public class FailedModsRecord
+{
+  [XmlElement("Mod")]
+  public List<FailedModEntry> Mods = [];
+}
+
+public class FailedModEntry
+{
+  [XmlAttribute("WorkshopHandle")]
+  public ulong WorkshopHandle;
+  [XmlAttribute("ModID")]
+  public string ModID;
+  [XmlAttribute("Name")]
+  public string Name;
+}
+
+public static class FailedModsStore
+{
+  private static string Path => System.IO.Path.Join(LaunchPadPaths.SavePath, "failed_mods.xml");
+
+  public static FailedModsRecord Load()
+  {
+    try
+    {
+      if (File.Exists(Path))
+        return XmlSerialization.Deserialize<FailedModsRecord>(Path) ?? new();
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogWarning($"failed to read {Path}: {ex.Message}");
+    }
+    return new();
+  }
+
+  public static void Save(IEnumerable<ModInfo> failed)
+  {
+    var record = new FailedModsRecord();
+    foreach (var mod in failed)
+      record.Mods.Add(new FailedModEntry
+      {
+        WorkshopHandle = mod.WorkshopHandle,
+        ModID = mod.ModID,
+        Name = mod.Name,
+      });
+    if (!record.SaveXml(Path))
+      Logger.Global.LogWarning($"failed to save {Path}");
+  }
+
+  public static bool Matches(FailedModsRecord record, ModInfo mod) =>
+    record.Mods.Any(e =>
+      (e.WorkshopHandle > 1 && e.WorkshopHandle == mod.WorkshopHandle)
+      || (!string.IsNullOrEmpty(e.ModID) && e.ModID == mod.ModID)
+      || (!string.IsNullOrEmpty(e.Name) && e.Name == mod.Name));
+}

--- a/StationeersLaunchPad/Sources/ModSource.cs
+++ b/StationeersLaunchPad/Sources/ModSource.cs
@@ -1,5 +1,7 @@
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Cysharp.Threading.Tasks;
 using StationeersLaunchPad.Metadata;
 using StationeersLaunchPad.Repos;
@@ -51,4 +53,18 @@ public abstract class ModDefinition(ModAboutEx about)
   public abstract ulong WorkshopHandle { get; }
   public abstract string DirectoryPath { get; }
   public abstract ModData ToModData(bool enabled);
+
+  // Release/update timestamps used by the mod loader UI for sorting.
+  // Workshop mods override these with Steam metadata; otherwise we fall back to
+  // the mod folder's filesystem creation/last-write time. Returns null when unknown.
+  public virtual DateTime? Created => GetDirTime(lastWrite: false);
+  public virtual DateTime? Updated => GetDirTime(lastWrite: true);
+
+  protected DateTime? GetDirTime(bool lastWrite)
+  {
+    var path = DirectoryPath;
+    if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+      return null;
+    return lastWrite ? Directory.GetLastWriteTime(path) : Directory.GetCreationTime(path);
+  }
 }

--- a/StationeersLaunchPad/Sources/Workshop.cs
+++ b/StationeersLaunchPad/Sources/Workshop.cs
@@ -45,6 +45,8 @@ public class WorkshopModDefinition(Item item, ModAboutEx about) : ModDefinition(
   public override ModSourceType Type => ModSourceType.Workshop;
   public override ulong WorkshopHandle => Item.Id;
   public override string DirectoryPath => Item.Directory;
+  public override System.DateTime? Created => Item.Created;
+  public override System.DateTime? Updated => Item.Updated;
   public override ModData ToModData(bool enabled) => new WorkshopModData(
     SteamTransport.ItemWrapper.WrapWorkshopItem(Item, "About/About.xml"),
     enabled

--- a/StationeersLaunchPad/UI/FilePicker.cs
+++ b/StationeersLaunchPad/UI/FilePicker.cs
@@ -1,0 +1,243 @@
+using System;
+using System.IO;
+using System.Linq;
+using ImGuiNET;
+using UnityEngine;
+
+namespace StationeersLaunchPad.UI;
+
+// A modal folder/file browser drawn on top of the loader UI with a darkened background.
+// Save mode lets the user pick a destination folder + file name; Open mode lets the user
+// pick an existing file. The chosen full path is handed back via the onConfirm callback.
+public static class FilePicker
+{
+  private static bool active;
+  private static bool saveMode;
+
+  private static string title;
+  private static string currentDir;
+  private static string fileName;
+  private static string selectedFile;
+  private static string filter;
+  private static Action<string> onConfirm;
+
+  public static bool IsOpen => active;
+
+  public static void OpenSave(string title, string startDir, string defaultName, string filter, Action<string> onConfirm)
+    => Open(title, startDir, defaultName, filter, false, onConfirm);
+
+  public static void OpenLoad(string title, string startDir, string filter, Action<string> onConfirm)
+    => Open(title, startDir, null, filter, true, onConfirm);
+
+  private static void Open(string title, string startDir, string defaultName, string filter, bool open, Action<string> onConfirm)
+  {
+    FilePicker.title = title;
+    FilePicker.filter = filter;
+    FilePicker.onConfirm = onConfirm;
+    saveMode = !open;
+    fileName = defaultName ?? "";
+    selectedFile = null;
+    currentDir = ResolveStartDir(startDir);
+    active = true;
+  }
+
+  private static string ResolveStartDir(string dir)
+  {
+    try
+    {
+      if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
+        return Path.GetFullPath(dir);
+    }
+    catch { }
+    return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+  }
+
+  public static void Draw()
+  {
+    if (!active)
+      return;
+
+    ImGuiHelper.Draw(() =>
+    {
+      var screen = ImGuiHelper.ScreenRect();
+
+      // A single full-screen window IS the darkened backdrop. The dialog is a centered child
+      // inside it, so there is only one interactive window (like AlertPopup) - this keeps the
+      // child's widgets clickable while the backdrop absorbs clicks outside the dialog.
+      ImGui.SetNextWindowPos(screen.Min);
+      ImGui.SetNextWindowSize(screen.Size);
+      ImGui.SetNextWindowFocus();
+      ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 0f);
+      ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0f);
+      ImGui.PushStyleColor(ImGuiCol.WindowBg, (Vector4)new Color(0f, 0f, 0f, 0.6f));
+      ImGui.Begin("##pickeroverlay",
+        ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove
+        | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse
+        | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoSavedSettings);
+      ImGui.PopStyleColor();
+      ImGui.PopStyleVar(2);
+
+      var size = new Vector2(760, 540);
+      ImGui.SetCursorScreenPos(screen.Min + (screen.Size - size) / 2f);
+
+      ImGui.PushStyleColor(ImGuiCol.ChildBg, (Vector4)new Color(0.07f, 0.07f, 0.09f, 0.98f));
+      ImGui.BeginChild("##pickerpanel", size, true);
+      ImGui.PopStyleColor();
+
+      ImGuiHelper.Text(title);
+      ImGui.Separator();
+      DrawContent();
+
+      ImGui.EndChild();
+      ImGui.End();
+    });
+  }
+
+  private static void DrawContent()
+  {
+    ImGui.AlignTextToFramePadding();
+    ImGuiHelper.Text("Location:");
+    ImGui.SameLine();
+    ImGuiHelper.TextDisabled(currentDir);
+
+    // Drive shortcuts.
+    foreach (var drive in SafeDrives())
+    {
+      ImGui.SameLine();
+      if (ImGui.Button(drive))
+        Navigate(drive);
+    }
+
+    ImGui.Separator();
+
+    var spacing = ImGui.GetStyle().ItemSpacing.y;
+    var bottomHeight = ImGui.GetFrameHeightWithSpacing()
+      + (saveMode ? ImGui.GetFrameHeightWithSpacing() : 0f)
+      + spacing + 1f;
+    var listSize = new Vector2(0f, ImGui.GetContentRegionAvail().y - bottomHeight);
+
+    string navTo = null;
+    ImGui.BeginChild("##picklist", listSize, true);
+
+    var parent = SafeParent(currentDir);
+    if (parent != null && ImGui.Selectable("[..]"))
+      navTo = parent;
+
+    foreach (var dir in SafeDirectories(currentDir))
+      if (ImGui.Selectable($"[D] {Path.GetFileName(dir)}"))
+        navTo = dir;
+
+    if (saveMode == false)
+    {
+      foreach (var file in SafeFiles(currentDir))
+      {
+        var name = Path.GetFileName(file);
+        if (ImGui.Selectable(name, selectedFile == file))
+          selectedFile = file;
+        if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left))
+        {
+          selectedFile = file;
+          Confirm();
+        }
+      }
+    }
+
+    ImGui.EndChild();
+
+    if (navTo != null)
+    {
+      currentDir = navTo;
+      selectedFile = null;
+    }
+
+    ImGui.Separator();
+
+    if (saveMode)
+    {
+      ImGui.AlignTextToFramePadding();
+      ImGuiHelper.Text("File name:");
+      ImGui.SameLine();
+      ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().x);
+      ImGui.InputText("##filename", ref fileName, 256);
+    }
+
+    var canConfirm = saveMode ? !string.IsNullOrWhiteSpace(fileName) : selectedFile != null;
+    ImGui.BeginDisabled(!canConfirm);
+    if (ImGui.Button(saveMode ? "Save" : "Open", new Vector2(120, 0)))
+      Confirm();
+    ImGui.EndDisabled();
+
+    ImGui.SameLine();
+    if (ImGui.Button("Cancel", new Vector2(120, 0)))
+      Close();
+  }
+
+  private static void Confirm()
+  {
+    string path;
+    try
+    {
+      path = saveMode ? Path.Combine(currentDir, fileName.Trim()) : selectedFile;
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      Close();
+      return;
+    }
+
+    var callback = onConfirm;
+    Close();
+    callback?.Invoke(path);
+  }
+
+  private static void Close()
+  {
+    active = false;
+    onConfirm = null;
+    selectedFile = null;
+  }
+
+  private static void Navigate(string dir)
+  {
+    currentDir = dir;
+    selectedFile = null;
+  }
+
+  private static string[] SafeDrives()
+  {
+    try
+    {
+      return DriveInfo.GetDrives().Where(d => d.IsReady).Select(d => d.Name).ToArray();
+    }
+    catch { return []; }
+  }
+
+  private static string SafeParent(string dir)
+  {
+    try { return Directory.GetParent(dir)?.FullName; }
+    catch { return null; }
+  }
+
+  private static string[] SafeDirectories(string dir)
+  {
+    try
+    {
+      return Directory.GetDirectories(dir)
+        .OrderBy(d => Path.GetFileName(d), StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+    }
+    catch { return []; }
+  }
+
+  private static string[] SafeFiles(string dir)
+  {
+    try
+    {
+      return Directory.GetFiles(dir, $"*{filter}")
+        .OrderBy(f => Path.GetFileName(f), StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+    }
+    catch { return []; }
+  }
+}

--- a/StationeersLaunchPad/UI/LaunchPadTheme.cs
+++ b/StationeersLaunchPad/UI/LaunchPadTheme.cs
@@ -1,0 +1,96 @@
+using ImGuiNET;
+using UnityEngine;
+
+namespace StationeersLaunchPad.UI;
+
+// Color palette + ImGui style matching the redesigned LaunchPad UI (dark panels, orange accent).
+public static class LaunchPadTheme
+{
+  public static Color Hex(uint rgb, float a = 1f) =>
+    new(((rgb >> 16) & 0xFF) / 255f, ((rgb >> 8) & 0xFF) / 255f, (rgb & 0xFF) / 255f, a);
+
+  public static readonly Color Bg = Hex(0x1E2027);
+  public static readonly Color Panel = Hex(0x2B2F3B);
+  public static readonly Color PanelAlt = Hex(0x252833);
+  public static readonly Color Deep = Hex(0x14161C);
+  public static readonly Color Sidebar = Hex(0x191C23);
+  public static readonly Color Toolbar = Hex(0x181B22);
+  public static readonly Color Border = new(1f, 1f, 1f, 0.07f);
+  public static readonly Color RowAlt = new(1f, 1f, 1f, 0.025f);
+
+  public static readonly Color Orange = Hex(0xF47A2A);
+  public static readonly Color OrangeFaint = Hex(0xF47A2A, 0.10f);
+  public static readonly Color OrangeBorder = Hex(0xF47A2A, 0.25f);
+
+  public static readonly Color Text = Hex(0xF1F3F6);
+  public static readonly Color TextSub = Hex(0xB7BDC9);
+  public static readonly Color TextMuted = Hex(0x6A728A);
+  public static readonly Color TextDim = Hex(0x4A5266);
+
+  public static readonly Color Ok = Hex(0x5FAF5F);
+  public static readonly Color Warn = Hex(0xD8B14A);
+  public static readonly Color Err = Hex(0xD9534F);
+
+  private static int colors;
+  private static int vars;
+
+  public static void Push()
+  {
+    colors = 0;
+    vars = 0;
+
+    void C(ImGuiCol c, Color col) { ImGui.PushStyleColor(c, (Vector4)col); colors++; }
+    void V1(ImGuiStyleVar v, float f) { ImGui.PushStyleVar(v, f); vars++; }
+    void V2(ImGuiStyleVar v, Vector2 f) { ImGui.PushStyleVar(v, f); vars++; }
+
+    C(ImGuiCol.WindowBg, Bg);
+    C(ImGuiCol.ChildBg, new Color(0f, 0f, 0f, 0f));
+    C(ImGuiCol.PopupBg, Panel);
+    C(ImGuiCol.Border, Border);
+    C(ImGuiCol.Text, Text);
+    C(ImGuiCol.TextDisabled, TextMuted);
+    C(ImGuiCol.FrameBg, Deep);
+    C(ImGuiCol.FrameBgHovered, PanelAlt);
+    C(ImGuiCol.FrameBgActive, PanelAlt);
+    C(ImGuiCol.Button, new Color(1f, 1f, 1f, 0.04f));
+    C(ImGuiCol.ButtonHovered, new Color(1f, 1f, 1f, 0.09f));
+    C(ImGuiCol.ButtonActive, OrangeFaint);
+    C(ImGuiCol.Header, Hex(0xF47A2A, 0.16f));
+    C(ImGuiCol.HeaderHovered, new Color(1f, 1f, 1f, 0.09f));
+    C(ImGuiCol.HeaderActive, Hex(0xF47A2A, 0.22f));
+    C(ImGuiCol.CheckMark, Orange);
+    C(ImGuiCol.Separator, Border);
+    C(ImGuiCol.ScrollbarBg, new Color(0f, 0f, 0f, 0f));
+    C(ImGuiCol.ScrollbarGrab, new Color(1f, 1f, 1f, 0.10f));
+    C(ImGuiCol.ScrollbarGrabHovered, new Color(1f, 1f, 1f, 0.18f));
+
+    V1(ImGuiStyleVar.FrameRounding, 3f);
+    V1(ImGuiStyleVar.ChildRounding, 3f);
+    V1(ImGuiStyleVar.FrameBorderSize, 1f);
+    V2(ImGuiStyleVar.ItemSpacing, new Vector2(6f, 5f));
+  }
+
+  public static void Pop()
+  {
+    ImGui.PopStyleVar(vars);
+    ImGui.PopStyleColor(colors);
+  }
+
+  // -- Draw helpers ----------------------------------------------
+  public static void Fill(Rect r, Color c) =>
+    ImGui.GetWindowDrawList().AddRectFilled(r.Min, r.Max, U32(c));
+
+  public static void Stroke(Rect r, Color c) =>
+    ImGui.GetWindowDrawList().AddRect(r.Min, r.Max, U32(c));
+
+  public static void HLine(Vector2 a, Vector2 b, Color c) =>
+    ImGui.GetWindowDrawList().AddLine(a, b, U32(c));
+
+  public static void TextAt(Vector2 pos, string text, Color c)
+  {
+    ImGui.SetCursorScreenPos(pos);
+    ImGuiHelper.TextColored(text, c);
+  }
+
+  private static uint U32(Color c) => ImGui.ColorConvertFloat4ToU32((Vector4)c);
+}

--- a/StationeersLaunchPad/UI/LayoutPrefs.cs
+++ b/StationeersLaunchPad/UI/LayoutPrefs.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Xml.Serialization;
+using Assets.Scripts.Serialization;
+
+namespace StationeersLaunchPad.UI;
+
+// User-adjustable, persisted layout: mod-list width and console height fraction.
+[XmlRoot("LaunchPadLayout")]
+public class LayoutPrefs
+{
+  [XmlElement("ListWidth")]
+  public float ListWidth = 360f;
+
+  [XmlElement("ConsoleFraction")]
+  public float ConsoleFraction = 0.20f;
+
+  private static LayoutPrefs current;
+  private static string Path => System.IO.Path.Join(LaunchPadPaths.SavePath, "ui_layout.xml");
+
+  public static LayoutPrefs Current
+  {
+    get
+    {
+      if (current == null)
+      {
+        try
+        {
+          if (File.Exists(Path))
+            current = XmlSerialization.Deserialize<LayoutPrefs>(Path);
+        }
+        catch (Exception ex)
+        {
+          Logger.Global.LogWarning($"failed to read {Path}: {ex.Message}");
+        }
+        current ??= new LayoutPrefs();
+      }
+      return current;
+    }
+  }
+
+  public static void Save()
+  {
+    try
+    {
+      if (!Current.SaveXml(Path))
+        Logger.Global.LogWarning($"failed to save {Path}");
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogWarning($"failed to save {Path}: {ex.Message}");
+    }
+  }
+}

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using ImGuiNET;
 using StationeersLaunchPad.Loading;
 using StationeersLaunchPad.Metadata;
@@ -25,6 +27,24 @@ public static class ManualLoadWindow
   private static ModInfo draggingMod = null;
   private static bool dragged = false;
 
+  // Mod list sorting/filtering state (see DrawModListTools / DrawSearchAndCount)
+  private static ModList.ModSortField sortField = ModList.ModSortField.LoadOrder;
+  private static bool sortDescending = false;
+  private static bool sortApplyToLoadOrder = false;
+  private static string searchText = "";
+  // Redesigned shell: left-sidebar navigation sections + collapsible console.
+  private enum NavSection { Mods, Dependencies, Settings, About }
+  private static NavSection nav = NavSection.Mods;
+  private static bool consoleOpen = true;
+  private static bool layoutDirty = false;
+
+  private static readonly string[] SortFieldLabels =
+    { "Load order", "Name", "Author", "Released", "Updated" };
+
+  // Subtle background tint for alternating list rows (zebra striping).
+  private static uint RowAltColor =>
+    ImGui.ColorConvertFloat4ToU32(new Color(1f, 1f, 1f, 0.045f));
+
   public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort)
   {
     Platform.SetBackgroundEnabled(false);
@@ -37,77 +57,501 @@ public static class ManualLoadWindow
 
     ImGuiHelper.Draw(() =>
     {
-      var style = ImGui.GetStyle();
+      LaunchPadTheme.Push();
+
       var windowRect = ImGuiHelper.ScreenRect().Shrink(25f);
       ImGuiHelper.SetNextWindowRect(windowRect);
       ImGui.Begin("##preloadermanual", ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings);
 
-      var contentRect = ImGuiHelper.AvailableRect();
-      contentRect.SplitRY(0.6f, out var topRect, out var bottomRect);
-      topRect.SplitRX(0.5f, out var leftRect, out var rightRect);
+      var full = ImGuiHelper.AvailableRect();
+      LaunchPadTheme.Fill(full, LaunchPadTheme.Bg);
 
-      leftRect.SplitOY(ImGui.GetTextLineHeight(), out var statusRect, out leftRect);
+      full.SplitOY(36f, out var titleRect, out var bodyRect);
+      DrawTitleBar(titleRect, stage, modList);
 
-      if (DrawStatusLine(statusRect, stage))
+      bodyRect.SplitOX(210f, out var sideRect, out var mainRect);
+      if (DrawSidebar(sideRect, stage))
         changed |= ChangeFlags.NextStep;
 
-      ImGui.SetCursorScreenPos(leftRect.Min);
-      ImGui.Separator();
-      leftRect = leftRect.From(ImGui.GetCursorScreenPos());
-
-      ImGuiHelper.SetNextWindowRect(leftRect);
-      ImGui.SetCursorScreenPos(leftRect.Min);
-      ImGui.BeginChild("##left", leftRect.Size);
-
-      if (stage is LoadStage.Searching or LoadStage.Configuring)
+      var winHeight = full.Size.y;
+      float consoleHeight;
+      if (consoleOpen)
       {
-        changed |= DrawModSelectOptions(modList, autoSort);
-        leftRect = leftRect.From(ImGui.GetCursorScreenPos());
-        ImGui.BeginChild("##modselect", leftRect.Size);
-        if (DrawModSelectTable(modList, stage == LoadStage.Configuring, autoSort))
-          changed |= ChangeFlags.Mods;
-        ImGui.EndChild();
+        var minConsole = ImGui.GetTextLineHeightWithSpacing() * 8f + 44f;
+        consoleHeight = Mathf.Clamp(winHeight * LayoutPrefs.Current.ConsoleFraction,
+          minConsole, mainRect.Size.y * 0.65f);
       }
-      else if (stage is LoadStage.Loading or LoadStage.Loaded)
+      else
+        consoleHeight = 26f;
+
+      mainRect.SplitOY(-consoleHeight, out var contentRect, out var consoleRect);
+
+      var splitterRect = default(Rect);
+      if (consoleOpen)
+        contentRect.SplitOY(-5f, out contentRect, out splitterRect);
+
+      changed |= DrawMainContent(contentRect, stage, modList, autoSort);
+
+      if (consoleOpen)
       {
-        DrawLoadTable(modList);
+        var dy = HSplitter("##consolesplit", splitterRect);
+        if (dy != 0f)
+          LayoutPrefs.Current.ConsoleFraction =
+            Mathf.Clamp(LayoutPrefs.Current.ConsoleFraction - dy / winHeight, 0.12f, 0.55f);
       }
-      ImGui.EndChild();
 
-      ImGuiHelper.SeparatorLine(rightRect.TL, rightRect.BL);
-      rightRect = rightRect.Shrink(1, 0, 0, 0);
-
-      ImGui.SetCursorScreenPos(rightRect.Min);
-      ImGui.BeginChild("##right", rightRect.Size);
-      if (ImGui.BeginTabBar("##right"))
-      {
-        DrawModInfoTab(stage);
-        DrawModConfigTab(stage);
-
-        // If we changed launchpad config and haven't loaded mods yet, mark mods changed to apply disable/sort behaviour
-        if (DrawLaunchPadConfigTab() && stage <= LoadStage.Configuring)
-          changed |= ChangeFlags.Mods;
-
-        ImGui.EndTabBar();
-      }
-      ImGui.EndChild();
-
-      ImGuiHelper.SeparatorLine(bottomRect.TL, bottomRect.TR);
-      bottomRect = bottomRect.Shrink(0, 1, 0, 0);
-
-      bottomRect.SplitOY(-ImGui.GetTextLineHeightWithSpacing(),
-        out var logRect, out var consoleRect);
-
-      ImGui.SetCursorScreenPos(logRect.TL);
-      ImGui.BeginChild("##logs", logRect.Size);
-      LogPanel.DrawConsole(selectedMod?.Logger ?? Logger.Global);
-      ImGui.EndChild();
-
-      StartupConsole.DrawInput(consoleRect);
+      DrawConsolePanel(consoleRect);
 
       ImGui.End();
+      LaunchPadTheme.Pop();
     });
     return changed;
+  }
+
+  // -- Redesigned shell -------------------------------------------
+
+  private static void DrawTitleBar(Rect rect, LoadStage stage, ModList modList)
+  {
+    LaunchPadTheme.Fill(rect, LaunchPadTheme.Deep);
+    LaunchPadTheme.HLine(rect.BL, rect.BR, LaunchPadTheme.Border);
+
+    var cy = rect.Min.y + (rect.Size.y - ImGui.GetTextLineHeight()) / 2f;
+    const float pad = 14f;
+
+    var logo = new Rect(new(rect.Min.x + pad, rect.Min.y + 8f), new(rect.Min.x + pad + 20f, rect.Min.y + 28f));
+    LaunchPadTheme.Fill(logo, LaunchPadTheme.OrangeFaint);
+    LaunchPadTheme.Stroke(logo, LaunchPadTheme.OrangeBorder);
+    LaunchPadTheme.TextAt(new(logo.Min.x + 6f, cy), "L", LaunchPadTheme.Orange);
+
+    var x = rect.Min.x + pad + 30f;
+    LaunchPadTheme.TextAt(new(x, cy), "STATIONEERS LAUNCHPAD", LaunchPadTheme.Text);
+    x += ImGui.CalcTextSize("STATIONEERS LAUNCHPAD").x + 10f;
+    LaunchPadTheme.TextAt(new(x, cy), $"v{LaunchPadInfo.VERSION}", LaunchPadTheme.TextMuted);
+
+    var mods = modList.AllMods.Where(m => m.Source != ModSourceType.Core).ToList();
+    var enabled = mods.Count(m => m.Enabled);
+    var disabled = mods.Count - enabled;
+    var errs = PreLoadCheck.Current?.Errors ?? 0;
+    var warns = PreLoadCheck.Current?.Warnings ?? 0;
+
+    var segs = new List<(string, Color)>
+    {
+      (StageText(stage), LaunchPadTheme.TextSub),
+      ($"Active {enabled}", LaunchPadTheme.Orange),
+      ($"Disabled {disabled}", LaunchPadTheme.TextSub),
+      ($"Warn {warns}", warns > 0 ? LaunchPadTheme.Warn : LaunchPadTheme.TextDim),
+      ($"Err {errs}", errs > 0 ? LaunchPadTheme.Err : LaunchPadTheme.TextDim),
+    };
+
+    var width = segs.Sum(s => ImGui.CalcTextSize(s.Item1).x + 16f) - 16f;
+    var sx = rect.Max.x - pad - width;
+    foreach (var (text, color) in segs)
+    {
+      LaunchPadTheme.TextAt(new(sx, cy), text, color);
+      sx += ImGui.CalcTextSize(text).x + 16f;
+    }
+  }
+
+  private static string StageText(LoadStage stage) => stage switch
+  {
+    LoadStage.Updating => "Checking for updates",
+    LoadStage.Initializing => "Initializing",
+    LoadStage.Searching => "Locating mods",
+    LoadStage.Configuring => "Ready to load mods",
+    LoadStage.Loading => "Loading mods",
+    LoadStage.Loaded => "Ready to start game",
+    LoadStage.Failed => "Mods failed to load",
+    _ => "",
+  };
+
+  private static bool DrawSidebar(Rect rect, LoadStage stage)
+  {
+    LaunchPadTheme.Fill(rect, LaunchPadTheme.Sidebar);
+    LaunchPadTheme.HLine(rect.TR, rect.BR, LaunchPadTheme.Border);
+
+    const float pad = 10f;
+    var x = rect.Min.x + pad;
+    var w = rect.Size.x - pad * 2f;
+    var y = rect.Min.y + 14f;
+
+    LaunchPadTheme.TextAt(new(x + 4f, y), "NAVIGATION", LaunchPadTheme.TextDim);
+    y += 22f;
+
+    (NavSection id, string label)[] items =
+    {
+      (NavSection.Mods, "Mod Manager"),
+      (NavSection.Dependencies, "Dependency Tree"),
+      (NavSection.Settings, "Configuration"),
+      (NavSection.About, "About"),
+    };
+    foreach (var (id, label) in items)
+    {
+      ImGui.SetCursorScreenPos(new(x, y));
+      var active = nav == id;
+      if (active)
+        ImGui.PushStyleColor(ImGuiCol.Text, (Vector4)LaunchPadTheme.Orange);
+      if (ImGui.Selectable($"  {label}", active, new Vector2(w, 26f)))
+        nav = id;
+      if (active)
+        ImGui.PopStyleColor();
+      y += 28f;
+    }
+
+    y += 8f;
+    LaunchPadTheme.HLine(new(x, y), new(x + w, y), LaunchPadTheme.Border);
+    y += 10f;
+
+    var (loadEnabled, loadText) = stage switch
+    {
+      LoadStage.Configuring => (true, "Load Mods"),
+      LoadStage.Loaded or LoadStage.Failed => (true, "Start Game"),
+      _ => (false, "..."),
+    };
+
+    ImGui.SetCursorScreenPos(new(x, y));
+    ImGui.PushStyleColor(ImGuiCol.Button, (Vector4)(loadEnabled ? LaunchPadTheme.Orange : new Color(1f, 1f, 1f, 0.04f)));
+    ImGui.PushStyleColor(ImGuiCol.ButtonHovered, (Vector4)(loadEnabled ? LaunchPadTheme.Hex(0xE06B1F) : new Color(1f, 1f, 1f, 0.06f)));
+    ImGui.PushStyleColor(ImGuiCol.ButtonActive, (Vector4)LaunchPadTheme.Orange);
+    ImGui.PushStyleColor(ImGuiCol.Text, (Vector4)(loadEnabled ? Color.white : LaunchPadTheme.TextMuted));
+    ImGui.BeginDisabled(!loadEnabled);
+    var clicked = ImGui.Button(loadText, new Vector2(w, 32f));
+    ImGui.EndDisabled();
+    ImGui.PopStyleColor(4);
+
+    return clicked;
+  }
+
+  private static ChangeFlags DrawMainContent(Rect rect, LoadStage stage, ModList modList, bool autoSort)
+  {
+    var changed = ChangeFlags.None;
+    ImGui.SetCursorScreenPos(rect.Min);
+    ImGui.BeginChild("##maincontent", rect.Size);
+
+    switch (nav)
+    {
+      case NavSection.Mods:
+        changed |= DrawModsView(rect, stage, modList, autoSort);
+        break;
+      case NavSection.Dependencies:
+        if (DrawModTree(modList))
+          changed |= ChangeFlags.Mods;
+        break;
+      case NavSection.Settings:
+        if (ConfigPanel.DrawConfigFile(Configs.Sorted, category => category != "Internal")
+            && stage <= LoadStage.Configuring)
+          changed |= ChangeFlags.Mods;
+        break;
+      case NavSection.About:
+        DrawAboutView();
+        break;
+    }
+
+    ImGui.EndChild();
+    return changed;
+  }
+
+  private static ChangeFlags DrawModsView(Rect rect, LoadStage stage, ModList modList, bool autoSort)
+  {
+    var changed = ChangeFlags.None;
+
+    if (stage is LoadStage.Searching or LoadStage.Configuring)
+    {
+      var (flagged, checkChanged) = PreLoadCheckPanel.DrawBanner(modList);
+      if (checkChanged)
+        changed |= ChangeFlags.Mods;
+      if (flagged != null && flagged.Source != ModSourceType.Core)
+      {
+        selectedInfo = flagged;
+        selectedMod = null;
+      }
+      changed |= DrawModSelectOptions(modList, autoSort);
+    }
+    else
+    {
+      DrawModListToolbar(modList, loaded: true);
+      ImGui.Separator();
+    }
+
+    var area = ImGuiHelper.AvailableRect();
+    var listW = Mathf.Clamp(LayoutPrefs.Current.ListWidth, 260f, area.Size.x - 300f);
+    area.SplitOX(listW, out var listRect, out var rest);
+    rest.SplitOX(5f, out var listSplitter, out var detailRect);
+
+    ImGui.SetCursorScreenPos(listRect.Min);
+    ImGui.BeginChild("##modlist", listRect.Size);
+    if (stage is LoadStage.Searching or LoadStage.Configuring)
+    {
+      if (DrawModSelectTable(modList, stage == LoadStage.Configuring, autoSort))
+        changed |= ChangeFlags.Mods;
+    }
+    else
+      DrawLoadTable(modList);
+    ImGui.EndChild();
+
+    var dx = VSplitter("##listsplit", listSplitter);
+    if (dx != 0f)
+      LayoutPrefs.Current.ListWidth = Mathf.Clamp(listW + dx, 260f, area.Size.x - 300f);
+
+    LaunchPadTheme.Fill(detailRect, LaunchPadTheme.PanelAlt);
+    LaunchPadTheme.HLine(detailRect.TL, detailRect.BL, LaunchPadTheme.Border);
+    var inner = detailRect.Shrink(12f);
+    ImGui.SetCursorScreenPos(inner.Min);
+    ImGui.BeginChild("##detail", inner.Size, false, ImGuiWindowFlags.HorizontalScrollbar);
+    DrawModDetail(modList, selectedInfo);
+    ImGui.EndChild();
+
+    return changed;
+  }
+
+  private static void DrawAboutView()
+  {
+    ImGuiHelper.TextColored("Stationeers LaunchPad", LaunchPadTheme.Orange);
+    ImGuiHelper.TextDisabled($"Version {LaunchPadInfo.VERSION}");
+    ImGui.Separator();
+    ImGuiHelper.Text("Community mod loader for Stationeers.");
+    ImGuiHelper.TextDisabled("Unofficial community tool, not affiliated with RocketWerkz.");
+  }
+
+  // -- Draggable splitters (persisted via LayoutPrefs) ------------
+  private static float VSplitter(string id, Rect rect)
+  {
+    ImGui.SetCursorScreenPos(rect.Min);
+    ImGui.InvisibleButton(id, rect.Size);
+    var active = ImGui.IsItemActive();
+    var hovered = ImGui.IsItemHovered();
+    if (active || hovered)
+      ImGui.SetMouseCursor(ImGuiMouseCursor.ResizeEW);
+    var cx = rect.Min.x + rect.Size.x / 2f;
+    LaunchPadTheme.HLine(new(cx, rect.Min.y + 2f), new(cx, rect.Max.y - 2f),
+      active ? LaunchPadTheme.Orange : hovered ? LaunchPadTheme.OrangeBorder : LaunchPadTheme.Border);
+    return SplitterDelta(active, ImGui.GetIO().MouseDelta.x);
+  }
+
+  private static float HSplitter(string id, Rect rect)
+  {
+    ImGui.SetCursorScreenPos(rect.Min);
+    ImGui.InvisibleButton(id, rect.Size);
+    var active = ImGui.IsItemActive();
+    var hovered = ImGui.IsItemHovered();
+    if (active || hovered)
+      ImGui.SetMouseCursor(ImGuiMouseCursor.ResizeNS);
+    var cy = rect.Min.y + rect.Size.y / 2f;
+    LaunchPadTheme.HLine(new(rect.Min.x + 2f, cy), new(rect.Max.x - 2f, cy),
+      active ? LaunchPadTheme.Orange : hovered ? LaunchPadTheme.OrangeBorder : LaunchPadTheme.Border);
+    return SplitterDelta(active, ImGui.GetIO().MouseDelta.y);
+  }
+
+  private static float SplitterDelta(bool active, float delta)
+  {
+    if (active)
+    {
+      layoutDirty = true;
+      return delta;
+    }
+    if (layoutDirty && !ImGui.IsMouseDown(ImGuiMouseButton.Left))
+    {
+      LayoutPrefs.Save();
+      layoutDirty = false;
+    }
+    return 0f;
+  }
+
+  // -- Status system ----------------------------------------------
+  private enum ModUiStatus { Ok, Warn, Error, Disabled }
+
+  // Worst pre-load-check severity (Warning/Error) per mod, for status icons/chips.
+  private static Dictionary<ModInfo, CheckSeverity> BuildSeverity()
+  {
+    var dict = new Dictionary<ModInfo, CheckSeverity>();
+    var issues = PreLoadCheck.Current?.Issues;
+    if (issues != null)
+      foreach (var i in issues)
+        if (i.Mod != null && i.Severity != CheckSeverity.Info
+            && (!dict.TryGetValue(i.Mod, out var cur) || i.Severity > cur))
+          dict[i.Mod] = i.Severity;
+    return dict;
+  }
+
+  private static ModUiStatus StatusOf(ModInfo mod, Dictionary<ModInfo, CheckSeverity> sev)
+  {
+    if (!mod.Enabled && mod.Source != ModSourceType.Core)
+      return ModUiStatus.Disabled;
+    if (sev.TryGetValue(mod, out var s))
+      return s == CheckSeverity.Error ? ModUiStatus.Error : ModUiStatus.Warn;
+    return ModUiStatus.Ok;
+  }
+
+  private static Color StatusColor(ModUiStatus s) => s switch
+  {
+    ModUiStatus.Ok => LaunchPadTheme.Ok,
+    ModUiStatus.Warn => LaunchPadTheme.Warn,
+    ModUiStatus.Error => LaunchPadTheme.Err,
+    _ => LaunchPadTheme.TextMuted,
+  };
+
+  private static void DrawStatusDot(Rect rect, ModUiStatus status)
+  {
+    var center = (rect.Min + rect.Max) / 2f;
+    ImGui.GetWindowDrawList().AddCircleFilled(center, 4f,
+      ImGui.ColorConvertFloat4ToU32((Vector4)StatusColor(status)));
+  }
+
+  private static void DrawStatusChip(ModUiStatus status)
+  {
+    var label = status switch
+    {
+      ModUiStatus.Ok => "OK",
+      ModUiStatus.Warn => "WARN",
+      ModUiStatus.Error => "ERR",
+      _ => "OFF",
+    };
+    ImGuiHelper.TextColored(label, StatusColor(status));
+  }
+
+  // -- Redesigned detail panel ------------------------------------
+  private static void DrawModDetail(ModList modList, ModInfo mod)
+  {
+    if (mod == null)
+    {
+      ImGuiHelper.TextDisabled("Select a mod to view details");
+      return;
+    }
+
+    var about = mod.About;
+    var sev = BuildSeverity();
+
+    ImGui.AlignTextToFramePadding();
+    ImGuiHelper.TextColored(mod.Name, LaunchPadTheme.Text);
+    ImGui.SameLine();
+    DrawStatusChip(StatusOf(mod, sev));
+
+    ImGuiHelper.TextDisabled($"by {(string.IsNullOrEmpty(mod.Author) ? "Unknown" : mod.Author)}");
+    if (mod.WorkshopHandle > 1)
+    {
+      ImGui.SameLine();
+      ImGuiHelper.TextDisabled($"#{mod.WorkshopHandle}");
+    }
+
+    ImGui.Separator();
+
+    DetailField("Version", string.IsNullOrEmpty(about?.Version) ? "-" : about.Version.Trim());
+    DetailField("Updated", mod.Updated?.ToString("yyyy-MM-dd") ?? "-");
+    DetailField("Source", mod.Source.ToString());
+
+    ImGui.Separator();
+
+    ImGuiHelper.TextDisabled("DESCRIPTION");
+    var desc = about?.Description;
+    ImGuiHelper.TextWrapped(string.IsNullOrEmpty(desc) ? "No description provided." : StripBBCode(desc));
+
+    if (about?.Tags is { Count: > 0 } tags)
+    {
+      ImGui.Spacing();
+      for (var i = 0; i < tags.Count; i++)
+      {
+        if (i > 0)
+          ImGui.SameLine();
+        ImGuiHelper.TextDisabled($"[{tags[i]}]");
+      }
+    }
+
+    var deps = new List<ModInfo>();
+    foreach (var d in about?.DependsOn ?? [])
+    {
+      if (!d.IsValid)
+        continue;
+      var p = modList.AllMods.FirstOrDefault(m => m != mod && m.Satisfies(d));
+      if (p != null)
+        deps.Add(p);
+    }
+    if (deps.Count > 0)
+    {
+      ImGui.Separator();
+      ImGuiHelper.TextDisabled($"REQUIRES ({deps.Count})");
+      foreach (var dep in deps)
+        if (DrawDepRow(dep, sev))
+          selectedInfo = dep;
+    }
+
+    var dependents = modList.AllMods
+      .Where(m => m != mod && (m.About?.DependsOn?.Any(d => d.IsValid && mod.Satisfies(d)) ?? false))
+      .ToList();
+    if (dependents.Count > 0)
+    {
+      ImGui.Separator();
+      ImGuiHelper.TextDisabled($"REQUIRED BY ({dependents.Count})");
+      foreach (var dep in dependents)
+        if (DrawDepRow(dep, sev))
+          selectedInfo = dep;
+    }
+
+    ImGui.Separator();
+    if (mod.Source != ModSourceType.Core)
+    {
+      if (ImGui.Button(mod.Enabled ? "Disable" : "Enable"))
+        mod.Enabled = !mod.Enabled;
+      ImGui.SameLine();
+    }
+    if (!string.IsNullOrEmpty(mod.DirectoryPath))
+    {
+      if (ImGui.Button("Open Folder"))
+        ProcessUtil.OpenExplorerDir(mod.DirectoryPath);
+      ImGui.SameLine();
+    }
+    if (mod.WorkshopHandle > 1 && ImGui.Button("Open Workshop Page"))
+      Steam.OpenWorkshopPage(mod.WorkshopHandle);
+  }
+
+  // Strips Steam Workshop BBCode tags ([h1], [b], [url=...], [list], etc.) for readability.
+  private static string StripBBCode(string text) =>
+    System.Text.RegularExpressions.Regex.Replace(text.Trim(), @"\[/?[^\]]*\]", "").Trim();
+
+  private static void DetailField(string label, string value)
+  {
+    ImGuiHelper.TextDisabled(label);
+    ImGui.SameLine(110f);
+    ImGuiHelper.Text(value);
+  }
+
+  private static bool DrawDepRow(ModInfo mod, Dictionary<ModInfo, CheckSeverity> sev)
+  {
+    var pos = ImGui.GetCursorScreenPos();
+    var h = ImGui.GetTextLineHeightWithSpacing();
+    var clicked = ImGui.Button($"##dep_{mod.DirectoryName}", new Vector2(ImGui.GetContentRegionAvail().x, h));
+
+    // Draw the dot + name on top of the button via the draw list (no cursor changes).
+    var dl = ImGui.GetWindowDrawList();
+    dl.AddCircleFilled(new(pos.x + 9f, pos.y + h / 2f), 4f,
+      ImGui.ColorConvertFloat4ToU32((Vector4)StatusColor(StatusOf(mod, sev))));
+    dl.AddText(new(pos.x + 22f, pos.y + (h - ImGui.GetTextLineHeight()) / 2f),
+      ImGui.ColorConvertFloat4ToU32((Vector4)LaunchPadTheme.Text), mod.Name);
+    return clicked;
+  }
+
+  private static void DrawConsolePanel(Rect rect)
+  {
+    LaunchPadTheme.Fill(rect, LaunchPadTheme.Deep);
+    LaunchPadTheme.HLine(rect.TL, rect.TR, LaunchPadTheme.Border);
+
+    rect.SplitOY(26f, out var headerRect, out var bodyRect);
+
+    ImGui.SetCursorScreenPos(headerRect.Min);
+    if (ImGui.InvisibleButton("##consoletoggle", headerRect.Size))
+      consoleOpen = !consoleOpen;
+    var cy = headerRect.Min.y + (headerRect.Size.y - ImGui.GetTextLineHeight()) / 2f;
+    LaunchPadTheme.TextAt(new(headerRect.Min.x + 10f, cy), consoleOpen ? "v CONSOLE" : "> CONSOLE", LaunchPadTheme.TextMuted);
+
+    if (!consoleOpen)
+      return;
+
+    bodyRect.SplitOY(-ImGui.GetTextLineHeightWithSpacing(), out var logRect, out var inputRect);
+
+    ImGui.SetCursorScreenPos(logRect.Min);
+    ImGui.BeginChild("##logs", logRect.Size);
+    LogPanel.DrawConsole(selectedMod?.Logger ?? Logger.Global);
+    ImGui.EndChild();
+
+    StartupConsole.DrawInput(inputRect);
   }
 
   private static bool DrawStatusLine(Rect rect, LoadStage stage)
@@ -237,9 +681,192 @@ public static class ManualLoadWindow
       }
     }
 
+    changed |= DrawModListToolbar(modList, loaded: false);
+
     ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetStyle().ItemSpacing.y);
     ImGui.Separator();
 
+    return changed;
+  }
+
+  // Full toolbar above the mod list: list/tree toggle, sort controls, JSON export/import,
+  // search box, counters and (in list view) column headers.
+  private static ChangeFlags DrawModListToolbar(ModList modList, bool loaded)
+  {
+    var changed = DrawModListTools(modList, loaded);
+    DrawSearchAndCount(modList, loaded);
+    DrawColumnHeader(loaded);
+    return changed;
+  }
+
+  // Draws the sort selector and the JSON export/import buttons.
+  // When loaded is true the load-order controls are hidden.
+  private static ChangeFlags DrawModListTools(ModList modList, bool loaded = false)
+  {
+    var changed = ChangeFlags.None;
+
+    {
+      ImGui.AlignTextToFramePadding();
+      ImGuiHelper.Text("Sort:");
+
+      ImGui.SameLine();
+      ImGui.SetNextItemWidth(140f);
+      var cur = (int)sortField;
+      if (ImGui.Combo("##sortfield", ref cur, SortFieldLabels, SortFieldLabels.Length))
+      {
+        sortField = (ModList.ModSortField)cur;
+        if (!loaded && sortApplyToLoadOrder && modList.ApplySort(sortField, sortDescending))
+          changed |= ChangeFlags.Mods;
+      }
+      ImGuiHelper.ItemTooltip("Order the mod list by load order, name, author, release date or last update.");
+
+      ImGui.SameLine();
+      if (ImGui.Button(sortDescending ? "Desc" : "Asc"))
+      {
+        sortDescending = !sortDescending;
+        if (!loaded && sortApplyToLoadOrder && modList.ApplySort(sortField, sortDescending))
+          changed |= ChangeFlags.Mods;
+      }
+      ImGuiHelper.ItemTooltip("Toggle ascending/descending order.");
+
+      if (!loaded)
+      {
+        ImGui.SameLine();
+        if (ImGui.Checkbox("Apply to load order", ref sortApplyToLoadOrder)
+            && sortApplyToLoadOrder
+            && modList.ApplySort(sortField, sortDescending))
+          changed |= ChangeFlags.Mods;
+        ImGuiHelper.ItemTooltip(
+          "On: sorting also rewrites the real mod load order (drag & drop is disabled while a sort is active).\n" +
+          "Off: sorting only changes how the list is displayed; the load order is left untouched.");
+      }
+    }
+
+    ImGui.SameLine();
+    ImGuiHelper.TextDisabled("|", true);
+    ImGui.SameLine();
+    ImGuiHelper.TextDisabled("Modpack:");
+
+    ImGui.SameLine();
+    ImGui.BeginDisabled(!LaunchPadConfig.CanImportModList);
+    if (ImGui.Button("Import"))
+      FilePicker.OpenLoad("Import Mod List", LaunchPadPaths.SavePath, ".json",
+        path => LaunchPadConfig.ImportModListJson(path));
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      "Load a mod list (.json) and apply its enabled state and order.",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
+
+    ImGui.SameLine();
+    if (ImGui.Button("Export"))
+      FilePicker.OpenSave("Export Mod List", LaunchPadPaths.SavePath, "modlist.json", ".json",
+        path => LaunchPadConfig.ExportModListJson(path));
+    ImGuiHelper.ItemTooltip("Save the current mod list (state + order) as JSON.");
+
+    return changed;
+  }
+
+  private static string SortValueText(ModInfo mod) => sortField switch
+  {
+    ModList.ModSortField.Author => string.IsNullOrEmpty(mod.Author) ? "-" : mod.Author,
+    ModList.ModSortField.Released => mod.Released?.ToString("yyyy-MM-dd") ?? "-",
+    ModList.ModSortField.Updated => mod.Updated?.ToString("yyyy-MM-dd") ?? "-",
+    _ => null,
+  };
+
+  // True when the mod matches the current search text (by name or author).
+  private static bool MatchesSearch(ModInfo mod)
+  {
+    if (string.IsNullOrWhiteSpace(searchText))
+      return true;
+    var q = searchText.Trim();
+    return (mod.Name?.IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0)
+        || (mod.Author?.IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0);
+  }
+
+  // Search box + counters row.
+  private static void DrawSearchAndCount(ModList modList, bool loaded)
+  {
+    ImGui.AlignTextToFramePadding();
+    ImGuiHelper.Text("Search:");
+
+    ImGui.SameLine();
+    ImGui.SetNextItemWidth(200f);
+    ImGui.InputTextWithHint("##modsearch", "name or author...", ref searchText, 256);
+
+    if (!string.IsNullOrEmpty(searchText))
+    {
+      ImGui.SameLine();
+      if (ImGui.Button("Clear##search"))
+        searchText = "";
+    }
+
+    int total = 0, enabled = 0, shown = 0;
+    if (loaded)
+    {
+      total = enabled = ModLoader.LoadedMods.Count;
+      shown = ModLoader.LoadedMods.Count(m => MatchesSearch(m.Info));
+    }
+    else
+    {
+      foreach (var mod in modList.AllMods)
+      {
+        if (mod.Source == ModSourceType.Core)
+          continue;
+        total++;
+        if (mod.Enabled)
+          enabled++;
+        if (MatchesSearch(mod))
+          shown++;
+      }
+    }
+
+    ImGui.SameLine();
+    ImGuiHelper.TextDisabled("|", true);
+    ImGui.SameLine();
+    var countText = loaded ? $"Loaded: {total}" : $"Enabled: {enabled} / {total}";
+    if (!string.IsNullOrWhiteSpace(searchText))
+      countText += $"   (showing {shown})";
+    ImGuiHelper.TextDisabled(countText);
+  }
+
+  // Fixed (non-scrolling) column headers aligned with the table columns below.
+  private static void DrawColumnHeader(bool loaded)
+  {
+    var spacing = ImGui.GetStyle().ItemSpacing.x * 2;
+    var c0 = loaded
+      ? ImGui.CalcTextSize("XXX").x + spacing
+      : ImGui.GetTextLineHeightWithSpacing() + spacing;
+    var c1 = loaded
+      ? ImGui.CalcTextSize($"{ModSourceType.Workshop}").x + spacing
+      : ImGui.GetTextLineHeight() + spacing;
+
+    var available = ImGuiHelper.AvailableRect();
+    var row = available.TableRow(ImGui.GetTextLineHeightWithSpacing(), stackalloc[] { c0, c1 });
+
+    if (loaded)
+      ImGuiHelper.TextCentered(row.Column(1), "Source");
+
+    var nameHeader = "Mod";
+    if (sortField != ModList.ModSortField.LoadOrder)
+      nameHeader = $"Mod   (by {SortFieldLabels[(int)sortField]} {(sortDescending ? "v" : "^")})";
+    ImGuiHelper.Text(row.Column(2), nameHeader);
+
+    if (!loaded)
+      ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled("Author"));
+  }
+
+  // Draws the dependency tree and routes a clicked mod to the Mod Info tab.
+  // Returns true when the tree changed the mod list (e.g. enabling disabled dependencies).
+  private static bool DrawModTree(ModList modList)
+  {
+    var (changed, selected) = ModTreePanel.Draw(modList, searchText);
+    if (selected != null && selected.Source != ModSourceType.Core)
+    {
+      selectedInfo = selected;
+      selectedMod = null;
+      openInfo = true;
+    }
     return changed;
   }
 
@@ -259,10 +886,19 @@ public static class ManualLoadWindow
       dragged = false;
     }
 
+    // Display order may differ from the real load order when a sort/search is active.
+    // Drag & drop reordering is only allowed when showing the full, unsorted load order.
+    var displayMods = modList.Sorted(sortField, sortDescending);
+    if (!string.IsNullOrWhiteSpace(searchText))
+      displayMods = displayMods.Where(MatchesSearch).ToList();
+    var canReorder = edit
+      && sortField == ModList.ModSortField.LoadOrder
+      && string.IsNullOrWhiteSpace(searchText);
+
     var hoveringIndex = -1;
     var draggingIndex = -1;
     if (draggingMod != null)
-      draggingIndex = modList.IndexOf(draggingMod);
+      draggingIndex = displayMods.IndexOf(draggingMod);
 
     var rowHeight = ImGui.GetTextLineHeightWithSpacing();
     var spacing = ImGui.GetStyle().ItemSpacing.x * 2;
@@ -273,16 +909,20 @@ public static class ManualLoadWindow
       stackalloc[]
       {
         rowHeight + spacing,
-        ImGui.CalcTextSize($"{ModSourceType.Workshop}").x + spacing,
+        ImGui.GetTextLineHeight() + spacing,
       }
     );
 
+    var sev = BuildSeverity();
     ImGui.BeginDisabled(!edit);
 
     var idx = 0;
-    foreach (var mod in modList.AllMods)
+    foreach (var mod in displayMods)
     {
       ImGui.PushID(idx);
+
+      if ((idx & 1) == 1)
+        ImGui.GetWindowDrawList().AddRectFilled(row.Rect.TL, row.Rect.BR, RowAltColor);
 
       ImGui.SetCursorScreenPos(row.Column(0).TL);
       ImGui.BeginDisabled(mod.Source is ModSourceType.Core);
@@ -304,15 +944,45 @@ public static class ManualLoadWindow
         }
       }
 
-      ImGuiHelper.TextCentered(row.Column(1), $"{mod.Source}");
+      // Orange accent bar on the selected row (on top of the Selectable's highlight).
+      if (draggingMod == null && mod == selectedInfo)
+        ImGui.GetWindowDrawList().AddRectFilled(row.Rect.TL,
+          new Vector2(row.Rect.Min.x + 3f, row.Rect.Max.y),
+          ImGui.ColorConvertFloat4ToU32((Vector4)LaunchPadTheme.Orange));
 
-      ImGuiHelper.Text(row.Column(2), $"{mod.Name}");
+      DrawStatusDot(row.Column(1), StatusOf(mod, sev));
 
-      if (draggingMod != null)
+      // Name and author each get their own clipped column (no overlap).
+      var nameCol = row.Column(2);
+      const float authorWidth = 118f;
+      var nameRight = Mathf.Max(nameCol.Min.x + 20f, nameCol.Max.x - authorWidth - 8f);
+      var nameRect = new Rect(nameCol.Min, new Vector2(nameRight, nameCol.Max.y));
+      var authorRect = new Rect(new Vector2(nameRight + 8f, nameCol.Min.y), nameCol.Max);
+
+      var dim = !mod.Enabled && mod.Source != ModSourceType.Core;
+      if (dim)
+        ImGui.PushStyleColor(ImGuiCol.Text, (Vector4)ImGuiHelper.TextDisabledColor);
+      ImGuiHelper.Text(nameRect, mod.Name);
+      if (dim)
+        ImGui.PopStyleColor();
+
+      string rightText = null;
+      if (draggingMod != null && canReorder)
+      {
         if (mod.SortBefore(draggingMod))
-          ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled("Before"));
+          rightText = "Before";
         else if (draggingMod.SortBefore(mod))
-          ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled("After"));
+          rightText = "After";
+      }
+      else if (!string.IsNullOrEmpty(mod.Author))
+        rightText = mod.Author;
+
+      if (rightText != null)
+      {
+        ImGui.PushStyleColor(ImGuiCol.Text, (Vector4)LaunchPadTheme.TextMuted);
+        ImGuiHelper.Text(authorRect, rightText);
+        ImGui.PopStyleColor();
+      }
 
       ImGui.PopID();
 
@@ -322,7 +992,7 @@ public static class ManualLoadWindow
 
     ImGui.EndDisabled();
 
-    if (edit && draggingIndex != -1 && hoveringIndex != -1 && draggingIndex != hoveringIndex)
+    if (canReorder && draggingIndex != -1 && hoveringIndex != -1 && draggingIndex != hoveringIndex)
     {
       dragged = true;
       if (modList.MoveModTo(draggingMod, hoveringIndex, autoSort))
@@ -345,12 +1015,28 @@ public static class ManualLoadWindow
       ImGui.CalcTextSize($"{ModSourceType.Workshop}").x + spacing
     });
 
+    // Apply the same view sorting/search as the pre-load list. The actual load order is
+    // fixed at this point, so this only changes how the loaded mods are displayed.
+    IEnumerable<LoadedMod> loadedMods = ModLoader.LoadedMods;
+    if (sortField != ModList.ModSortField.LoadOrder)
+    {
+      var cmp = ModList.GetComparer(sortField, sortDescending);
+      var sorted = new List<LoadedMod>(ModLoader.LoadedMods);
+      sorted.Sort((a, b) => cmp.Compare(a.Info, b.Info));
+      loadedMods = sorted;
+    }
+    if (!string.IsNullOrWhiteSpace(searchText))
+      loadedMods = loadedMods.Where(m => MatchesSearch(m.Info));
+
     var idx = 0;
-    foreach (var mod in ModLoader.LoadedMods)
+    foreach (var mod in loadedMods)
     {
       ImGui.PushID(idx);
       var info = mod.Info;
       var isSelected = selectedMod == mod;
+
+      if ((idx & 1) == 1)
+        ImGui.GetWindowDrawList().AddRectFilled(row.Rect.TL, row.Rect.BR, RowAltColor);
 
       ImGui.SetCursorScreenPos(row.Rect.TL);
       if (ImGui.Selectable("##scopeselect", isSelected, row.Rect.Size))
@@ -364,6 +1050,10 @@ public static class ManualLoadWindow
       ImGuiHelper.TextCentered(row.Column(1), $"{info.Source}");
 
       ImGuiHelper.Text(row.Column(2), info.Name);
+
+      var sortValue = SortValueText(info);
+      if (sortValue != null)
+        ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled(sortValue));
 
       ImGui.PopID();
       idx++;
@@ -439,4 +1129,5 @@ public static class ManualLoadWindow
     }
     return changed;
   }
+
 }

--- a/StationeersLaunchPad/UI/ModTreePanel.cs
+++ b/StationeersLaunchPad/UI/ModTreePanel.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+using StationeersLaunchPad.Sources;
+
+namespace StationeersLaunchPad.UI;
+
+// Renders the enabled mods as a dependency tree: "library" mods at the top with the
+// mods that depend on them nested underneath. Surfaces missing/disabled dependencies and
+// lets the user enable disabled ones in one click. Returns whether the mod list changed
+// and which mod (if any) the user clicked to inspect.
+public static class ModTreePanel
+{
+  private class DepInfo
+  {
+    public readonly List<ModInfo> DependsOn = [];      // enabled mods this one requires
+    public readonly List<ModInfo> Dependents = [];     // enabled mods that require this one
+    public readonly List<ModReference> Missing = [];   // declared deps that aren't installed
+    public readonly List<ModReference> Disabled = [];  // declared deps installed but disabled
+  }
+
+  public static (bool changed, ModInfo selected) Draw(ModList modList, string search)
+  {
+    var all = modList.AllMods.ToList();
+    var enabled = all.Where(m => m.Enabled).ToList();
+    var info = Resolve(enabled, all);
+
+    // When searching, keep matching mods plus the dependency chain above them.
+    var visible = ComputeVisible(enabled, info, search);
+
+    var changed = DrawLegend(modList, enabled, all, info);
+    ImGui.Separator();
+
+    ModInfo selected = null;
+    var counter = 0;
+
+    // Core first (the game's own assemblies/data).
+    var core = enabled.FirstOrDefault(m => m.Source == ModSourceType.Core);
+    if (core != null && visible.Contains(core))
+      DrawNode(core, info, visible, [], ref counter, ref selected);
+
+    // Dependency roots: enabled mods that require nothing but are required by others.
+    var roots = enabled
+      .Where(m => m.Source != ModSourceType.Core
+        && info[m].DependsOn.Count == 0
+        && info[m].Dependents.Count > 0
+        && visible.Contains(m))
+      .OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase);
+    foreach (var mod in roots)
+      DrawNode(mod, info, visible, [], ref counter, ref selected);
+
+    // Standalone mods: no dependencies and nothing depends on them.
+    var standalone = enabled
+      .Where(m => m.Source != ModSourceType.Core
+        && info[m].DependsOn.Count == 0
+        && info[m].Dependents.Count == 0
+        && visible.Contains(m))
+      .OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
+      .ToList();
+
+    if (standalone.Count > 0)
+    {
+      ImGui.Separator();
+      if (ImGui.TreeNodeEx($"Standalone ({standalone.Count}) - no dependencies",
+          ImGuiTreeNodeFlags.SpanAvailWidth))
+      {
+        foreach (var mod in standalone)
+        {
+          ImGui.PushID(counter++);
+          DrawLeafRow(mod, ref selected);
+          ImGui.PopID();
+        }
+        ImGui.TreePop();
+      }
+    }
+
+    return (changed, selected);
+  }
+
+  private static bool DrawLegend(ModList modList, List<ModInfo> enabled,
+    List<ModInfo> all, Dictionary<ModInfo, DepInfo> info)
+  {
+    var total = enabled.Count(m => m.Source != ModSourceType.Core);
+    var withDeps = enabled.Count(m => info[m].DependsOn.Count > 0);
+    var missing = enabled.Count(m => info[m].Missing.Count > 0);
+
+    ImGuiHelper.TextDisabled($"{total} enabled mods - {withDeps} with dependencies");
+
+    if (missing > 0)
+      ImGuiHelper.TextError($"{missing} mod(s) have missing dependencies (not installed)");
+
+    // Collect the distinct installed-but-disabled mods that an enabled mod requires.
+    var disabledProviders = new HashSet<ModInfo>();
+    foreach (var mod in enabled)
+      foreach (var modRef in info[mod].Disabled)
+        foreach (var provider in all.Where(m => !m.Enabled && m.Satisfies(modRef)))
+          disabledProviders.Add(provider);
+
+    var changed = false;
+    if (disabledProviders.Count > 0)
+    {
+      ImGuiHelper.TextWarning($"{disabledProviders.Count} required mod(s) are installed but disabled");
+      ImGui.SameLine();
+      if (ImGui.Button($"Enable {disabledProviders.Count} disabled dependenc{(disabledProviders.Count == 1 ? "y" : "ies")}"))
+      {
+        var count = modList.EnableDisabledDependencies();
+        Logger.Global.LogInfo($"Enabled {count} missing dependenc{(count == 1 ? "y" : "ies")}");
+        changed = count > 0;
+      }
+      ImGuiHelper.ItemTooltip("Enable every installed mod that an enabled mod depends on (follows chains).");
+    }
+
+    return changed;
+  }
+
+  private static void DrawNode(ModInfo mod, Dictionary<ModInfo, DepInfo> info,
+    HashSet<ModInfo> visible, HashSet<ModInfo> path, ref int counter, ref ModInfo selected)
+  {
+    var dep = info[mod];
+    var children = dep.Dependents
+      .Where(visible.Contains)
+      .OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
+      .ToList();
+    var hasExtras = dep.Missing.Count > 0 || dep.Disabled.Count > 0;
+    var isLeaf = children.Count == 0 && !hasExtras;
+
+    ImGui.PushID(counter++);
+
+    // Guard against dependency cycles.
+    if (path.Contains(mod))
+    {
+      ImGui.Bullet();
+      ImGui.SameLine();
+      ImGuiHelper.TextWarning($"{mod.Name} (cycle)");
+      ImGui.PopID();
+      return;
+    }
+
+    if (isLeaf)
+    {
+      DrawLeafRow(mod, ref selected);
+      ImGui.PopID();
+      return;
+    }
+
+    var flags = ImGuiTreeNodeFlags.SpanAvailWidth | ImGuiTreeNodeFlags.OpenOnArrow
+      | ImGuiTreeNodeFlags.DefaultOpen;
+
+    var open = ImGui.TreeNodeEx($"{mod.Name}", flags);
+    if (ImGui.IsItemClicked())
+      selected = mod;
+    NodeTooltip(mod);
+
+    if (open)
+    {
+      path.Add(mod);
+
+      foreach (var modRef in dep.Missing)
+      {
+        ImGui.Bullet();
+        ImGui.SameLine();
+        ImGuiHelper.TextError($"missing: {modRef}");
+      }
+      foreach (var modRef in dep.Disabled)
+      {
+        ImGui.Bullet();
+        ImGui.SameLine();
+        ImGuiHelper.TextWarning($"disabled: {modRef}");
+      }
+
+      foreach (var child in children)
+        DrawNode(child, info, visible, path, ref counter, ref selected);
+
+      path.Remove(mod);
+      ImGui.TreePop();
+    }
+
+    ImGui.PopID();
+  }
+
+  private static void DrawLeafRow(ModInfo mod, ref ModInfo selected)
+  {
+    ImGui.Bullet();
+    ImGui.SameLine();
+    if (ImGui.Selectable(mod.Name))
+      selected = mod;
+    NodeTooltip(mod);
+  }
+
+  private static void NodeTooltip(ModInfo mod)
+  {
+    if (!ImGui.IsItemHovered())
+      return;
+    var version = string.IsNullOrEmpty(mod.About?.Version) ? "?" : mod.About.Version;
+    var author = string.IsNullOrEmpty(mod.Author) ? "?" : mod.Author;
+    ImGuiHelper.TextTooltip(
+      $"{mod.Name}\nSource: {mod.Source}\nAuthor: {author}\nVersion: {version}\n\nClick to view details");
+  }
+
+  // Resolves dependency edges among enabled mods, and records dependencies that are
+  // missing (not installed at all) or only provided by a disabled mod.
+  private static Dictionary<ModInfo, DepInfo> Resolve(List<ModInfo> enabled, List<ModInfo> all)
+  {
+    var info = new Dictionary<ModInfo, DepInfo>();
+    foreach (var mod in enabled)
+      info[mod] = new DepInfo();
+
+    foreach (var mod in enabled)
+    {
+      if (mod.Source == ModSourceType.Core)
+        continue;
+      foreach (var modRef in mod.About?.DependsOn ?? [])
+      {
+        if (!modRef.IsValid)
+          continue;
+
+        var providers = enabled.Where(m => m != mod && m.Satisfies(modRef)).ToList();
+        if (providers.Count > 0)
+        {
+          foreach (var provider in providers)
+          {
+            info[mod].DependsOn.Add(provider);
+            info[provider].Dependents.Add(mod);
+          }
+        }
+        else if (all.Any(m => m != mod && m.Satisfies(modRef)))
+          info[mod].Disabled.Add(modRef); // installed but disabled
+        else
+          info[mod].Missing.Add(modRef);  // not installed at all
+      }
+    }
+
+    return info;
+  }
+
+  // Returns the set of mods to render: everything when not searching, otherwise the
+  // mods matching the search plus their (transitive) dependencies, so the path stays intact.
+  private static HashSet<ModInfo> ComputeVisible(List<ModInfo> enabled,
+    Dictionary<ModInfo, DepInfo> info, string search)
+  {
+    var visible = new HashSet<ModInfo>();
+    if (string.IsNullOrWhiteSpace(search))
+    {
+      foreach (var mod in enabled)
+        visible.Add(mod);
+      return visible;
+    }
+
+    var q = search.Trim();
+    bool matches(ModInfo m) =>
+      (m.Name?.IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0)
+      || (m.Author?.IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0);
+
+    void markUp(ModInfo m)
+    {
+      if (!visible.Add(m))
+        return;
+      foreach (var parent in info[m].DependsOn)
+        markUp(parent);
+    }
+
+    foreach (var mod in enabled)
+      if (matches(mod))
+        markUp(mod);
+
+    return visible;
+  }
+}

--- a/StationeersLaunchPad/UI/PreLoadCheckPanel.cs
+++ b/StationeersLaunchPad/UI/PreLoadCheckPanel.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+using UnityEngine;
+
+namespace StationeersLaunchPad.UI;
+
+// Colored banner summarising the pre-load health check. Returns a mod the user clicked
+// (to inspect in the Mod Info tab), or null.
+public static class PreLoadCheckPanel
+{
+  public static (ModInfo selected, bool changed) DrawBanner(ModList modList)
+  {
+    if (PreLoadCheck.Current == null)
+      PreLoadCheck.Run(modList);
+    var result = PreLoadCheck.Current;
+    if (result == null)
+      return (null, false);
+
+    ModInfo selected = null;
+    var changed = false;
+
+    if (result.Ok)
+    {
+      ImGuiHelper.TextSuccess("Pre-load check: no problems detected");
+      if (result.Infos > 0
+          && ImGui.TreeNodeEx($"{result.Infos} note(s)###preloadnotes", ImGuiTreeNodeFlags.SpanAvailWidth))
+      {
+        DrawIssues(result, ref selected);
+        ImGui.TreePop();
+      }
+      ImGui.Separator();
+      return (selected, changed);
+    }
+
+    var color = result.Errors > 0 ? ImGuiHelper.Red : ImGuiHelper.Yellow;
+    ImGuiHelper.TextColored(
+      $"Pre-load check: {result.Errors} error(s), {result.Warnings} warning(s)", color);
+
+    changed |= DrawActions(modList, result);
+
+    if (ImGui.TreeNodeEx($"Details ({result.Issues.Count})###preloaddetails",
+        ImGuiTreeNodeFlags.SpanAvailWidth | ImGuiTreeNodeFlags.DefaultOpen))
+    {
+      DrawIssues(result, ref selected);
+      ImGui.TreePop();
+    }
+
+    ImGui.Separator();
+    return (selected, changed);
+  }
+
+  // One-click fixes for the detected problems.
+  private static bool DrawActions(ModList modList, CheckResult result)
+  {
+    var changed = false;
+    var any = false;
+
+    changed |= DisableButton(result, "Incompatible",
+      "Disable {0} incompatible mod(s)",
+      "Disable mods whose code targets game members that no longer exist (incompatible with this game version).",
+      ref any);
+
+    changed |= DisableButton(result, "Previous failure",
+      "Disable {0} previously-failed mod(s)",
+      "Turn off every mod that failed to load in a previous session.",
+      ref any);
+
+    return changed;
+  }
+
+  private static bool DisableButton(CheckResult result, string category, string labelFormat, string tooltip, ref bool any)
+  {
+    var mods = result.Issues
+      .Where(i => i.Category == category && i.Mod != null)
+      .Select(i => i.Mod)
+      .Distinct()
+      .ToList();
+    if (mods.Count == 0)
+      return false;
+
+    if (any)
+      ImGui.SameLine();
+    any = true;
+
+    var changed = false;
+    if (ImGui.Button(string.Format(labelFormat, mods.Count)))
+    {
+      foreach (var mod in mods)
+        mod.Enabled = false;
+      Logger.Global.LogInfo($"Disabled {mods.Count} mod(s) ({category})");
+      changed = true;
+    }
+    ImGuiHelper.ItemTooltip(tooltip);
+    return changed;
+  }
+
+  private static void DrawIssues(CheckResult result, ref ModInfo selected)
+  {
+    var idx = 0;
+    foreach (var issue in result.Issues
+      .OrderByDescending(i => (int)i.Severity)
+      .ThenBy(i => i.Category, StringComparer.OrdinalIgnoreCase))
+    {
+      ImGui.PushID(idx++);
+
+      var color = issue.Severity switch
+      {
+        CheckSeverity.Error => ImGuiHelper.Red,
+        CheckSeverity.Warning => ImGuiHelper.Yellow,
+        _ => ImGuiHelper.TextDisabledColor,
+      };
+
+      ImGui.Bullet();
+      ImGui.SameLine();
+      ImGui.PushStyleColor(ImGuiCol.Text, (Vector4)color);
+      if (ImGui.Selectable($"[{issue.Category}] {issue.Message}") && issue.Mod != null)
+        selected = issue.Mod;
+      ImGui.PopStyleColor();
+
+      ImGui.PopID();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

A reskin of the mod loader window plus a set of mod-management tools. This supersedes #143 (it includes the same sorting / search / readability / JSON export-import work), so #143 can be closed if this lands.

The React/Tailwind design that inspired the look is not included in the repo (kept local); this is a pure ImGui reimplementation using the existing font.

## UI redesign

- New shell: title bar with live status counts (`Active / Disabled / Warn / Err`), a left sidebar (Mod Manager / Dependency Tree / Configuration / About) and the orange Load Mods / Start Game button, plus a collapsible bottom console. Replaces the old status line + right-side tab bar.
- Dark theme with orange accent (`LaunchPadTheme`).
- Mod list: per-row status dots, separate clipped name/author columns (fixes overlap), alternating rows, stronger selection highlight.
- Detail panel: name + status chip, author/workshop id, Version / Updated / Source, description (Steam BBCode stripped), tags, clickable Requires / Required By, and Enable/Disable / Open Folder / Open Workshop Page actions.
- Draggable splitters for the mod-list width and console height, persisted to `ui_layout.xml`.

## Features

- Sorting (load order / name / author / released / updated, asc-desc, optional apply-to-load-order) and a search/filter box.
- Dependency tree view, grouped by `DependsOn`, with a one-click "enable disabled dependencies".
- Pre-load health check (auto-running banner): missing/disabled dependencies, duplicates, circular order, invalid About.xml, Workshop update/removed plus a "possibly outdated" heuristic, and remembered past load failures (`failed_mods.xml`).
- Compatibility scanner using Mono.Cecil: statically inspects enabled mod assemblies (without executing them) for references to game members that no longer exist, and flags them as incompatible before loading, with one-click disable. Catches the runtime `MissingMethodException` family (e.g. a mod patching a removed `SmallGrid.ConnectedDevices()`).
- JSON export/import of the mod list, via a modal folder/file picker.
- `ModInfo.Author/Released/Updated` (Steam metadata for Workshop mods, folder timestamps otherwise).

## Files

15 C# files (8 new), plus a `Mono.Cecil` GameReference in `SLP.common.props`. No new NuGet dependencies (Mono.Cecil ships with BepInEx).

## Notes for reviewers

- Typography does not match the original design 1:1 (ImGui uses the game font atlas; loading custom TTFs at the preloader stage was deemed too risky).
- The compatibility scanner is conservative (name + parameter-count matching, skips generics/ctors) to limit false positives; it does not catch HarmonyPatch attribute-target mismatches (those are caught by the past-failure memory) nor mod-vs-mod-library mismatches.
- Splitter sizes persist to `ui_layout.xml` in the save folder.
- Builds against the game references with `TreatWarningsAsErrors` clean.

## Testing

Exercised in-game on a ~55-mod setup across all stages: sorting/search, drag and drop, dependency tree + enable-deps, pre-load banner + disable actions, compatibility scan flagging incompatible mods, JSON export/import through the picker, and the draggable/persistent splitters.
