### PR TITLE
Mod list sorting, search and readability in the loader UI

### DIFF
--- a/StationeersLaunchPad/Metadata/ModInfo.cs
+++ b/StationeersLaunchPad/Metadata/ModInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,10 +25,16 @@ public class ModInfo
   public ModAboutEx About => Def.About;
   public ModSourceType Source => Def.Type;
   public string Name => About.Name;
+  public string Author => About?.Author ?? "";
   public string DirectoryPath => Def.DirectoryPath;
   public string DirectoryName => new DirectoryInfo(DirectoryPath).Name;
   public ulong WorkshopHandle => Def.WorkshopHandle;
   public string ModID => About.ModID ?? "";
+
+  // Release/update timestamps used for sorting. For Workshop mods these come from
+  // Steam metadata; for Local/Repo mods they fall back to the mod folder timestamps.
+  public DateTime? Released => Def.Created;
+  public DateTime? Updated => Def.Updated;
 
   public string AboutPath => Path.Combine(DirectoryPath, "About");
   public string AboutXmlPath => Path.Combine(AboutPath, "About.xml");

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -312,6 +312,70 @@ public class ModList
     return true;
   }
 
+  // Fields by which the mod list can be sorted in the loader UI.
+  public enum ModSortField { LoadOrder, Name, Author, Released, Updated }
+
+  public static IComparer<ModInfo> GetComparer(ModSortField field, bool descending)
+  {
+    Comparison<ModInfo> cmp = field switch
+    {
+      ModSortField.Name => (a, b) =>
+        string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase),
+      ModSortField.Author => (a, b) =>
+      {
+        var r = string.Compare(a.Author, b.Author, StringComparison.OrdinalIgnoreCase);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      ModSortField.Released => (a, b) =>
+      {
+        var r = Nullable.Compare(a.Released, b.Released);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      ModSortField.Updated => (a, b) =>
+      {
+        var r = Nullable.Compare(a.Updated, b.Updated);
+        return r != 0 ? r : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+      },
+      _ => (a, b) => 0,
+    };
+    return Comparer<ModInfo>.Create(descending ? (a, b) => cmp(b, a) : cmp);
+  }
+
+  // Returns the mods sorted for display, without touching the underlying load order.
+  public List<ModInfo> Sorted(ModSortField field, bool descending)
+  {
+    var list = new List<ModInfo>(mods);
+    if (field != ModSortField.LoadOrder)
+      list.Sort(GetComparer(field, descending));
+    return list;
+  }
+
+  // Rewrites the actual load order to match the given sort. Returns true if anything moved.
+  public bool ApplySort(ModSortField field, bool descending)
+  {
+    if (field == ModSortField.LoadOrder)
+      return false;
+    return SetOrder(Sorted(field, descending));
+  }
+
+  // Replaces the load order with the given permutation of the current mods.
+  // Returns true only when the order actually changed.
+  public bool SetOrder(List<ModInfo> ordered)
+  {
+    if (ordered == null || ordered.Count != mods.Count)
+      return false;
+    var changed = false;
+    for (var i = 0; i < mods.Count; i++)
+      if (!ReferenceEquals(mods[i], ordered[i]))
+      {
+        changed = true;
+        break;
+      }
+    if (changed)
+      mods = ordered;
+    return changed;
+  }
+
   private static string NormalizePath(string path) =>
     path?.Replace("\\", "/").Trim().ToLowerInvariant() ?? string.Empty;
 }

--- a/StationeersLaunchPad/Sources/ModSource.cs
+++ b/StationeersLaunchPad/Sources/ModSource.cs
@@ -1,5 +1,7 @@
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Cysharp.Threading.Tasks;
 using StationeersLaunchPad.Metadata;
 using StationeersLaunchPad.Repos;
@@ -51,4 +53,18 @@ public abstract class ModDefinition(ModAboutEx about)
   public abstract ulong WorkshopHandle { get; }
   public abstract string DirectoryPath { get; }
   public abstract ModData ToModData(bool enabled);
+
+  // Release/update timestamps used by the mod loader UI for sorting.
+  // Workshop mods override these with Steam metadata; otherwise we fall back to
+  // the mod folder's filesystem creation/last-write time. Returns null when unknown.
+  public virtual DateTime? Created => GetDirTime(lastWrite: false);
+  public virtual DateTime? Updated => GetDirTime(lastWrite: true);
+
+  protected DateTime? GetDirTime(bool lastWrite)
+  {
+    var path = DirectoryPath;
+    if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+      return null;
+    return lastWrite ? Directory.GetLastWriteTime(path) : Directory.GetCreationTime(path);
+  }
 }

