### PR TITLE
Feat/workshop betachannel

### DIFF
--- a/StationeersLaunchPad/Metadata/ModAbout.cs
+++ b/StationeersLaunchPad/Metadata/ModAbout.cs
@@ -41,6 +41,12 @@ public class ModAboutEx
   [XmlElement("WorkshopHandle")]
   public ulong WorkshopHandle;
 
+  [XmlElement("BetaProgram")]
+  public ModReference BetaProgram;
+
+  [XmlElement("IsBetaProgramMod")]
+  public bool IsBetaProgramMod;
+
   [XmlArray("Tags"), XmlArrayItem("Tag")]
   public List<string> Tags;
 

--- a/StationeersLaunchPad/Metadata/ModInfo.cs
+++ b/StationeersLaunchPad/Metadata/ModInfo.cs
@@ -28,6 +28,9 @@ public class ModInfo
   public string DirectoryName => new DirectoryInfo(DirectoryPath).Name;
   public ulong WorkshopHandle => Def.WorkshopHandle;
   public string ModID => About.ModID ?? "";
+  public bool HasBetaProgram => About?.BetaProgram?.WorkshopHandle > 1;
+  public ulong BetaWorkshopHandle => HasBetaProgram ? About.BetaProgram.WorkshopHandle : 0;
+  public bool IsBetaProgramMod => About?.IsBetaProgramMod ?? false;
 
   public string AboutPath => Path.Combine(DirectoryPath, "About");
   public string AboutXmlPath => Path.Combine(AboutPath, "About.xml");
@@ -67,4 +70,17 @@ public class ModInfo
       return true;
     return !string.IsNullOrEmpty(modRef.ModID) && ModID == modRef.ModID;
   }
+
+  public bool IsBetaProgramFor(ModInfo mod)
+  {
+    var beta = About?.BetaProgram;
+    if (beta == null)
+      return false;
+    if (beta.WorkshopHandle > 1)
+      return beta.WorkshopHandle == mod.WorkshopHandle;
+    return !string.IsNullOrEmpty(beta.ModID) && beta.ModID == mod.ModID;
+  }
+
+  public bool IsBetaRelated(ModInfo mod) =>
+    IsBetaProgramFor(mod) || mod.IsBetaProgramFor(this);
 }

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -15,6 +15,8 @@ public class ModList
   public IEnumerable<ModInfo> AllMods => mods;
   public IEnumerable<ModInfo> EnabledMods => mods.Where(mod => mod.Enabled);
   public int IndexOf(ModInfo mod) => mods.IndexOf(mod);
+  public bool IsBetaMod(ModInfo mod) =>
+    mod.IsBetaProgramMod || mods.Any(stable => stable != mod && stable.IsBetaProgramFor(mod));
 
   public static ModList NewEmpty() => new();
   public static ModList FromDefs(List<ModDefinition> defs)

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -178,6 +178,12 @@ public class ModList
         prefMods.Add(mod);
         continue;
       }
+      if (pref.IsBetaRelated(mod))
+      {
+        Logger.Global.LogDebug($"Beta program pair detected for {mod.Name}, skipping duplicate handling");
+        prefMods.AddBetaRelated(mod);
+        continue;
+      }
       var nonPref = mod;
       var prefPrio = pref.Source switch
       {

--- a/StationeersLaunchPad/Metadata/ModSet.cs
+++ b/StationeersLaunchPad/Metadata/ModSet.cs
@@ -18,6 +18,13 @@ public class ModSet
     all.Add(mod);
   }
 
+  public void AddBetaRelated(ModInfo mod)
+  {
+    if (mod.WorkshopHandle > 1)
+      byWorkshopHandle[mod.WorkshopHandle] = mod;
+    all.Add(mod);
+  }
+
   public bool TryGetExisting(ModInfo mod, out ModInfo existing)
   {
     if (mod.WorkshopHandle > 1 && byWorkshopHandle.TryGetValue(mod.WorkshopHandle, out existing))

--- a/StationeersLaunchPad/News/NewsRunner.cs
+++ b/StationeersLaunchPad/News/NewsRunner.cs
@@ -5,8 +5,6 @@ using Cysharp.Threading.Tasks;
 using StationeersLaunchPad;
 using StationeersLaunchPad.Metadata;
 using StationeersLaunchPad.Repos;
-using Steamworks.Data;
-using Steamworks.Ugc;
 using UnityEngine;
 
 namespace StationeersLaunchPad.News;
@@ -165,56 +163,6 @@ public static class NewsRunner
       return false;
     }
 