--- a/StationeersLaunchPad/Sources/Workshop.cs
+++ b/StationeersLaunchPad/Sources/Workshop.cs
@@ -45,6 +45,8 @@ public class WorkshopModDefinition(Item item, ModAboutEx about) : ModDefinition(
   public override ModSourceType Type => ModSourceType.Workshop;
   public override ulong WorkshopHandle => Item.Id;
   public override string DirectoryPath => Item.Directory;
+  public override System.DateTime? Created => Item.Created;
+  public override System.DateTime? Updated => Item.Updated;
   public override ModData ToModData(bool enabled) => new WorkshopModData(
     SteamTransport.ItemWrapper.WrapWorkshopItem(Item, "About/About.xml"),
     enabled

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using ImGuiNET;
 using StationeersLaunchPad.Loading;
 using StationeersLaunchPad.Metadata;
@@ -24,6 +26,19 @@ public static class ManualLoadWindow
   private static bool openInfo = false;
   private static ModInfo draggingMod = null;
   private static bool dragged = false;
+
+  // Mod list sorting/filtering state (see DrawModListTools / DrawSearchAndCount)
+  private static ModList.ModSortField sortField = ModList.ModSortField.LoadOrder;
+  private static bool sortDescending = false;
+  private static bool sortApplyToLoadOrder = false;
+  private static string searchText = "";
+
+  private static readonly string[] SortFieldLabels =
+    { "Load order", "Name", "Author", "Released", "Updated" };
+
+  // Subtle background tint for alternating list rows (zebra striping).
+  private static uint RowAltColor =>
+    ImGui.ColorConvertFloat4ToU32(new Color(1f, 1f, 1f, 0.045f));
 
   public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort)
   {
@@ -70,7 +85,13 @@ public static class ManualLoadWindow
       }
       else if (stage is LoadStage.Loading or LoadStage.Loaded)
       {
+        DrawModListToolbar(modList, loaded: true);
+        ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetStyle().ItemSpacing.y);
+        ImGui.Separator();
+        leftRect = leftRect.From(ImGui.GetCursorScreenPos());
+        ImGui.BeginChild("##loadtable", leftRect.Size);
         DrawLoadTable(modList);
+        ImGui.EndChild();
       }
       ImGui.EndChild();
 
@@ -237,10 +258,153 @@ public static class ManualLoadWindow
       }
     }
 
+    changed |= DrawModListToolbar(modList, loaded: false);
+
     ImGui.SetCursorPosY(ImGui.GetCursorPosY() - ImGui.GetStyle().ItemSpacing.y);
     ImGui.Separator();
 
     return changed;