-    try
-    {
-      var pfid = new PublishedFileId { Value = wid };
-      var item = new Item(pfid);
-
-      Logger.Global.LogInfo($"news: subscribing to workshop item {wid}");
-      bool subOk = await item.Subscribe();
-      if (!subOk)
-      {
-        Logger.Global.LogError($"news: Subscribe() returned false for workshop {wid}");
-        return false;
-      }
-
-      Logger.Global.LogInfo($"news: downloading workshop item {wid}");
-      bool dlOk = await item.DownloadAsync();
-      if (!dlOk)
-      {
-        Logger.Global.LogError($"news: DownloadAsync() failed or was not successful for workshop {wid}");
-        return false;
-      }
-
-      Logger.Global.LogInfo($"news: workshop mod {wid} subscribed and downloaded successfully");
-
-      if (unsubscribeWorkshopId.HasValue)
-      {
-        var oldWid = unsubscribeWorkshopId.Value;
-        if (oldWid > 1 && oldWid != wid)
-        {
-          try
-          {
-            var oldPfid = new PublishedFileId { Value = oldWid };
-            var oldItem = new Item(oldPfid);
-            bool unsubOk = await oldItem.Unsubscribe();
-            Logger.Global.LogInfo($"news: unsubscribed old workshop {oldWid} (success={unsubOk})");
-          }
-          catch (Exception ex)
-          {
-            Logger.Global.LogException(ex);
-            // Unsubscribe failure should not fail the overall migration
-          }
-        }
-      }
-
-      return true;
-    }
-    catch (Exception ex)
-    {
-      Logger.Global.LogException(ex);
-      Logger.Global.LogError("news: workshop_mod_install failed");
-      return false;
-    }
+    return await Steam.SubscribeAndDownload(wid, unsubscribeWorkshopId);
   }
 }

--- a/StationeersLaunchPad/Steam.cs
+++ b/StationeersLaunchPad/Steam.cs
@@ -104,19 +104,7 @@ public static class Steam
       Logger.Global.LogInfo($"Workshop item {workshopId} subscribed and downloaded successfully");
 
       if (unsubscribeWorkshopId is > 1 && unsubscribeWorkshopId != workshopId)
-      {
-        try
-        {
-          var oldItem = new Item(new PublishedFileId { Value = unsubscribeWorkshopId.Value });
-          var unsubscribed = await oldItem.Unsubscribe();
-          Logger.Global.LogInfo($"Unsubscribed old workshop {unsubscribeWorkshopId} (success={unsubscribed})");
-        }
-        catch (Exception ex)
-        {
-          Logger.Global.LogException(ex);
-          // Unsubscribe failure should not fail the completed install
-        }
-      }
+        await Unsubscribe(unsubscribeWorkshopId.Value);
 
       return true;
     }
@@ -124,6 +112,26 @@ public static class Steam
     {
       Logger.Global.LogException(ex);
       Logger.Global.LogError($"Workshop install failed for {workshopId}");
+      return false;
+    }
+  }
+
+  public static async UniTask<bool> Unsubscribe(ulong workshopId)
+  {
+    if (workshopId < 2)
+      return false;
+
+    try
+    {
+      var item = new Item(new PublishedFileId { Value = workshopId });
+      var unsubscribed = await item.Unsubscribe();
+      Logger.Global.LogInfo($"Unsubscribed workshop item {workshopId} (success={unsubscribed})");
+      return unsubscribed;
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      Logger.Global.LogError($"Workshop unsubscribe failed for {workshopId}");
       return false;
     }
   }

--- a/StationeersLaunchPad/Steam.cs
+++ b/StationeersLaunchPad/Steam.cs
@@ -7,6 +7,7 @@ using Cysharp.Threading.Tasks;
 using StationeersLaunchPad.Metadata;
 using StationeersLaunchPad.Sources;
 using Steamworks;
+using Steamworks.Data;
 using Steamworks.Ugc;
 using UnityEngine;
 
@@ -75,6 +76,56 @@ public static class Steam
     return !result.HasValue || result.Value.ResultCount == 0
       ? []
       : [.. result.Value.Entries.Where(item => item.Result != Result.FileNotFound)];
+  }
+
+  public static async UniTask<bool> SubscribeAndDownload(ulong workshopId, ulong? unsubscribeWorkshopId = null)
+  {
+    if (workshopId < 2)
+      return false;
+
+    try
+    {
+      var item = new Item(new PublishedFileId { Value = workshopId });
+
+      Logger.Global.LogInfo($"Subscribing to workshop item {workshopId}");
+      if (!await item.Subscribe())
+      {
+        Logger.Global.LogError($"Subscribe() returned false for workshop {workshopId}");
+        return false;
+      }
+
+      Logger.Global.LogInfo($"Downloading workshop item {workshopId}");
+      if (!await item.DownloadAsync())
+      {
+        Logger.Global.LogError($"DownloadAsync() failed or was not successful for workshop {workshopId}");
+        return false;
+      }
+
+      Logger.Global.LogInfo($"Workshop item {workshopId} subscribed and downloaded successfully");
+
+      if (unsubscribeWorkshopId is > 1 && unsubscribeWorkshopId != workshopId)
+      {
+        try
+        {
+          var oldItem = new Item(new PublishedFileId { Value = unsubscribeWorkshopId.Value });
+          var unsubscribed = await oldItem.Unsubscribe();
+          Logger.Global.LogInfo($"Unsubscribed old workshop {unsubscribeWorkshopId} (success={unsubscribed})");
+        }
+        catch (Exception ex)
+        {
+          Logger.Global.LogException(ex);
+          // Unsubscribe failure should not fail the completed install
+        }
+      }
+
+      return true;
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      Logger.Global.LogError($"Workshop install failed for {workshopId}");
+      return false;
+    }
   }
 
   public static (bool, string) ValidateForWorkshop(ModInfo mod)

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -81,6 +81,17 @@ public static class BetaProgramsPanel
           Steam.OpenWorkshopPage(stable.WorkshopHandle);
       }
 
+      if (beta?.Enabled == true && stable.Enabled)
+        ImGuiHelper.TextWarning("Stable and beta are both enabled.");
+      else if (beta?.Enabled == true)
+        ImGuiHelper.TextWarning("Beta is active.");
+      else if (stable.Enabled)
+        ImGuiHelper.TextDisabled("Stable is active.");
+      else if (beta != null)
+        ImGuiHelper.TextDisabled("Both versions are disabled.");
+      else
+        ImGuiHelper.TextDisabled("Stable is disabled.");
+
       if (statuses.TryGetValue(stable.BetaWorkshopHandle, out var status))
         ImGuiHelper.TextDisabled(status);
       ImGui.Separator();
@@ -129,7 +140,9 @@ public static class BetaProgramsPanel
     stable.Enabled = !enabled;
     beta.Enabled = enabled;
     Logger.Global.LogInfo($"Switched {stable.Name} to {(enabled ? "beta" : "stable")}");
-    if (!enabled)
+    if (enabled)
+      statuses.Remove(beta.WorkshopHandle);
+    else
       UnsubscribeFromBeta(stable, beta, modList).Forget();
     return true;
   }
@@ -151,7 +164,7 @@ public static class BetaProgramsPanel
 
       stable.Enabled = false;
       ModConfigUtil.SaveConfig(modList.ToModConfig());
-      statuses[workshopId] = "Beta downloaded and enabled.";
+      statuses.Remove(workshopId);
       LaunchPadConfig.ReloadMods();
     }
     finally
@@ -178,7 +191,7 @@ public static class BetaProgramsPanel
         return;
       }
 