+  }
+
+  // Full toolbar above the mod list: sort controls, search box, counters and column headers.
+  private static ChangeFlags DrawModListToolbar(ModList modList, bool loaded)
+  {
+    var changed = DrawModListTools(modList, loaded);
+    DrawSearchAndCount(modList, loaded);
+    DrawColumnHeader(loaded);
+    return changed;
+  }
+
+  // Sort selector: field combo, direction toggle and an optional "apply to load order" switch.
+  // When loaded is true the mods are already loaded, so the load-order switch is hidden and
+  // sorting only changes how the list is displayed.
+  private static ChangeFlags DrawModListTools(ModList modList, bool loaded)
+  {
+    var changed = ChangeFlags.None;
+
+    ImGui.AlignTextToFramePadding();
+    ImGuiHelper.Text("Sort:");
+
+    ImGui.SameLine();
+    ImGui.SetNextItemWidth(140f);
+    var cur = (int)sortField;
+    if (ImGui.Combo("##sortfield", ref cur, SortFieldLabels, SortFieldLabels.Length))
+    {
+      sortField = (ModList.ModSortField)cur;
+      if (!loaded && sortApplyToLoadOrder && modList.ApplySort(sortField, sortDescending))
+        changed |= ChangeFlags.Mods;
+    }
+    ImGuiHelper.ItemTooltip(
+      "Order the mod list by load order, name, author, release date or last update.\n" +
+      "Release/update dates come from Steam for Workshop mods; for local mods the mod " +
+      "folder timestamps are used as a fallback.");
+
+    ImGui.SameLine();
+    if (ImGui.Button(sortDescending ? "Desc" : "Asc"))
+    {
+      sortDescending = !sortDescending;
+      if (!loaded && sortApplyToLoadOrder && modList.ApplySort(sortField, sortDescending))
+        changed |= ChangeFlags.Mods;
+    }
+    ImGuiHelper.ItemTooltip("Toggle ascending/descending order.");
+
+    if (!loaded)
+    {
+      ImGui.SameLine();
+      if (ImGui.Checkbox("Apply to load order", ref sortApplyToLoadOrder)
+          && sortApplyToLoadOrder
+          && modList.ApplySort(sortField, sortDescending))
+        changed |= ChangeFlags.Mods;
+      ImGuiHelper.ItemTooltip(
+        "On: sorting also rewrites the real mod load order (drag & drop is disabled while a sort is active).\n" +
+        "Off: sorting only changes how the list is displayed; the load order is left untouched.");
+    }
+
+    return changed;
+  }
+
+  private static string SortValueText(ModInfo mod) => sortField switch
+  {
+    ModList.ModSortField.Author => string.IsNullOrEmpty(mod.Author) ? "-" : mod.Author,
+    ModList.ModSortField.Released => mod.Released?.ToString("yyyy-MM-dd") ?? "-",
+    ModList.ModSortField.Updated => mod.Updated?.ToString("yyyy-MM-dd") ?? "-",
+    _ => null,
+  };
+
+  // True when the mod matches the current search text (by name or author).
+  private static bool MatchesSearch(ModInfo mod)
+  {
+    if (string.IsNullOrWhiteSpace(searchText))
+      return true;
+    var q = searchText.Trim();
+    return (mod.Name?.IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0)
+        || (mod.Author?.IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0);
+  }
+
+  // Search box + counters row.
+  private static void DrawSearchAndCount(ModList modList, bool loaded)
+  {
+    ImGui.AlignTextToFramePadding();
+    ImGuiHelper.Text("Search:");
+
+    ImGui.SameLine();
+    ImGui.SetNextItemWidth(200f);
+    ImGui.InputTextWithHint("##modsearch", "name or author...", ref searchText, 256);
+
+    if (!string.IsNullOrEmpty(searchText))
+    {
+      ImGui.SameLine();
+      if (ImGui.Button("Clear##search"))
+        searchText = "";
+    }
+
+    int total = 0, enabled = 0, shown = 0;
+    if (loaded)
+    {
+      total = enabled = ModLoader.LoadedMods.Count;
+      shown = ModLoader.LoadedMods.Count(m => MatchesSearch(m.Info));
+    }
+    else
+    {
+      foreach (var mod in modList.AllMods)
+      {
+        if (mod.Source == ModSourceType.Core)
+          continue;
+        total++;
+        if (mod.Enabled)
+          enabled++;
+        if (MatchesSearch(mod))
+          shown++;
+      }
+    }
+
+    ImGui.SameLine();
+    ImGuiHelper.TextDisabled("|", true);
+    ImGui.SameLine();
+    var countText = loaded ? $"Loaded: {total}" : $"Enabled: {enabled} / {total}";
+    if (!string.IsNullOrWhiteSpace(searchText))
+      countText += $"   (showing {shown})";
+    ImGuiHelper.TextDisabled(countText);
+  }
+
+  // Fixed (non-scrolling) column headers aligned with the table columns below.
+  private static void DrawColumnHeader(bool loaded)
+  {
+    var spacing = ImGui.GetStyle().ItemSpacing.x * 2;
+    var c0 = loaded
+      ? ImGui.CalcTextSize("XXX").x + spacing
+      : ImGui.GetTextLineHeightWithSpacing() + spacing;
+    var c1 = ImGui.CalcTextSize($"{ModSourceType.Workshop}").x + spacing;
+
+    var available = ImGuiHelper.AvailableRect();
+    var row = available.TableRow(ImGui.GetTextLineHeightWithSpacing(), stackalloc[] { c0, c1 });
+
+    ImGuiHelper.TextCentered(row.Column(1), "Source");
+
+    var nameHeader = "Name";
+    if (sortField != ModList.ModSortField.LoadOrder)
+      nameHeader = $"Name   (by {SortFieldLabels[(int)sortField]} {(sortDescending ? "v" : "^")})";
+    ImGuiHelper.Text(row.Column(2), nameHeader);
   }
 
   private static bool DrawModSelectTable(ModList modList, bool edit = false, bool autoSort = false)
@@ -259,10 +423,19 @@ public static class ManualLoadWindow
       dragged = false;
     }
 
+    // Display order may differ from the real load order when a sort/search is active.
+    // Drag & drop reordering is only allowed when showing the full, unsorted load order.
+    var displayMods = modList.Sorted(sortField, sortDescending);
+    if (!string.IsNullOrWhiteSpace(searchText))
+      displayMods = displayMods.Where(MatchesSearch).ToList();
+    var canReorder = edit
+      && sortField == ModList.ModSortField.LoadOrder
+      && string.IsNullOrWhiteSpace(searchText);
+
     var hoveringIndex = -1;
     var draggingIndex = -1;
     if (draggingMod != null)
-      draggingIndex = modList.IndexOf(draggingMod);
+      draggingIndex = displayMods.IndexOf(draggingMod);
 
     var rowHeight = ImGui.GetTextLineHeightWithSpacing();
     var spacing = ImGui.GetStyle().ItemSpacing.x * 2;