-      statuses[workshopId] = "Beta unsubscribed.";
+      statuses.Remove(workshopId);
       LaunchPadConfig.ReloadMods();
     }
     finally

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -8,10 +8,10 @@ namespace StationeersLaunchPad.UI;
 
 public static class BetaProgramsPanel
 {
-  private static readonly HashSet<ulong> downloads = [];
+  private static readonly HashSet<ulong> operations = [];
   private static readonly Dictionary<ulong, string> statuses = [];
 
-  public static bool Busy => downloads.Count > 0;
+  public static bool Busy => operations.Count > 0;
 
   public static bool Draw(LoadStage stage, ModList modList)
   {
@@ -24,7 +24,7 @@ public static class BetaProgramsPanel
       .GroupBy(mod => mod.BetaWorkshopHandle)
       .Select(mods => mods.FirstOrDefault(mod => mod.Enabled) ?? mods.First())
       .ToList();
-    var betaMods = modList.AllMods.Where(mod => mod.IsBetaProgramMod).ToList();
+    var betaMods = modList.AllMods.Where(modList.IsBetaMod).ToList();
 
     ImGui.BeginDisabled(stage != LoadStage.Configuring || Busy);
     if (ImGui.Button("Refresh subscribed betas"))
@@ -45,7 +45,7 @@ public static class BetaProgramsPanel
     {
       var beta = modList.AllMods.FirstOrDefault(mod =>
         mod.WorkshopHandle == stable.BetaWorkshopHandle);
-      var downloading = downloads.Contains(stable.BetaWorkshopHandle);
+      var busy = operations.Contains(stable.BetaWorkshopHandle);
 
       ImGui.PushID($"beta-{stable.BetaWorkshopHandle}");
       ImGui.Spacing();
@@ -57,21 +57,23 @@ public static class BetaProgramsPanel
 
       if (beta == null)
       {
-        ImGui.BeginDisabled(stage != LoadStage.Configuring || downloading);
-        if (ImGui.Button(downloading ? "Downloading..." : "Subscribe to Beta"))
+        ImGui.BeginDisabled(stage != LoadStage.Configuring || busy);
+        if (ImGui.Button(busy ? "Downloading..." : "Subscribe to Beta"))
           SubscribeToBeta(stable, modList).Forget();
         ImGui.EndDisabled();
       }
       else
       {
         var useBeta = beta.Enabled;
-        ImGui.BeginDisabled(stage != LoadStage.Configuring);
+        ImGui.BeginDisabled(stage != LoadStage.Configuring || busy);
         if (ImGui.Checkbox("Use Beta Version", ref useBeta))
         {
           stable.Enabled = !useBeta;
           beta.Enabled = useBeta;
           changed = true;
           Logger.Global.LogInfo($"Switched {stable.Name} to {(useBeta ? "beta" : "stable")}");
+          if (!useBeta)
+            UnsubscribeFromBeta(stable, beta, modList).Forget();
         }
         ImGui.EndDisabled();
       }
@@ -109,7 +111,7 @@ public static class BetaProgramsPanel
   private static async UniTask SubscribeToBeta(ModInfo stable, ModList modList)
   {
     var workshopId = stable.BetaWorkshopHandle;
-    if (!downloads.Add(workshopId))
+    if (!operations.Add(workshopId))
       return;
 
     statuses[workshopId] = "Subscribing and downloading...";
@@ -128,7 +130,34 @@ public static class BetaProgramsPanel
     }
     finally
     {
-      downloads.Remove(workshopId);
+      operations.Remove(workshopId);
+    }
+  }
+
+  private static async UniTask UnsubscribeFromBeta(ModInfo stable, ModInfo beta, ModList modList)
+  {
+    var workshopId = beta.WorkshopHandle;
+    if (!operations.Add(workshopId))
+      return;
+
+    stable.Enabled = true;
+    beta.Enabled = false;
+    ModConfigUtil.SaveConfig(modList.ToModConfig());
+    statuses[workshopId] = "Unsubscribing from beta...";
+    try
+    {
+      if (!await Steam.Unsubscribe(workshopId))
+      {
+        statuses[workshopId] = "Unsubscribe failed. The beta remains disabled.";
+        return;
+      }
+
+      statuses[workshopId] = "Beta unsubscribed.";
+      LaunchPadConfig.ReloadMods();
+    }
+    finally
+    {
+      operations.Remove(workshopId);
     }
   }
 }

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -67,14 +67,7 @@ public static class BetaProgramsPanel
         var useBeta = beta.Enabled;
         ImGui.BeginDisabled(stage != LoadStage.Configuring || busy);
         if (ImGui.Checkbox("Use Beta Version", ref useBeta))
-        {
-          stable.Enabled = !useBeta;
-          beta.Enabled = useBeta;
-          changed = true;
-          Logger.Global.LogInfo($"Switched {stable.Name} to {(useBeta ? "beta" : "stable")}");
-          if (!useBeta)
-            UnsubscribeFromBeta(stable, beta, modList).Forget();
-        }
+          changed = SetBetaEnabled(stable, beta, modList, useBeta);
         ImGui.EndDisabled();
       }
 