@@ -280,9 +453,12 @@ public static class ManualLoadWindow
     ImGui.BeginDisabled(!edit);
 
     var idx = 0;
-    foreach (var mod in modList.AllMods)
+    foreach (var mod in displayMods)
     {
       ImGui.PushID(idx);
+
+      if ((idx & 1) == 1)
+        ImGui.GetWindowDrawList().AddRectFilled(row.Rect.TL, row.Rect.BR, RowAltColor);
 
       ImGui.SetCursorScreenPos(row.Column(0).TL);
       ImGui.BeginDisabled(mod.Source is ModSourceType.Core);
@@ -308,11 +484,19 @@ public static class ManualLoadWindow
 
       ImGuiHelper.Text(row.Column(2), $"{mod.Name}");
 
-      if (draggingMod != null)
+      if (draggingMod != null && canReorder)
+      {
         if (mod.SortBefore(draggingMod))
           ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled("Before"));
         else if (draggingMod.SortBefore(mod))
           ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled("After"));
+      }
+      else
+      {
+        var sortValue = SortValueText(mod);
+        if (sortValue != null)
+          ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled(sortValue));
+      }
 
       ImGui.PopID();
 
@@ -322,7 +506,7 @@ public static class ManualLoadWindow
 
     ImGui.EndDisabled();
 
-    if (edit && draggingIndex != -1 && hoveringIndex != -1 && draggingIndex != hoveringIndex)
+    if (canReorder && draggingIndex != -1 && hoveringIndex != -1 && draggingIndex != hoveringIndex)
     {
       dragged = true;
       if (modList.MoveModTo(draggingMod, hoveringIndex, autoSort))
@@ -345,12 +529,28 @@ public static class ManualLoadWindow
       ImGui.CalcTextSize($"{ModSourceType.Workshop}").x + spacing
     });
 
+    // Apply the same view sorting/search as the pre-load list. The actual load order is
+    // fixed at this point, so this only changes how the loaded mods are displayed.
+    IEnumerable<LoadedMod> loadedMods = ModLoader.LoadedMods;
+    if (sortField != ModList.ModSortField.LoadOrder)
+    {
+      var cmp = ModList.GetComparer(sortField, sortDescending);
+      var sorted = new List<LoadedMod>(ModLoader.LoadedMods);
+      sorted.Sort((a, b) => cmp.Compare(a.Info, b.Info));
+      loadedMods = sorted;
+    }
+    if (!string.IsNullOrWhiteSpace(searchText))
+      loadedMods = loadedMods.Where(m => MatchesSearch(m.Info));
+
     var idx = 0;
-    foreach (var mod in ModLoader.LoadedMods)
+    foreach (var mod in loadedMods)
     {
       ImGui.PushID(idx);
       var info = mod.Info;
       var isSelected = selectedMod == mod;
+
+      if ((idx & 1) == 1)
+        ImGui.GetWindowDrawList().AddRectFilled(row.Rect.TL, row.Rect.BR, RowAltColor);
 
       ImGui.SetCursorScreenPos(row.Rect.TL);
       if (ImGui.Selectable("##scopeselect", isSelected, row.Rect.Size))
@@ -364,6 +564,10 @@ public static class ManualLoadWindow
       ImGuiHelper.TextCentered(row.Column(1), $"{info.Source}");
 
       ImGuiHelper.Text(row.Column(2), info.Name);
+
+      var sortValue = SortValueText(info);
+      if (sortValue != null)
+        ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextRightDisabled(sortValue));
 
       ImGui.PopID();
       idx++;


### PR DESCRIPTION
## What

Adds display-level usability to the existing mod loader window, with no change to the window's layout or theme:

- Sorting by load order, name, author, release date or last update (ascending/descending). Sorting is display-only by default; an optional "Apply to load order" switch rewrites the real load order when wanted. Drag and drop reordering stays available when no sort or search is active.
- A search box to filter mods by name or author.
- Readability: zebra striping, fixed column headers, and an enabled/total counter (with a result count while filtering).
- Author/Released/Updated accessors on ModInfo. Release and update dates come from Steam for Workshop mods and fall back to the mod folder's filesystem timestamps for local and repo mods.

Applies to both the pre-load configuration screen and the post-load screen (where sorting and search are display-only since the load order is fixed).

## Why this is its own PR

This is the smallest, safe slice of the larger UI work: pure readability and sorting on the current layout, with no new shell, theme or storage. It is useful on its own and easy to review in isolation.

## Scope and dependencies

- No theme, no new window shell, no new storage format, no new dependencies.
- Foundational for the rest of the split. The ModInfo date/author metadata added here is reused by the compatibility and redesign PRs.
- Builds clean (0 warnings, 0 errors).

Part of the split of #144 into smaller, reviewable PRs.