@@ -106,6 +99,39 @@ public static class BetaProgramsPanel
 
     ImGui.EndTabItem();
     return changed;
+  }
+
+  public static bool SetModEnabled(ModList modList, ModInfo mod, bool enabled)
+  {
+    if (modList.IsBetaMod(mod))
+    {
+      var stable = modList.AllMods.FirstOrDefault(stable => stable.IsBetaProgramFor(mod));
+      if (stable != null)
+        return SetBetaEnabled(stable, mod, modList, enabled);
+    }
+    else if (enabled && mod.HasBetaProgram)
+    {
+      var beta = modList.AllMods.FirstOrDefault(beta =>
+        beta.WorkshopHandle == mod.BetaWorkshopHandle);
+      if (beta?.Enabled == true)
+        return SetBetaEnabled(mod, beta, modList, false);
+    }
+
+    mod.Enabled = enabled;
+    return true;
+  }
+
+  private static bool SetBetaEnabled(ModInfo stable, ModInfo beta, ModList modList, bool enabled)
+  {
+    if (operations.Contains(beta.WorkshopHandle))
+      return false;
+
+    stable.Enabled = !enabled;
+    beta.Enabled = enabled;
+    Logger.Global.LogInfo($"Switched {stable.Name} to {(enabled ? "beta" : "stable")}");
+    if (!enabled)
+      UnsubscribeFromBeta(stable, beta, modList).Forget();
+    return true;
   }
 
   private static async UniTask SubscribeToBeta(ModInfo stable, ModList modList)

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cysharp.Threading.Tasks;
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+
+namespace StationeersLaunchPad.UI;
+
+public static class BetaProgramsPanel
+{
+  private static readonly HashSet<ulong> downloads = [];
+  private static readonly Dictionary<ulong, string> statuses = [];
+
+  public static bool Busy => downloads.Count > 0;
+
+  public static bool Draw(LoadStage stage, ModList modList)
+  {
+    var changed = false;
+    if (!ImGui.BeginTabItem("Betas"))
+      return changed;
+
+    var stableMods = modList.AllMods
+      .Where(mod => mod.HasBetaProgram)
+      .GroupBy(mod => mod.BetaWorkshopHandle)
+      .Select(mods => mods.FirstOrDefault(mod => mod.Enabled) ?? mods.First())
+      .ToList();
+    var betaMods = modList.AllMods.Where(mod => mod.IsBetaProgramMod).ToList();
+
+    ImGui.BeginDisabled(stage != LoadStage.Configuring || Busy);
+    if (ImGui.Button("Refresh subscribed betas"))
+      LaunchPadConfig.ReloadMods();
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(stage == LoadStage.Configuring
+      ? "Reload the current local and workshop mod list."
+      : "The mod list can only be refreshed before loading mods.",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
+
+    if (stableMods.Count == 0 && betaMods.Count == 0)
+    {
+      ImGui.Spacing();
+      ImGuiHelper.TextDisabled("No installed mods advertise a beta program.");
+    }
+
+    foreach (var stable in stableMods)
+    {
+      var beta = modList.AllMods.FirstOrDefault(mod =>
+        mod.WorkshopHandle == stable.BetaWorkshopHandle);
+      var downloading = downloads.Contains(stable.BetaWorkshopHandle);
+
+      ImGui.PushID($"beta-{stable.BetaWorkshopHandle}");
+      ImGui.Spacing();
+      ImGuiHelper.Text(stable.Name);
+      ImGuiHelper.TextDisabled($"Stable: {stable.About?.Version ?? "Unknown"} ({stable.WorkshopHandle})");
+      ImGuiHelper.TextDisabled(beta == null
+        ? $"Beta: not subscribed ({stable.BetaWorkshopHandle})"
+        : $"Beta: {beta.About?.Version ?? "Unknown"} ({beta.WorkshopHandle})");
+
+      if (beta == null)
+      {
+        ImGui.BeginDisabled(stage != LoadStage.Configuring || downloading);
+        if (ImGui.Button(downloading ? "Downloading..." : "Subscribe to Beta"))
+          SubscribeToBeta(stable, modList).Forget();
+        ImGui.EndDisabled();
+      }
+      else
+      {
+        var useBeta = beta.Enabled;
+        ImGui.BeginDisabled(stage != LoadStage.Configuring);
+        if (ImGui.Checkbox("Use Beta Version", ref useBeta))
+        {
+          stable.Enabled = !useBeta;
+          beta.Enabled = useBeta;
+          changed = true;
+          Logger.Global.LogInfo($"Switched {stable.Name} to {(useBeta ? "beta" : "stable")}");
+        }
+        ImGui.EndDisabled();
+      }
+
+      ImGui.SameLine();
+      if (ImGui.Button("Open Beta Workshop Page"))
+        Steam.OpenWorkshopPage(stable.BetaWorkshopHandle);
+      if (stable.WorkshopHandle > 1)
+      {
+        ImGui.SameLine();
+        if (ImGui.Button("Open Stable Workshop Page"))
+          Steam.OpenWorkshopPage(stable.WorkshopHandle);
+      }
+
+      if (statuses.TryGetValue(stable.BetaWorkshopHandle, out var status))
+        ImGuiHelper.TextDisabled(status);
+      ImGui.Separator();
+      ImGui.PopID();
+    }
+
+    var linkedBetaHandles = stableMods.Select(mod => mod.BetaWorkshopHandle).ToHashSet();
+    var unlinkedBetas = betaMods.Where(mod => !linkedBetaHandles.Contains(mod.WorkshopHandle)).ToList();
+    if (unlinkedBetas.Count > 0)
+    {
+      ImGui.Spacing();
+      ImGuiHelper.Text("Other beta program mods");
+      foreach (var beta in unlinkedBetas)
+        ImGuiHelper.TextDisabled($"{beta.Name} {beta.About?.Version} ({(beta.Enabled ? "Active" : "Disabled")})");
+    }
+
+    ImGui.EndTabItem();
+    return changed;
+  }
+
+  private static async UniTask SubscribeToBeta(ModInfo stable, ModList modList)
+  {
+    var workshopId = stable.BetaWorkshopHandle;
+    if (!downloads.Add(workshopId))
+      return;
+
+    statuses[workshopId] = "Subscribing and downloading...";
+    try
+    {
+      if (!await Steam.SubscribeAndDownload(workshopId))
+      {
+        statuses[workshopId] = "Subscription or download failed. See logs for details.";
+        return;
+      }
+
+      stable.Enabled = false;
+      ModConfigUtil.SaveConfig(modList.ToModConfig());
+      statuses[workshopId] = "Beta downloaded and enabled.";
+      LaunchPadConfig.ReloadMods();
+    }
+    finally
+    {
+      downloads.Remove(workshopId);
+    }
+  }
+}

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -291,8 +291,9 @@ public static class ManualLoadWindow
 
       ImGui.SetCursorScreenPos(row.Column(0).TL);
       ImGui.BeginDisabled(mod.Source is ModSourceType.Core);
-      if (ImGui.Checkbox("##enable", ref mod.Enabled))
-        changed = true;
+      var enabled = mod.Enabled;
+      if (ImGui.Checkbox("##enable", ref enabled))
+        changed |= BetaProgramsPanel.SetModEnabled(modList, mod, enabled);
       ImGui.EndDisabled();
 
       var c12 = row.ColumnsFrom(1);

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -138,7 +138,7 @@ public static class ManualLoadWindow
     ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, Vector2.zero);
     var (nextEnabled, nextText) = stage switch
     {
-      LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Downloading Beta..."),
+      LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Updating Betas..."),
       LoadStage.Configuring => (true, "Load Mods"),
       LoadStage.Loaded or LoadStage.Failed => (true, "Start Game"),
       _ => (false, "..."),
@@ -287,6 +287,7 @@ public static class ManualLoadWindow
     foreach (var mod in modList.AllMods)
     {
       ImGui.PushID(idx);
+      var isBeta = modList.IsBetaMod(mod);
 
       ImGui.SetCursorScreenPos(row.Column(0).TL);
       ImGui.BeginDisabled(mod.Source is ModSourceType.Core);
@@ -310,7 +311,13 @@ public static class ManualLoadWindow
 
       ImGuiHelper.TextCentered(row.Column(1), $"{mod.Source}");
 
-      ImGuiHelper.Text(row.Column(2), mod.IsBetaProgramMod ? $"{mod.Name} (Beta)" : mod.Name);
+      ImGui.SetCursorScreenPos(row.Column(2).TL);
+      if (isBeta)
+        ImGuiHelper.TextColored($"{mod.Name} [BETA]", ImGuiHelper.Yellow);
+      else
+        ImGuiHelper.Text(mod.Name);
+      if (isBeta)
+        ImGuiHelper.ItemTooltip("This item is a beta version of an installed mod.");
 
       if (draggingMod != null)
         if (mod.SortBefore(draggingMod))
@@ -367,7 +374,11 @@ public static class ManualLoadWindow
 
       ImGuiHelper.TextCentered(row.Column(1), $"{info.Source}");
 
-      ImGuiHelper.Text(row.Column(2), info.Name);
+      ImGui.SetCursorScreenPos(row.Column(2).TL);
+      if (modList.IsBetaMod(info))
+        ImGuiHelper.TextColored($"{info.Name} [BETA]", ImGuiHelper.Yellow);
+      else
+        ImGuiHelper.Text(info.Name);
 
       ImGui.PopID();
       idx++;

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -84,6 +84,9 @@ public static class ManualLoadWindow
         DrawModInfoTab(stage);
         DrawModConfigTab(stage);
 
+        if (BetaProgramsPanel.Draw(stage, modList))
+          changed |= ChangeFlags.Mods;
+
         // If we changed launchpad config and haven't loaded mods yet, mark mods changed to apply disable/sort behaviour
         if (DrawLaunchPadConfigTab() && stage <= LoadStage.Configuring)
           changed |= ChangeFlags.Mods;
@@ -135,6 +138,7 @@ public static class ManualLoadWindow
     ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, Vector2.zero);
     var (nextEnabled, nextText) = stage switch
     {
+      LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Downloading Beta..."),
       LoadStage.Configuring => (true, "Load Mods"),
       LoadStage.Loaded or LoadStage.Failed => (true, "Start Game"),
       _ => (false, "..."),
@@ -306,7 +310,7 @@ public static class ManualLoadWindow
 
       ImGuiHelper.TextCentered(row.Column(1), $"{mod.Source}");
 
-      ImGuiHelper.Text(row.Column(2), $"{mod.Name}");
+      ImGuiHelper.Text(row.Column(2), mod.IsBetaProgramMod ? $"{mod.Name} (Beta)" : mod.Name);
 
       if (draggingMod != null)
         if (mod.SortBefore(draggingMod))

--- a/StationeersLaunchPad/UI/ModInfoPanel.cs
+++ b/StationeersLaunchPad/UI/ModInfoPanel.cs
@@ -65,6 +65,14 @@ public class ModInfoPanel
       DrawOneLine("ModID:", mod.ModID);
     if (mod.WorkshopHandle > 1)
       DrawOneLine("Workshop ID:", $"{mod.WorkshopHandle}");
+    if (mod.HasBetaProgram)
+    {
+      DrawOneLine("Beta Workshop ID:", $"{mod.BetaWorkshopHandle}");
+      if (ImGui.Button("Open Beta Workshop Page"))
+        Steam.OpenWorkshopPage(mod.BetaWorkshopHandle);
+    }
+    if (mod.IsBetaProgramMod)
+      DrawOneLine("Beta Program:", "Yes");
     if (!string.IsNullOrEmpty(about.Author))
       DrawOneLine("Author", about.Author.Trim());
     if (!string.IsNullOrEmpty(about.Version))


### PR DESCRIPTION
Adds Workshop-based beta programs for mods, including automatic subscription, switching, persistence, and beta-aware deduplication. Beta items are clearly marked in the mod list, and switching back to stable unsubscribes the beta. Can (and should) be extended with repomods support further down the line.