### PR TITLE
Mod Profiles, Workshop Betas, and LaunchPad Polish

### DIFF
--- a/StationeersLaunchPad/Configs.cs
+++ b/StationeersLaunchPad/Configs.cs
@@ -8,13 +8,6 @@ using StationeersLaunchPad.Loading;
 
 namespace StationeersLaunchPad;
 
-public enum ProfilePromptMode
-{
-  Never,
-  Auto,
-  Always,
-}
-
 public enum UiAccentColor
 {
   Classic,
@@ -67,10 +60,7 @@ public static class Configs
   public static ConfigEntry<int> RepoModFetchTimeout;
   public static ConfigEntry<bool> RepoModValidateDigest;
   public static ConfigEntry<bool> RepoModValidateVersion;
-  public static ConfigEntry<ProfilePromptMode> ProfilePrompt;
   public static ConfigEntry<string> ModProfile;
-  public static ConfigEntry<string> AppliedModProfile;
-  public static ConfigEntry<string> AppliedModProfileHash;
 
   public static ConfigEntry<bool> NewsCheckOnStart;
   public static ConfigEntry<string> NewsFeedUrl;
@@ -264,14 +254,6 @@ public static class Configs
         "Reject new mod versions when they don't match the target ModID and Version."
       )
     );
-    ProfilePrompt = config.Bind(
-      new ConfigDefinition("Mod Profiles", "PromptMode"),
-      ProfilePromptMode.Auto,
-      new ConfigDescription(
-        "Choose when to stop at the profile selector. Auto only stops when input is needed."
-      )
-    );
-
     NewsCheckOnStart = config.Bind(
       new ConfigDefinition("News", "NewsCheckOnStart"),
       true,
@@ -336,20 +318,6 @@ public static class Configs
       "",
       new ConfigDescription(
         "The active mod profile. Leave empty to use the normal mod configuration."
-      )
-    );
-    AppliedModProfile = config.Bind(
-      new ConfigDefinition("Internal", "AppliedModProfile"),
-      "",
-      new ConfigDescription(
-        "The mod profile last applied to the normal mod configuration. Automatically managed."
-      )
-    );
-    AppliedModProfileHash = config.Bind(
-      new ConfigDefinition("Internal", "AppliedModProfileHash"),
-      "",
-      new ConfigDescription(
-        "Fingerprint of the mod configuration last applied by a profile. Automatically managed."
       )
     );
     LinuxPathPatch = config.Bind(

--- a/StationeersLaunchPad/Configs.cs
+++ b/StationeersLaunchPad/Configs.cs
@@ -15,6 +15,14 @@ public enum ProfilePromptMode
   Always,
 }
 
+public enum UiAccentColor
+{
+  Classic,
+  Orange,
+  Blue,
+  Green,
+}
+
 // config values that have different defaults depending on platform
 public struct ConfigDefaults
 {
@@ -51,6 +59,7 @@ public static class Configs
   public static ConfigEntry<bool> CompactLogs;
   public static ConfigEntry<bool> LinuxPathPatch;
   public static ConfigEntry<bool> CompactConfigPanel;
+  public static ConfigEntry<UiAccentColor> UiAccent;
   public static ConfigEntry<bool> RepoCheckUpdates;
   public static ConfigEntry<int> RepoUpdateFrequency;
   public static ConfigEntry<int> RepoFetchTimeout;
@@ -355,6 +364,13 @@ public static class Configs
       false,
       new ConfigDescription(
         "Display configuration entires on the same line with their names"
+      )
+    );
+    UiAccent = config.Bind(
+      new ConfigDefinition("Appearance", "AccentColor"),
+      UiAccentColor.Classic,
+      new ConfigDescription(
+        "Accent color for LaunchPad controls. Classic uses the existing SLP theme."
       )
     );
     Sorted = new SortedConfigFile(config);

--- a/StationeersLaunchPad/Configs.cs
+++ b/StationeersLaunchPad/Configs.cs
@@ -8,6 +8,13 @@ using StationeersLaunchPad.Loading;
 
 namespace StationeersLaunchPad;
 
+public enum ProfilePromptMode
+{
+  Never,
+  Auto,
+  Always,
+}
+
 // config values that have different defaults depending on platform
 public struct ConfigDefaults
 {
@@ -50,6 +57,9 @@ public static class Configs
   public static ConfigEntry<int> RepoModFetchTimeout;
   public static ConfigEntry<bool> RepoModValidateDigest;
   public static ConfigEntry<bool> RepoModValidateVersion;
+  public static ConfigEntry<ProfilePromptMode> ProfilePrompt;
+  public static ConfigEntry<string> ModProfile;
+  public static ConfigEntry<string> AppliedModProfile;
 
   public static ConfigEntry<bool> NewsCheckOnStart;
   public static ConfigEntry<string> NewsFeedUrl;
@@ -236,6 +246,13 @@ public static class Configs
         "Reject new mod versions when they don't match the target ModID and Version."
       )
     );
+    ProfilePrompt = config.Bind(
+      new ConfigDefinition("Mod Profiles", "PromptMode"),
+      ProfilePromptMode.Auto,
+      new ConfigDescription(
+        "Choose when to stop at the profile selector. Auto only stops when input is needed."
+      )
+    );
 
     NewsCheckOnStart = config.Bind(
       new ConfigDefinition("News", "NewsCheckOnStart"),
@@ -294,6 +311,20 @@ public static class Configs
       true,
       new ConfigDescription(
         "This setting is automatically managed and should probably not be manually changed. Remove update backup files on start."
+      )
+    );
+    ModProfile = config.Bind(
+      new ConfigDefinition("Internal", "ModProfile"),
+      "",
+      new ConfigDescription(
+        "The active mod profile. Leave empty to use the normal mod configuration."
+      )
+    );
+    AppliedModProfile = config.Bind(
+      new ConfigDefinition("Internal", "AppliedModProfile"),
+      "",
+      new ConfigDescription(
+        "The mod profile last applied to the normal mod configuration. Automatically managed."
       )
     );
     LinuxPathPatch = config.Bind(

--- a/StationeersLaunchPad/Configs.cs
+++ b/StationeersLaunchPad/Configs.cs
@@ -14,6 +14,11 @@ public enum UiAccentColor
   Orange,
   Blue,
   Green,
+  Pink,
+  Yellow,
+  Purple,
+  Teal,
+  Dark,
 }
 
 // config values that have different defaults depending on platform

--- a/StationeersLaunchPad/Configs.cs
+++ b/StationeersLaunchPad/Configs.cs
@@ -35,6 +35,7 @@ public static class Configs
   public static ConfigEntry<LoadStrategyMode> LoadStrategyMode;
   public static ConfigEntry<bool> DisableSteamOnStart;
   public static ConfigEntry<string> SavePathOnStart;
+  public static ConfigEntry<bool> RetainWorkshopMods;
   public static ConfigEntry<bool> PostUpdateCleanup;
   public static ConfigEntry<bool> OneTimeBoosterInstall;
   public static ConfigEntry<bool> AutoScrollLogs;
@@ -173,6 +174,13 @@ public static class Configs
       "",
       new ConfigDescription(
         "This setting allows you to override the default path that config and save files are stored. Notice, due to how this path is implemented in the base game, this setting can only be applied on server start.  Changing it while in game will not have an effect until after a restart."
+      )
+    );
+    RetainWorkshopMods = config.Bind(
+      new ConfigDefinition("Mod Loading", "RetainWorkshopMods"),
+      true,
+      new ConfigDescription(
+        "When running with steam disabled, use the workshop mods already in the mod config as the list of available workshop mods."
       )
     );
     RepoCheckUpdates = config.Bind(

--- a/StationeersLaunchPad/Configs.cs
+++ b/StationeersLaunchPad/Configs.cs
@@ -140,7 +140,7 @@ public static class Configs
       new ConfigDefinition("Startup", "AutoSort"),
       true,
       new ConfigDescription(
-        "Automatically sort based on OrderBefore/OrderAfter tags in mod data"
+        "Automatically sort based on dependencies and OrderBefore/OrderAfter tags in mod data"
       )
     );
     DisableSteamOnStart = config.Bind(

--- a/StationeersLaunchPad/Configs.cs
+++ b/StationeersLaunchPad/Configs.cs
@@ -61,6 +61,7 @@ public static class Configs
   public static ConfigEntry<ProfilePromptMode> ProfilePrompt;
   public static ConfigEntry<string> ModProfile;
   public static ConfigEntry<string> AppliedModProfile;
+  public static ConfigEntry<string> AppliedModProfileHash;
 
   public static ConfigEntry<bool> NewsCheckOnStart;
   public static ConfigEntry<string> NewsFeedUrl;
@@ -333,6 +334,13 @@ public static class Configs
       "",
       new ConfigDescription(
         "The mod profile last applied to the normal mod configuration. Automatically managed."
+      )
+    );
+    AppliedModProfileHash = config.Bind(
+      new ConfigDefinition("Internal", "AppliedModProfileHash"),
+      "",
+      new ConfigDescription(
+        "Fingerprint of the mod configuration last applied by a profile. Automatically managed."
       )
     );
     LinuxPathPatch = config.Bind(

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -91,7 +91,7 @@ public static class LaunchPadConfig
   {
     if (AutoLoad)
     {
-      if (AutoLoadWindow.Draw(Stage, CurWait))
+      if (AutoLoadWindow.Draw(Stage, CurWait, pendingProfileName))
       {
         StopAutoLoad();
         if (!string.IsNullOrEmpty(Configs.ModProfile.Value))
@@ -415,6 +415,7 @@ public static class LaunchPadConfig
       return;
     var sortChanged = changed.HasFlag(ManualLoadWindow.ChangeFlags.AutoSort);
     var modsChanged = changed.HasFlag(ManualLoadWindow.ChangeFlags.Mods);
+    var profileChanged = changed.HasFlag(ManualLoadWindow.ChangeFlags.Profile);
     if (sortChanged)
       Configs.AutoSortOnStart.Value = AutoSort = !AutoSort;
     if (sortChanged || modsChanged)
@@ -424,7 +425,10 @@ public static class LaunchPadConfig
       if (AutoSort)
         modList.SortByDeps();
       ModConfigUtil.SaveConfig(modList.ToModConfig());
-      profileManager.SyncActiveProfile(modList);
+      if (profileChanged)
+        profileManager.MarkActiveProfileApplied(modList);
+      else
+        profileManager.MarkActiveProfileDirty();
     }
     var next = changed.HasFlag(ManualLoadWindow.ChangeFlags.NextStep);
     if (next)

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -129,8 +129,8 @@ public static class LaunchPadConfig
     do
     {
       await StageSearching(firstLoad);
+      await StageConfiguring(firstLoad);
       firstLoad = false;
-      await StageConfiguring();
     }
     while (Stage == LoadStage.Searching);
     await StageLoading();
@@ -331,7 +331,7 @@ public static class LaunchPadConfig
     }
   }
 
-  private static async UniTask StageConfiguring()
+  private static async UniTask StageConfiguring(bool firstLoad)
   {
     if (Stage == LoadStage.Failed) return;
     Stage = LoadStage.Configuring;
@@ -339,7 +339,7 @@ public static class LaunchPadConfig
     CurWait = new(Configs.AutoLoadWaitTime.Value, AutoLoad);
 
     await SLPCommand.MoveToStage(CommandStage.ConfigLoaded);
-    PrepareProfileStartup();
+    PrepareProfileStartup(firstLoad);
     await Platform.Wait(CurWait, CommandStage.ConfigLoaded);
 
     if (!AutoLoad || string.IsNullOrEmpty(pendingProfileName))
@@ -435,7 +435,7 @@ public static class LaunchPadConfig
       CurWait.Skip();
   }
 
-  private static void PrepareProfileStartup()
+  private static void PrepareProfileStartup(bool firstLoad)
   {
     pendingProfileName = "";
     if (string.IsNullOrEmpty(Configs.ModProfile.Value))
@@ -462,7 +462,8 @@ public static class LaunchPadConfig
 
     if (!AutoLoad)
     {
-      ManualLoadWindow.OpenProfilesTab();
+      if (firstLoad)
+        ManualLoadWindow.OpenProfilesTab();
       return;
     }
 

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -265,7 +265,6 @@ public static class LaunchPadConfig
       if (firstLoad)
         await CheckNewsNotices();
 
-      PrepareProfileStartup();
       ModConfigUtil.SaveConfig(modList.ToModConfig());
 
       var depNotice = !modList.CheckDependencies();
@@ -340,6 +339,7 @@ public static class LaunchPadConfig
     CurWait = new(Configs.AutoLoadWaitTime.Value, AutoLoad);
 
     await SLPCommand.MoveToStage(CommandStage.ConfigLoaded);
+    PrepareProfileStartup();
     await Platform.Wait(CurWait, CommandStage.ConfigLoaded);
 
     if (!AutoLoad || string.IsNullOrEmpty(pendingProfileName))
@@ -437,10 +437,17 @@ public static class LaunchPadConfig
     if (string.IsNullOrEmpty(Configs.ModProfile.Value))
       return;
 
+    var profileName = Configs.ModProfile.Value;
+    var wasInitialized = profileManager.IsInitialized;
     profileManager.Initialize();
-    var profile = profileManager.ActiveProfile;
+    var profile = profileManager.FindProfile(profileName);
     if (profile == null)
+    {
+      if (wasInitialized)
+        Logger.Global.LogWarning($"Configured mod profile '{profileName}' was not found");
+      profileManager.DisableProfiles();
       return;
+    }
 
     profileManager.SyncActiveProfile(modList);
     if (Platform.IsServer)

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -67,6 +67,7 @@ public static class LaunchPadConfig
   private static bool AutoSort;
   private static bool AutoLoad = true;
   private static bool SteamDisabled;
+  private static string pendingProfileName = "";
 
   private static StageWait CurWait = new(0, false);
 
@@ -91,7 +92,11 @@ public static class LaunchPadConfig
     if (AutoLoad)
     {
       if (AutoLoadWindow.Draw(Stage, CurWait))
+      {
         StopAutoLoad();
+        if (!string.IsNullOrEmpty(Configs.ModProfile.Value))
+          ManualLoadWindow.OpenProfilesTab();
+      }
     }
     else
     {
@@ -260,6 +265,7 @@ public static class LaunchPadConfig
       if (firstLoad)
         await CheckNewsNotices();
 
+      PrepareProfileStartup();
       ModConfigUtil.SaveConfig(modList.ToModConfig());
 
       var depNotice = !modList.CheckDependencies();
@@ -335,6 +341,29 @@ public static class LaunchPadConfig
 
     await SLPCommand.MoveToStage(CommandStage.ConfigLoaded);
     await Platform.Wait(CurWait, CommandStage.ConfigLoaded);
+
+    if (!AutoLoad || string.IsNullOrEmpty(pendingProfileName))
+      return;
+    if (!pendingProfileName.Equals(profileManager.ActiveProfileName, StringComparison.OrdinalIgnoreCase))
+      return;
+    if (!profileManager.ApplyProfile(pendingProfileName, modList))
+      return;
+
+    pendingProfileName = "";
+    var depNotice = !modList.CheckDependencies();
+    depNotice = modList.DisableDuplicates() || depNotice;
+    if (AutoSort)
+      depNotice = !modList.SortByDeps() || depNotice;
+    ModConfigUtil.SaveConfig(modList.ToModConfig());
+    profileManager.SyncActiveProfile(modList);
+
+    if (depNotice && Platform.PauseOnDepNotice)
+    {
+      StopAutoLoad();
+      ManualLoadWindow.OpenProfilesTab();
+      CurWait = new(0, false);
+      await Platform.Wait(CurWait, CommandStage.ConfigLoaded);
+    }
   }
 
   private static async UniTask StageLoading()
@@ -395,10 +424,54 @@ public static class LaunchPadConfig
       if (AutoSort)
         modList.SortByDeps();
       ModConfigUtil.SaveConfig(modList.ToModConfig());
+      profileManager.SyncActiveProfile(modList);
     }
     var next = changed.HasFlag(ManualLoadWindow.ChangeFlags.NextStep);
     if (next)
       CurWait.Skip();
+  }
+
+  private static void PrepareProfileStartup()
+  {
+    pendingProfileName = "";
+    if (string.IsNullOrEmpty(Configs.ModProfile.Value))
+      return;
+
+    profileManager.Initialize();
+    var profile = profileManager.ActiveProfile;
+    if (profile == null)
+      return;
+
+    profileManager.SyncActiveProfile(modList);
+    if (Platform.IsServer)
+    {
+      pendingProfileName = profile.Name;
+      return;
+    }
+
+    if (!AutoLoad)
+    {
+      ManualLoadWindow.OpenProfilesTab();
+      return;
+    }
+
+    var newMods = profileManager.GetNewMods(profile.Name, modList);
+    if (Configs.ProfilePrompt.Value == ProfilePromptMode.Auto && newMods.Count > 0)
+    {
+      Logger.Global.LogInfo($"Found {newMods.Count} mod(s) not in profile '{profile.Name}'");
+      StopAutoLoad();
+      ManualLoadWindow.OpenProfilesTab();
+      return;
+    }
+
+    if (Configs.ProfilePrompt.Value == ProfilePromptMode.Always)
+    {
+      StopAutoLoad();
+      ManualLoadWindow.OpenProfilesTab();
+      return;
+    }
+
+    pendingProfileName = profile.Name;
   }
 
   private static void StartGame()

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -68,6 +68,7 @@ public static class LaunchPadConfig
   private static bool AutoLoad = true;
   private static bool SteamDisabled;
   private static bool quickProfileOpen;
+  private static bool preserveSelectionAfterReload = true;
 
   private static StageWait CurWait = new(0, false);
 
@@ -77,10 +78,11 @@ public static class LaunchPadConfig
     CurWait.Auto = false;
   }
 
-  public static void ReloadMods()
+  public static void ReloadMods(bool preserveSelection = true)
   {
     if (Stage != LoadStage.Configuring)
       return;
+    preserveSelectionAfterReload = preserveSelection;
     Logger.Global.LogInfo("Reloading Mod List");
     Stage = LoadStage.Searching;
     CurWait.Skip();
@@ -378,7 +380,8 @@ public static class LaunchPadConfig
     CurWait = new(Configs.AutoLoadWaitTime.Value, AutoLoad);
 
     await SLPCommand.MoveToStage(CommandStage.ConfigLoaded);
-    PrepareProfileStartup(firstLoad);
+    PrepareProfileStartup(firstLoad, preserveSelectionAfterReload);
+    preserveSelectionAfterReload = true;
     await Platform.Wait(CurWait, CommandStage.ConfigLoaded);
   }
 
@@ -460,7 +463,7 @@ public static class LaunchPadConfig
     }
   }
 
-  private static void PrepareProfileStartup(bool firstLoad)
+  private static void PrepareProfileStartup(bool firstLoad, bool preserveSelection)
   {
     if (string.IsNullOrEmpty(Configs.ModProfile.Value))
       return;
@@ -477,9 +480,8 @@ public static class LaunchPadConfig
       return;
     }
 
-    if (!firstLoad && !AutoLoad)
+    if (!firstLoad && preserveSelection)
     {
-      profileManager.DisableModsOutsideProfile(profile.Name, modList);
       if (profileManager.GetMissingMods(profile.Name, modList).Count > 0)
         ManualLoadWindow.OpenProfilesTab();
       return;

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -67,7 +67,7 @@ public static class LaunchPadConfig
   private static bool AutoSort;
   private static bool AutoLoad = true;
   private static bool SteamDisabled;
-  private static string pendingProfileName = "";
+  private static bool quickProfileOpen;
 
   private static StageWait CurWait = new(0, false);
 
@@ -91,11 +91,50 @@ public static class LaunchPadConfig
   {
     if (AutoLoad)
     {
-      if (AutoLoadWindow.Draw(Stage, CurWait, pendingProfileName))
+      var profileAction = ProfileLaunchWindow.Draw(
+        Stage, profileManager, modList, quickProfileOpen, out var profileChanged);
+      if (profileChanged)
       {
+        NormalizeModList();
+        ProfilePanel.SelectActive();
+      }
+
+      if (profileAction == ProfileLaunchAction.OpenSelector)
+      {
+        quickProfileOpen = true;
+        CurWait.Auto = false;
+      }
+      else if (profileAction == ProfileLaunchAction.Continue)
+      {
+        var activeProfile = profileManager.ActiveProfile;
+        var missingMods = activeProfile == null
+          ? []
+          : profileManager.GetMissingMods(activeProfile.Name, modList);
+        if (missingMods.Count > 0)
+        {
+          quickProfileOpen = true;
+          CurWait.Auto = false;
+          Logger.Global.LogWarning(
+            $"Profile '{activeProfile.Name}' has {missingMods.Count} missing required mod(s)");
+        }
+        else
+        {
+          quickProfileOpen = false;
+          CurWait.Skip();
+        }
+      }
+      else if (profileAction == ProfileLaunchAction.OpenMenu)
+      {
+        quickProfileOpen = false;
         StopAutoLoad();
-        if (!string.IsNullOrEmpty(Configs.ModProfile.Value))
-          ManualLoadWindow.OpenProfilesTab();
+        ManualLoadWindow.OpenProfilesTab();
+      }
+
+      if (AutoLoad && AutoLoadWindow.Draw(Stage, CurWait))
+      {
+        quickProfileOpen = false;
+        StopAutoLoad();
+        ManualLoadWindow.OpenModInfoTab();
       }
     }
     else
@@ -341,29 +380,6 @@ public static class LaunchPadConfig
     await SLPCommand.MoveToStage(CommandStage.ConfigLoaded);
     PrepareProfileStartup(firstLoad);
     await Platform.Wait(CurWait, CommandStage.ConfigLoaded);
-
-    if (!AutoLoad || string.IsNullOrEmpty(pendingProfileName))
-      return;
-    if (!pendingProfileName.Equals(profileManager.ActiveProfileName, StringComparison.OrdinalIgnoreCase))
-      return;
-    if (!profileManager.ApplyProfile(pendingProfileName, modList))
-      return;
-
-    pendingProfileName = "";
-    var depNotice = !modList.CheckDependencies();
-    depNotice = modList.DisableDuplicates() || depNotice;
-    if (AutoSort)
-      depNotice = !modList.SortByDeps() || depNotice;
-    ModConfigUtil.SaveConfig(modList.ToModConfig());
-    profileManager.SyncActiveProfile(modList);
-
-    if (depNotice && Platform.PauseOnDepNotice)
-    {
-      StopAutoLoad();
-      ManualLoadWindow.OpenProfilesTab();
-      CurWait = new(0, false);
-      await Platform.Wait(CurWait, CommandStage.ConfigLoaded);
-    }
   }
 
   private static async UniTask StageLoading()
@@ -415,29 +431,37 @@ public static class LaunchPadConfig
       return;
     var sortChanged = changed.HasFlag(ManualLoadWindow.ChangeFlags.AutoSort);
     var modsChanged = changed.HasFlag(ManualLoadWindow.ChangeFlags.Mods);
-    var profileChanged = changed.HasFlag(ManualLoadWindow.ChangeFlags.Profile);
     if (sortChanged)
       Configs.AutoSortOnStart.Value = AutoSort = !AutoSort;
     if (sortChanged || modsChanged)
-    {
-      modList.CheckDependencies();
-      modList.DisableDuplicates();
-      if (AutoSort)
-        modList.SortByDeps();
-      ModConfigUtil.SaveConfig(modList.ToModConfig());
-      if (profileChanged)
-        profileManager.MarkActiveProfileApplied(modList);
-      else
-        profileManager.MarkActiveProfileDirty();
-    }
+      NormalizeModList();
     var next = changed.HasFlag(ManualLoadWindow.ChangeFlags.NextStep);
     if (next)
-      CurWait.Skip();
+    {
+      var vanillaDiverged = ProfileManager.IsVanillaProfile(profileManager.ActiveProfileName)
+        && profileManager.HasDiverged(profileManager.ActiveProfileName, modList);
+      var missingMods = profileManager.ActiveProfile == null
+        ? []
+        : profileManager.GetMissingMods(profileManager.ActiveProfileName, modList);
+      if (vanillaDiverged)
+      {
+        Logger.Global.LogWarning("Vanilla profile cannot load with mods enabled");
+        ManualLoadWindow.OpenProfilesTab();
+      }
+      else if (missingMods.Count > 0)
+      {
+        Logger.Global.LogWarning(
+          $"Profile '{profileManager.ActiveProfileName}' has {missingMods.Count} missing required mod(s)");
+        ProfilePanel.ShowLoadBlocked(profileManager.ActiveProfileName, missingMods.Count);
+        ManualLoadWindow.OpenProfilesTab();
+      }
+      else
+        CurWait.Skip();
+    }
   }
 
   private static void PrepareProfileStartup(bool firstLoad)
   {
-    pendingProfileName = "";
     if (string.IsNullOrEmpty(Configs.ModProfile.Value))
       return;
 
@@ -453,37 +477,64 @@ public static class LaunchPadConfig
       return;
     }
 
-    profileManager.SyncActiveProfile(modList);
-    if (Platform.IsServer)
+    if (!firstLoad && !AutoLoad)
     {
-      pendingProfileName = profile.Name;
+      profileManager.DisableModsOutsideProfile(profile.Name, modList);
+      if (profileManager.GetMissingMods(profile.Name, modList).Count > 0)
+        ManualLoadWindow.OpenProfilesTab();
       return;
     }
-
-    if (!AutoLoad)
+    if (!profileManager.ApplyProfile(profile.Name, modList))
     {
-      if (firstLoad)
+      Logger.Global.LogError($"Could not apply mod profile '{profile.Name}'");
+      StopAutoLoad();
+      return;
+    }
+    var depNotice = NormalizeModList();
+    if (Platform.IsServer)
+      return;
+
+    var missingMods = profileManager.GetMissingMods(profile.Name, modList);
+    if (missingMods.Count > 0)
+    {
+      Logger.Global.LogWarning(
+        $"Profile '{profile.Name}' has {missingMods.Count} missing required mod(s)");
+      if (AutoLoad)
+      {
+        quickProfileOpen = true;
+        CurWait.Auto = false;
+      }
+      else
         ManualLoadWindow.OpenProfilesTab();
       return;
     }
 
-    var newMods = profileManager.GetNewMods(profile.Name, modList);
-    if (Configs.ProfilePrompt.Value == ProfilePromptMode.Auto && newMods.Count > 0)
+    if (depNotice && Platform.PauseOnDepNotice)
     {
-      Logger.Global.LogInfo($"Found {newMods.Count} mod(s) not in profile '{profile.Name}'");
       StopAutoLoad();
-      ManualLoadWindow.OpenProfilesTab();
+      ManualLoadWindow.OpenModInfoTab();
       return;
     }
 
-    if (Configs.ProfilePrompt.Value == ProfilePromptMode.Always)
+    if (!AutoLoad)
+      return;
+
+    if (quickProfileOpen)
     {
-      StopAutoLoad();
-      ManualLoadWindow.OpenProfilesTab();
+      CurWait.Auto = false;
       return;
     }
 
-    pendingProfileName = profile.Name;
+  }
+
+  private static bool NormalizeModList()
+  {
+    var depNotice = !modList.CheckDependencies();
+    depNotice = modList.DisableDuplicates() || depNotice;
+    if (AutoSort)
+      depNotice = !modList.SortByDeps() || depNotice;
+    ModConfigUtil.SaveConfig(modList.ToModConfig());
+    return depNotice;
   }
 
   private static void StartGame()

--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -58,6 +58,7 @@ public static class LaunchPadConfig
   public static SplashBehaviour SplashBehaviour;
 
   private static ModList modList = ModList.NewEmpty();
+  private static readonly ProfileManager profileManager = new();
 
   private static LoadStage Stage = LoadStage.Initializing;
   public static bool ModsLoaded => Stage > LoadStage.Configuring;
@@ -94,7 +95,7 @@ public static class LaunchPadConfig
     }
     else
     {
-      var changed = ManualLoadWindow.Draw(Stage, modList, AutoSort);
+      var changed = ManualLoadWindow.Draw(Stage, modList, AutoSort, profileManager);
       HandleChange(changed);
     }
 

--- a/StationeersLaunchPad/LaunchPadInfo.cs
+++ b/StationeersLaunchPad/LaunchPadInfo.cs
@@ -4,5 +4,5 @@ public class LaunchPadInfo
 {
   public const string NAME = "StationeersLaunchPad";
   public const string GUID = "stationeers.launchpad";
-  public const string VERSION = "0.4.0";
+  public const string VERSION = "0.5.0";
 }

--- a/StationeersLaunchPad/Metadata/ModAbout.cs
+++ b/StationeersLaunchPad/Metadata/ModAbout.cs
@@ -41,6 +41,12 @@ public class ModAboutEx
   [XmlElement("WorkshopHandle")]
   public ulong WorkshopHandle;
 
+  [XmlElement("BetaProgram")]
+  public ModReference BetaProgram;
+
+  [XmlElement("IsBetaProgramMod")]
+  public bool IsBetaProgramMod;
+
   [XmlArray("Tags"), XmlArrayItem("Tag")]
   public List<string> Tags;
 

--- a/StationeersLaunchPad/Metadata/ModAbout.cs
+++ b/StationeersLaunchPad/Metadata/ModAbout.cs
@@ -1,11 +1,20 @@
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
 namespace StationeersLaunchPad.Metadata;
+
+public enum ModSide
+{
+  Unknown,
+  Both,
+  Client,
+  Server,
+}
 
 [XmlRoot("ModMetadata")]
 public class ModAboutEx
@@ -46,6 +55,10 @@ public class ModAboutEx
 
   [XmlElement("IsBetaProgramMod")]
   public bool IsBetaProgramMod;
+
+  [XmlElement("ModSide")]
+  [DefaultValue(ModSide.Unknown)]
+  public ModSide ModSide;
 
   [XmlArray("Tags"), XmlArrayItem("Tag")]
   public List<string> Tags;

--- a/StationeersLaunchPad/Metadata/ModInfo.cs
+++ b/StationeersLaunchPad/Metadata/ModInfo.cs
@@ -59,6 +59,8 @@ public class ModInfo
 
   public bool SortBefore(ModInfo other)
   {
+    if (other.About?.DependsOn?.Any(Satisfies) ?? false)
+      return true;
     if (other.About?.OrderAfter?.Any(Satisfies) ?? false)
       return true;
     return About?.OrderBefore?.Any(other.Satisfies) ?? false;

--- a/StationeersLaunchPad/Metadata/ModInfo.cs
+++ b/StationeersLaunchPad/Metadata/ModInfo.cs
@@ -28,6 +28,9 @@ public class ModInfo
   public string DirectoryName => new DirectoryInfo(DirectoryPath).Name;
   public ulong WorkshopHandle => Def.WorkshopHandle;
   public string ModID => About.ModID ?? "";
+  public bool HasBetaProgram => About?.BetaProgram?.WorkshopHandle > 1;
+  public ulong BetaWorkshopHandle => HasBetaProgram ? About.BetaProgram.WorkshopHandle : 0;
+  public bool IsBetaProgramMod => About?.IsBetaProgramMod ?? false;
 
   public string AboutPath => Path.Combine(DirectoryPath, "About");
   public string AboutXmlPath => Path.Combine(AboutPath, "About.xml");
@@ -67,4 +70,17 @@ public class ModInfo
       return true;
     return !string.IsNullOrEmpty(modRef.ModID) && ModID == modRef.ModID;
   }
+
+  public bool IsBetaProgramFor(ModInfo mod)
+  {
+    var beta = About?.BetaProgram;
+    if (beta == null)
+      return false;
+    if (beta.WorkshopHandle > 1)
+      return beta.WorkshopHandle == mod.WorkshopHandle;
+    return !string.IsNullOrEmpty(beta.ModID) && beta.ModID == mod.ModID;
+  }
+
+  public bool IsBetaRelated(ModInfo mod) =>
+    IsBetaProgramFor(mod) || mod.IsBetaProgramFor(this);
 }

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -126,12 +126,13 @@ public class ModList
 
     var ordered = new List<ModInfo>();
     var matched = new HashSet<ModInfo>();
+    var unavailable = 0;
     foreach (var entry in profile.Mods)
     {
       var mod = ProfileManager.FindMod(entry, mods);
       if (mod == null)
       {
-        Logger.Global.LogWarning($"Profile mod not found: path='{entry.DirectoryPath}' handle={entry.WorkshopHandle}");
+        unavailable++;
         continue;
       }
 
@@ -145,6 +146,8 @@ public class ModList
         ordered.Add(mod);
 
     mods = ordered;
+    if (unavailable > 0)
+      Logger.Global.LogDebug($"Profile '{profile.Name}' skipped {unavailable} unavailable mod(s)");
   }
 
   // returns true if the mod was moved (even if it wasn't moved all the way to the target index)

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -119,39 +119,14 @@ public class ModList
 
   public void ApplyProfile(ProfileData profile)
   {
-    var modsByPath = new Dictionary<string, ModInfo>(StringComparer.OrdinalIgnoreCase);
-    var modsByHandle = new Dictionary<ulong, ModInfo>();
-
-    foreach (var mod in mods)
-    {
-      if (mod.Source == ModSourceType.Core && string.IsNullOrEmpty(mod.DirectoryPath))
-        modsByPath["Core"] = mod;
-      else if (!string.IsNullOrEmpty(mod.DirectoryPath))
-        modsByPath[NormalizePath(mod.DirectoryPath)] = mod;
-
-      if (mod.WorkshopHandle != 0)
-        modsByHandle[mod.WorkshopHandle] = mod;
-    }
-
     foreach (var mod in mods)
       mod.Enabled = false;
 
     var ordered = new List<ModInfo>();
     var matched = new HashSet<ModInfo>();
-
     foreach (var entry in profile.Mods)
     {
-      ModInfo mod = null;
-
-      // Core sentinel: empty path and zero handle
-      if (string.IsNullOrEmpty(entry.DirectoryPath) && entry.WorkshopHandle == 0)
-        modsByPath.TryGetValue("Core", out mod);
-      else if (!string.IsNullOrEmpty(entry.DirectoryPath))
-        modsByPath.TryGetValue(NormalizePath(entry.DirectoryPath), out mod);
-
-      if (mod == null && entry.WorkshopHandle != 0)
-        modsByHandle.TryGetValue(entry.WorkshopHandle, out mod);
-
+      var mod = ProfileManager.FindMod(entry, mods);
       if (mod == null)
       {
         Logger.Global.LogWarning($"Profile mod not found: path='{entry.DirectoryPath}' handle={entry.WorkshopHandle}");
@@ -159,13 +134,10 @@ public class ModList
       }
 
       mod.Enabled = entry.Enabled;
-      if (!matched.Contains(mod))
-      {
+      if (matched.Add(mod))
         ordered.Add(mod);
-        matched.Add(mod);
-      }
     }
-    
+
     foreach (var mod in mods)
       if (!matched.Contains(mod))
         ordered.Add(mod);

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -15,6 +15,8 @@ public class ModList
   public IEnumerable<ModInfo> AllMods => mods;
   public IEnumerable<ModInfo> EnabledMods => mods.Where(mod => mod.Enabled);
   public int IndexOf(ModInfo mod) => mods.IndexOf(mod);
+  public bool IsBetaMod(ModInfo mod) =>
+    mod.IsBetaProgramMod || mods.Any(stable => stable != mod && stable.IsBetaProgramFor(mod));
 
   public static ModList NewEmpty() => new();
   public static ModList FromDefs(List<ModDefinition> defs)

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -126,17 +126,17 @@ public class ModList
 
     var ordered = new List<ModInfo>();
     var matched = new HashSet<ModInfo>();
-    var unavailable = 0;
+    var missing = 0;
     foreach (var entry in profile.Mods)
     {
       var mod = ProfileManager.FindMod(entry, mods);
       if (mod == null)
       {
-        unavailable++;
+        missing++;
         continue;
       }
 
-      mod.Enabled = entry.Enabled;
+      mod.Enabled = true;
       if (matched.Add(mod))
         ordered.Add(mod);
     }
@@ -146,8 +146,8 @@ public class ModList
         ordered.Add(mod);
 
     mods = ordered;
-    if (unavailable > 0)
-      Logger.Global.LogDebug($"Profile '{profile.Name}' skipped {unavailable} unavailable mod(s)");
+    if (missing > 0)
+      Logger.Global.LogDebug($"Profile '{profile.Name}' skipped {missing} missing mod(s)");
   }
 
   // returns true if the mod was moved (even if it wasn't moved all the way to the target index)

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -178,6 +178,12 @@ public class ModList
         prefMods.Add(mod);
         continue;
       }
+      if (pref.IsBetaRelated(mod))
+      {
+        Logger.Global.LogDebug($"Beta program pair detected for {mod.Name}, skipping duplicate handling");
+        prefMods.AddBetaRelated(mod);
+        continue;
+      }
       var nonPref = mod;
       var prefPrio = pref.Source switch
       {

--- a/StationeersLaunchPad/Metadata/ModList.cs
+++ b/StationeersLaunchPad/Metadata/ModList.cs
@@ -117,6 +117,62 @@ public class ModList
     mods = newMods;
   }
 
+  public void ApplyProfile(ProfileData profile)
+  {
+    var modsByPath = new Dictionary<string, ModInfo>(StringComparer.OrdinalIgnoreCase);
+    var modsByHandle = new Dictionary<ulong, ModInfo>();
+
+    foreach (var mod in mods)
+    {
+      if (mod.Source == ModSourceType.Core && string.IsNullOrEmpty(mod.DirectoryPath))
+        modsByPath["Core"] = mod;
+      else if (!string.IsNullOrEmpty(mod.DirectoryPath))
+        modsByPath[NormalizePath(mod.DirectoryPath)] = mod;
+
+      if (mod.WorkshopHandle != 0)
+        modsByHandle[mod.WorkshopHandle] = mod;
+    }
+
+    foreach (var mod in mods)
+      mod.Enabled = false;
+
+    var ordered = new List<ModInfo>();
+    var matched = new HashSet<ModInfo>();
+
+    foreach (var entry in profile.Mods)
+    {
+      ModInfo mod = null;
+
+      // Core sentinel: empty path and zero handle
+      if (string.IsNullOrEmpty(entry.DirectoryPath) && entry.WorkshopHandle == 0)
+        modsByPath.TryGetValue("Core", out mod);
+      else if (!string.IsNullOrEmpty(entry.DirectoryPath))
+        modsByPath.TryGetValue(NormalizePath(entry.DirectoryPath), out mod);
+
+      if (mod == null && entry.WorkshopHandle != 0)
+        modsByHandle.TryGetValue(entry.WorkshopHandle, out mod);
+
+      if (mod == null)
+      {
+        Logger.Global.LogWarning($"Profile mod not found: path='{entry.DirectoryPath}' handle={entry.WorkshopHandle}");
+        continue;
+      }
+
+      mod.Enabled = entry.Enabled;
+      if (!matched.Contains(mod))
+      {
+        ordered.Add(mod);
+        matched.Add(mod);
+      }
+    }
+    
+    foreach (var mod in mods)
+      if (!matched.Contains(mod))
+        ordered.Add(mod);
+
+    mods = ordered;
+  }
+
   // returns true if the mod was moved (even if it wasn't moved all the way to the target index)
   public bool MoveModTo(ModInfo mod, int index, bool keepOrder)
   {

--- a/StationeersLaunchPad/Metadata/ModSet.cs
+++ b/StationeersLaunchPad/Metadata/ModSet.cs
@@ -18,6 +18,13 @@ public class ModSet
     all.Add(mod);
   }
 
+  public void AddBetaRelated(ModInfo mod)
+  {
+    if (mod.WorkshopHandle > 1)
+      byWorkshopHandle[mod.WorkshopHandle] = mod;
+    all.Add(mod);
+  }
+
   public bool TryGetExisting(ModInfo mod, out ModInfo existing)
   {
     if (mod.WorkshopHandle > 1 && byWorkshopHandle.TryGetValue(mod.WorkshopHandle, out existing))

--- a/StationeersLaunchPad/Metadata/OrderGraph.cs
+++ b/StationeersLaunchPad/Metadata/OrderGraph.cs
@@ -13,6 +13,14 @@ public class OrderGraph
     {
       if (!mod.Enabled || mod.Source == ModSourceType.Core)
         continue;
+      foreach (var modRef in mod.About.DependsOn ?? [])
+      {
+        foreach (var mod2 in mods)
+        {
+          if (mod2 != mod && mod2.Enabled && mod2.Satisfies(modRef))
+            graph.AddOrder(mod2, mod);
+        }
+      }
       foreach (var modRef in mod.About.OrderBefore ?? [])
       {
         foreach (var mod2 in mods)

--- a/StationeersLaunchPad/Metadata/ProfileData.cs
+++ b/StationeersLaunchPad/Metadata/ProfileData.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace StationeersLaunchPad.Metadata;
+
+[XmlRoot("ModProfile")]
+public class ProfileData
+{
+    [XmlAttribute("Name")]
+    public string Name;
+    
+    [XmlAttribute("Description")]
+    public string Description = "";
+    
+    [XmlElement("Mod")]
+    public List<ProfileModEntry> Mods = [];
+}
+
+public class ProfileModEntry
+{
+    [XmlAttribute("DirectoryPath")]
+    public string DirectoryPath;
+    
+    [XmlAttribute("WorkshopHandle")]
+    public ulong WorkshopHandle;
+    
+    [XmlAttribute("Enabled")]
+    public bool Enabled;
+}

--- a/StationeersLaunchPad/Metadata/ProfileData.cs
+++ b/StationeersLaunchPad/Metadata/ProfileData.cs
@@ -19,6 +19,9 @@ public class ProfileData
 
 public class ProfileModEntry
 {
+  [XmlAttribute("Name")]
+  public string Name = "";
+
   [XmlAttribute("Source")]
   public ModSourceType Source;
 

--- a/StationeersLaunchPad/Metadata/ProfileData.cs
+++ b/StationeersLaunchPad/Metadata/ProfileData.cs
@@ -1,29 +1,36 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Xml.Serialization;
+using StationeersLaunchPad.Sources;
 
 namespace StationeersLaunchPad.Metadata;
 
 [XmlRoot("ModProfile")]
 public class ProfileData
 {
-    [XmlAttribute("Name")]
-    public string Name;
-    
-    [XmlAttribute("Description")]
-    public string Description = "";
-    
-    [XmlElement("Mod")]
-    public List<ProfileModEntry> Mods = [];
+  [XmlAttribute("Name")]
+  public string Name;
+
+  [XmlAttribute("Description")]
+  public string Description = "";
+
+  [XmlElement("Mod")]
+  public List<ProfileModEntry> Mods = [];
 }
 
 public class ProfileModEntry
 {
-    [XmlAttribute("DirectoryPath")]
-    public string DirectoryPath;
-    
-    [XmlAttribute("WorkshopHandle")]
-    public ulong WorkshopHandle;
-    
-    [XmlAttribute("Enabled")]
-    public bool Enabled;
+  [XmlAttribute("Source")]
+  public ModSourceType Source;
+
+  [XmlAttribute("DirectoryPath")]
+  public string DirectoryPath;
+
+  [XmlAttribute("WorkshopHandle")]
+  public ulong WorkshopHandle;
+
+  [XmlAttribute("ModID")]
+  public string ModID;
+
+  [XmlAttribute("Enabled")]
+  public bool Enabled;
 }

--- a/StationeersLaunchPad/Metadata/ProfileData.cs
+++ b/StationeersLaunchPad/Metadata/ProfileData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Xml.Serialization;
 using StationeersLaunchPad.Sources;
 
@@ -35,5 +36,6 @@ public class ProfileModEntry
   public string ModID;
 
   [XmlAttribute("Enabled")]
-  public bool Enabled;
+  [DefaultValue(true)]
+  public bool LegacyEnabled = true;
 }

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -7,16 +7,14 @@ namespace StationeersLaunchPad.Metadata;
 
 public class ProfileManager
 {
+  public const string VanillaProfileName = "Vanilla";
+
   private List<ProfileData> profiles = [];
 
   public IReadOnlyList<ProfileData> AllProfiles => profiles;
   public bool IsInitialized { get; private set; }
   public string ActiveProfileName => Configs.ModProfile.Value;
   public ProfileData ActiveProfile => FindProfile(ActiveProfileName);
-  public bool WasActiveProfileApplied =>
-    !string.IsNullOrEmpty(ActiveProfileName)
-    && ActiveProfileName.Equals(Configs.AppliedModProfile.Value, StringComparison.OrdinalIgnoreCase)
-    && !string.IsNullOrEmpty(Configs.AppliedModProfileHash.Value);
 
   public void Initialize()
   {
@@ -24,7 +22,9 @@ public class ProfileManager
       return;
 
     profiles = ProfileStorage.LoadAll();
-    profiles.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+    profiles.RemoveAll(profile => IsVanillaProfile(profile.Name));
+    profiles.Add(CreateVanillaProfile());
+    SortProfiles();
     IsInitialized = true;
 
     if (string.IsNullOrEmpty(ActiveProfileName) || ActiveProfile != null)
@@ -36,7 +36,8 @@ public class ProfileManager
 
   public bool CreateProfile(string profileName, ModList modList)
   {
-    if (!ProfileStorage.IsValidName(profileName) || FindProfile(profileName) != null)
+    if (IsVanillaProfile(profileName)
+      || !ProfileStorage.IsValidName(profileName) || FindProfile(profileName) != null)
       return false;
 
     var profile = CaptureModList(profileName, modList);
@@ -44,7 +45,7 @@ public class ProfileManager
       return false;
 
     profiles.Add(profile);
-    profiles.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+    SortProfiles();
     return true;
   }
 
@@ -55,13 +56,30 @@ public class ProfileManager
       return false;
 
     modList.ApplyProfile(profile);
-    SetAppliedProfile(profile.Name, modList);
+    Configs.ModProfile.Value = profile.Name;
     ModConfigUtil.SaveConfig(modList.ToModConfig());
     return true;
   }
 
+  public void DisableModsOutsideProfile(string profileName, ModList modList)
+  {
+    var profile = FindProfile(profileName);
+    if (profile == null)
+      return;
+
+    var included = profile.Mods
+      .Select(GetIdentity)
+      .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    foreach (var mod in modList.AllMods)
+      if (!included.Contains(GetIdentity(mod)))
+        mod.Enabled = false;
+    ModConfigUtil.SaveConfig(modList.ToModConfig());
+  }
+
   public bool DeleteProfile(string profileName)
   {
+    if (IsVanillaProfile(profileName))
+      return false;
     var profile = FindProfile(profileName);
     if (profile == null || !ProfileStorage.Delete(profile.Name))
       return false;
@@ -75,81 +93,52 @@ public class ProfileManager
 
   public bool UpdateProfile(string profileName, ModList modList)
   {
+    if (IsVanillaProfile(profileName))
+      return false;
     var profile = FindProfile(profileName);
     if (profile == null)
       return false;
 
     var previousMods = profile.Mods;
-    profile.Mods = MergeModList(profile, modList, true);
+    profile.Mods = CaptureEnabledMods(modList);
     if (!ProfileStorage.Save(profile))
     {
       profile.Mods = previousMods;
       return false;
     }
 
-    if (profile == ActiveProfile)
-      SetAppliedProfile(profile.Name, modList);
     return true;
   }
 
   public bool RemoveMod(string profileName, ProfileModEntry entry)
   {
-    var profile = FindProfile(profileName);
-    var index = profile?.Mods.IndexOf(entry) ?? -1;
-    if (index < 0)
-      return false;
-
-    profile.Mods.RemoveAt(index);
-    if (ProfileStorage.Save(profile))
-      return true;
-
-    profile.Mods.Insert(index, entry);
-    return false;
+    return RemoveMods(profileName, [entry]);
   }
 
-  public bool SyncActiveProfile(ModList modList)
+  public bool RemoveMods(string profileName, IEnumerable<ProfileModEntry> entries)
   {
-    var profile = ActiveProfile;
-    if (profile == null || !WasActiveProfileApplied)
+    if (IsVanillaProfile(profileName))
       return false;
-    if (Configs.AppliedModProfileHash.Value == GetModListHash(modList))
+    var profile = FindProfile(profileName);
+    if (profile == null)
       return false;
 
-    var mods = MergeModList(profile, modList, false);
-    if (EntriesEqual(profile.Mods, mods))
+    var remove = entries.ToHashSet();
+    if (remove.Count == 0 || !profile.Mods.Any(remove.Contains))
       return false;
 
     var previousMods = profile.Mods;
-    profile.Mods = mods;
-    if (!ProfileStorage.Save(profile))
-    {
-      profile.Mods = previousMods;
-      return false;
-    }
-    SetAppliedProfile(profile.Name, modList);
-    return true;
-  }
+    profile.Mods = profile.Mods.Where(entry => !remove.Contains(entry)).ToList();
+    if (ProfileStorage.Save(profile))
+      return true;
 
-  public void MarkActiveProfileDirty()
-  {
-    if (ActiveProfile == null)
-      return;
-    Configs.AppliedModProfile.Value = "";
-    Configs.AppliedModProfileHash.Value = "";
-  }
-
-  public void MarkActiveProfileApplied(ModList modList)
-  {
-    var profile = ActiveProfile;
-    if (profile != null)
-      SetAppliedProfile(profile.Name, modList);
+    profile.Mods = previousMods;
+    return false;
   }
 
   public void DisableProfiles()
   {
     Configs.ModProfile.Value = "";
-    Configs.AppliedModProfile.Value = "";
-    Configs.AppliedModProfileHash.Value = "";
   }
 
   public bool HasDiverged(string profileName, ModList modList)
@@ -164,26 +153,27 @@ public class ProfileManager
 
     var current = modList.EnabledMods.Select(GetIdentity);
     var saved = profile.Mods
-      .Where(entry => entry.Enabled)
       .Select(entry => FindMod(entry, modIndex))
       .Where(mod => mod != null)
       .Select(GetIdentity);
     return !current.SequenceEqual(saved, StringComparer.OrdinalIgnoreCase);
   }
 
-  public List<ModInfo> GetNewMods(string profileName, ModList modList)
+  public List<ProfileModEntry> GetMissingMods(string profileName, ModList modList)
   {
     var profile = FindProfile(profileName);
     if (profile == null)
       return [];
 
-    var knownMods = profile.Mods
-      .Select(GetIdentity)
-      .ToHashSet(StringComparer.OrdinalIgnoreCase);
-    return modList.AllMods
-      .Where(mod => !knownMods.Contains(GetIdentity(mod)))
+    var modIndex = BuildModIndex(modList.AllMods);
+    return profile.Mods
+      .Where(entry => GetIdentity(entry) != "Core"
+        && FindMod(entry, modIndex) == null)
       .ToList();
   }
+
+  public static bool IsVanillaProfile(string profileName) =>
+    VanillaProfileName.Equals(profileName, StringComparison.OrdinalIgnoreCase);
 
   public ProfileData FindProfile(string profileName)
   {
@@ -208,30 +198,38 @@ public class ProfileManager
     return index;
   }
 
-  private static List<ProfileModEntry> MergeModList(ProfileData profile, ModList modList, bool addNew)
-  {
-    var entries = new List<ProfileModEntry>();
-    var matched = new HashSet<ProfileModEntry>();
-    foreach (var mod in modList.AllMods)
-    {
-      var existing = profile.Mods.FirstOrDefault(entry => Matches(entry, mod));
-      if (existing == null && !addNew)
-        continue;
-
-      entries.Add(CaptureMod(mod));
-      if (existing != null)
-        matched.Add(existing);
-    }
-
-    entries.AddRange(profile.Mods.Where(entry => !matched.Contains(entry)));
-    return entries;
-  }
-
   private static ProfileData CaptureModList(string profileName, ModList modList) => new()
   {
     Name = profileName,
-    Mods = [.. modList.AllMods.Select(CaptureMod)],
+    Mods = CaptureEnabledMods(modList),
   };
+
+  private static List<ProfileModEntry> CaptureEnabledMods(ModList modList) =>
+    [.. modList.EnabledMods.Select(CaptureMod)];
+
+  private static ProfileData CreateVanillaProfile() => new()
+  {
+    Name = VanillaProfileName,
+    Description = "Launch Stationeers without mods.",
+    Mods =
+    [
+      new()
+      {
+        Name = "Core",
+        Source = ModSourceType.Core,
+        DirectoryPath = "",
+      },
+    ],
+  };
+
+  private void SortProfiles() => profiles.Sort((a, b) =>
+  {
+    var aVanilla = IsVanillaProfile(a.Name);
+    var bVanilla = IsVanillaProfile(b.Name);
+    if (aVanilla != bVanilla)
+      return aVanilla ? -1 : 1;
+    return string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+  });
 
   private static ProfileModEntry CaptureMod(ModInfo mod) => new()
   {
@@ -240,19 +238,7 @@ public class ProfileManager
     DirectoryPath = mod.DirectoryPath ?? "",
     WorkshopHandle = mod.WorkshopHandle,
     ModID = mod.ModID,
-    Enabled = mod.Enabled,
   };
-
-  private static bool EntriesEqual(List<ProfileModEntry> left, List<ProfileModEntry> right)
-  {
-    if (left.Count != right.Count)
-      return false;
-
-    return left.Zip(right, (a, b) =>
-      a.Enabled == b.Enabled
-      && GetIdentity(a).Equals(GetIdentity(b), StringComparison.OrdinalIgnoreCase)
-    ).All(equal => equal);
-  }
 
   private static bool Matches(ProfileModEntry entry, ModInfo mod) =>
     GetIdentity(entry).Equals(GetIdentity(mod), StringComparison.OrdinalIgnoreCase);
@@ -268,26 +254,4 @@ public class ProfileManager
   private static string NormalizePath(string path) =>
     path?.Replace("\\", "/").Trim().ToLowerInvariant() ?? "";
 
-  private static void SetAppliedProfile(string profileName, ModList modList)
-  {
-    Configs.ModProfile.Value = profileName;
-    Configs.AppliedModProfile.Value = profileName;
-    Configs.AppliedModProfileHash.Value = GetModListHash(modList);
-  }
-
-  private static string GetModListHash(ModList modList)
-  {
-    var hash = 14695981039346656037UL;
-    foreach (var mod in modList.EnabledMods)
-    {
-      foreach (var c in GetIdentity(mod))
-      {
-        hash ^= c;
-        hash *= 1099511628211UL;
-      }
-      hash ^= 0xff;
-      hash *= 1099511628211UL;
-    }
-    return hash.ToString("x16");
-  }
 }

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -153,6 +153,10 @@ public class ProfileManager
   }
 
   public bool HasDiverged(string profileName, ModList modList)
+    => HasDiverged(profileName, modList, BuildModIndex(modList.AllMods));
+
+  internal bool HasDiverged(
+    string profileName, ModList modList, IReadOnlyDictionary<string, ModInfo> modIndex)
   {
     var profile = FindProfile(profileName);
     if (profile == null)
@@ -161,7 +165,7 @@ public class ProfileManager
     var current = modList.EnabledMods.Select(GetIdentity);
     var saved = profile.Mods
       .Where(entry => entry.Enabled)
-      .Select(entry => FindMod(entry, modList.AllMods))
+      .Select(entry => FindMod(entry, modIndex))
       .Where(mod => mod != null)
       .Select(GetIdentity);
     return !current.SequenceEqual(saved, StringComparer.OrdinalIgnoreCase);
@@ -173,8 +177,11 @@ public class ProfileManager
     if (profile == null)
       return [];
 
+    var knownMods = profile.Mods
+      .Select(GetIdentity)
+      .ToHashSet(StringComparer.OrdinalIgnoreCase);
     return modList.AllMods
-      .Where(mod => profile.Mods.All(entry => !Matches(entry, mod)))
+      .Where(mod => !knownMods.Contains(GetIdentity(mod)))
       .ToList();
   }
 
@@ -188,6 +195,18 @@ public class ProfileManager
 
   internal static ModInfo FindMod(ProfileModEntry entry, IEnumerable<ModInfo> mods) =>
     mods.FirstOrDefault(mod => Matches(entry, mod));
+
+  internal static ModInfo FindMod(
+    ProfileModEntry entry, IReadOnlyDictionary<string, ModInfo> modIndex) =>
+    modIndex.TryGetValue(GetIdentity(entry), out var mod) ? mod : null;
+
+  internal static Dictionary<string, ModInfo> BuildModIndex(IEnumerable<ModInfo> mods)
+  {
+    var index = new Dictionary<string, ModInfo>(StringComparer.OrdinalIgnoreCase);
+    foreach (var mod in mods)
+      index.TryAdd(GetIdentity(mod), mod);
+    return index;
+  }
 
   private static List<ProfileModEntry> MergeModList(ProfileData profile, ModList modList, bool addNew)
   {

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -10,6 +10,7 @@ public class ProfileManager
   private List<ProfileData> profiles = [];
 
   public IReadOnlyList<ProfileData> AllProfiles => profiles;
+  public bool IsInitialized { get; private set; }
   public string ActiveProfileName => Configs.ModProfile.Value;
   public ProfileData ActiveProfile => FindProfile(ActiveProfileName);
   public bool WasActiveProfileApplied =>
@@ -18,8 +19,12 @@ public class ProfileManager
 
   public void Initialize()
   {
+    if (IsInitialized)
+      return;
+
     profiles = ProfileStorage.LoadAll();
     profiles.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+    IsInitialized = true;
 
     if (string.IsNullOrEmpty(ActiveProfileName) || ActiveProfile != null)
       return;

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -1,141 +1,191 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using StationeersLaunchPad.Sources;
 
 namespace StationeersLaunchPad.Metadata;
 
 public class ProfileManager
 {
-    private List<ProfileData> profiles = [];
+  private List<ProfileData> profiles = [];
 
-    public IReadOnlyList<ProfileData> AllProfiles => profiles;
-    public string ActiveProfileName { get; private set; }
-    public bool HasDiverged { get; private set; }
+  public IReadOnlyList<ProfileData> AllProfiles => profiles;
+  public string ActiveProfileName => Configs.ModProfile.Value;
+  public ProfileData ActiveProfile => FindProfile(ActiveProfileName);
+  public bool WasActiveProfileApplied =>
+    !string.IsNullOrEmpty(ActiveProfileName)
+    && ActiveProfileName.Equals(Configs.AppliedModProfile.Value, StringComparison.OrdinalIgnoreCase);
 
-    public bool ProfileExists(string profileName) =>
-        profiles.Any(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+  public void Initialize()
+  {
+    profiles = ProfileStorage.LoadAll();
+    profiles.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
 
-    public void Initialize()
+    if (string.IsNullOrEmpty(ActiveProfileName) || ActiveProfile != null)
+      return;
+
+    Logger.Global.LogWarning($"Configured mod profile '{ActiveProfileName}' was not found");
+    DisableProfiles();
+  }
+
+  public bool CreateProfile(string profileName, ModList modList)
+  {
+    if (!ProfileStorage.IsValidName(profileName) || FindProfile(profileName) != null)
+      return false;
+
+    var profile = CaptureModList(profileName, modList);
+    if (!ProfileStorage.Save(profile))
+      return false;
+
+    profiles.Add(profile);
+    profiles.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+    return true;
+  }
+
+  public bool ApplyProfile(string profileName, ModList modList)
+  {
+    var profile = FindProfile(profileName);
+    if (profile == null)
+      return false;
+
+    modList.ApplyProfile(profile);
+    Configs.ModProfile.Value = profile.Name;
+    Configs.AppliedModProfile.Value = profile.Name;
+    ModConfigUtil.SaveConfig(modList.ToModConfig());
+    return true;
+  }
+
+  public bool DeleteProfile(string profileName)
+  {
+    var profile = FindProfile(profileName);
+    if (profile == null || !ProfileStorage.Delete(profile.Name))
+      return false;
+
+    var wasActive = profile == ActiveProfile;
+    profiles.Remove(profile);
+    if (wasActive)
+      DisableProfiles();
+    return true;
+  }
+
+  public bool UpdateProfile(string profileName, ModList modList)
+  {
+    var profile = FindProfile(profileName);
+    if (profile == null)
+      return false;
+
+    profile.Mods = MergeModList(profile, modList, true);
+    return ProfileStorage.Save(profile);
+  }
+
+  public bool SyncActiveProfile(ModList modList)
+  {
+    var profile = ActiveProfile;
+    if (profile == null || !WasActiveProfileApplied)
+      return false;
+
+    var mods = MergeModList(profile, modList, false);
+    if (EntriesEqual(profile.Mods, mods))
+      return false;
+
+    profile.Mods = mods;
+    ProfileStorage.Save(profile);
+    return true;
+  }
+
+  public void DisableProfiles()
+  {
+    Configs.ModProfile.Value = "";
+    Configs.AppliedModProfile.Value = "";
+  }
+
+  public bool HasDiverged(string profileName, ModList modList)
+  {
+    var profile = FindProfile(profileName);
+    if (profile == null)
+      return false;
+
+    var current = modList.EnabledMods.Select(GetIdentity);
+    var saved = profile.Mods.Where(mod => mod.Enabled).Select(GetIdentity);
+    return !current.SequenceEqual(saved, StringComparer.OrdinalIgnoreCase);
+  }
+
+  public List<ModInfo> GetNewMods(string profileName, ModList modList)
+  {
+    var profile = FindProfile(profileName);
+    if (profile == null)
+      return [];
+
+    return modList.AllMods
+      .Where(mod => profile.Mods.All(entry => !Matches(entry, mod)))
+      .ToList();
+  }
+
+  public ProfileData FindProfile(string profileName)
+  {
+    if (string.IsNullOrEmpty(profileName))
+      return null;
+    return profiles.FirstOrDefault(profile =>
+      profile.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+  }
+
+  internal static ModInfo FindMod(ProfileModEntry entry, IEnumerable<ModInfo> mods) =>
+    mods.FirstOrDefault(mod => Matches(entry, mod));
+
+  private static List<ProfileModEntry> MergeModList(ProfileData profile, ModList modList, bool addNew)
+  {
+    var entries = new List<ProfileModEntry>();
+    var matched = new HashSet<ProfileModEntry>();
+    foreach (var mod in modList.AllMods)
     {
-        profiles = ProfileStorage.LoadAll();
-        ActiveProfileName = ProfileStorage.LoadActiveName();
+      var existing = profile.Mods.FirstOrDefault(entry => Matches(entry, mod));
+      if (existing == null && !addNew)
+        continue;
 
-        if (ActiveProfileName != null && !ProfileExists(ActiveProfileName))
-        {
-            ActiveProfileName = null;
-            ProfileStorage.ClearActiveName();
-        }
+      entries.Add(CaptureMod(mod));
+      if (existing != null)
+        matched.Add(existing);
     }
 
-    public bool CreateProfile(string profileName, ModList modList)
-    {
-        if (string.IsNullOrWhiteSpace(profileName) || ProfileExists(profileName))
-            return false;
+    entries.AddRange(profile.Mods.Where(entry => !matched.Contains(entry)));
+    return entries;
+  }
 
-        var profile = CaptureModList(profileName, modList);
-        ProfileStorage.Save(profile);
-        profiles.Add(profile);
-        return true;
-    }
+  private static ProfileData CaptureModList(string profileName, ModList modList) => new()
+  {
+    Name = profileName,
+    Mods = [.. modList.AllMods.Select(CaptureMod)],
+  };
 
-    public bool LoadProfile(string profileName, ModList modList)
-    {
-        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
-        if (profile == null)
-            return false;
-        
-        modList.ApplyProfile(profile);
-        ActiveProfileName = profile.Name;
-        HasDiverged = false;
-        ProfileStorage.SaveActiveName(ActiveProfileName);
-        ModConfigUtil.SaveConfig(modList.ToModConfig());
-        return true;
-    }
+  private static ProfileModEntry CaptureMod(ModInfo mod) => new()
+  {
+    Source = mod.Source,
+    DirectoryPath = mod.DirectoryPath ?? "",
+    WorkshopHandle = mod.WorkshopHandle,
+    ModID = mod.ModID,
+    Enabled = mod.Enabled,
+  };
 
-    public bool DeleteProfile(string profileName)
-    {
-        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
-        if (profile == null)
-            return false;
+  private static bool EntriesEqual(List<ProfileModEntry> left, List<ProfileModEntry> right)
+  {
+    if (left.Count != right.Count)
+      return false;
 
-        profiles.Remove(profile);
-        ProfileStorage.Delete(profileName);
+    return left.Zip(right, (a, b) =>
+      a.Enabled == b.Enabled
+      && GetIdentity(a).Equals(GetIdentity(b), StringComparison.OrdinalIgnoreCase)
+    ).All(equal => equal);
+  }
 
-        if (ActiveProfileName != null && ActiveProfileName.Equals(profileName, StringComparison.OrdinalIgnoreCase))
-        {
-            ActiveProfileName = null;
-            ProfileStorage.ClearActiveName();
-        }
+  private static bool Matches(ProfileModEntry entry, ModInfo mod) =>
+    GetIdentity(entry).Equals(GetIdentity(mod), StringComparison.OrdinalIgnoreCase);
 
-        return true;
-    }
+  private static string GetIdentity(ProfileModEntry entry) =>
+    entry.Source == ModSourceType.Core ? "Core" : NormalizePath(entry.DirectoryPath);
 
-    public bool RenameProfile(string oldProfileName, string newProfileName)
-    {
-        if (string.IsNullOrWhiteSpace(newProfileName))
-            return false;
-        
-        var existingProfile = profiles.FirstOrDefault(p => p.Name.Equals(oldProfileName, StringComparison.OrdinalIgnoreCase));
-        if (existingProfile == null)
-            return false;
+  private static string GetIdentity(ModInfo mod) =>
+    mod.Source == ModSourceType.Core ? "Core" : NormalizePath(mod.DirectoryPath);
 
-        if (profiles.Any(p => p != existingProfile && p.Name.Equals(newProfileName, StringComparison.OrdinalIgnoreCase)))
-            return false;
-        
-        var renamedProfile = ProfileStorage.Rename(oldProfileName, newProfileName);
-        if (renamedProfile == null)
-            return false;
-        
-        var index = profiles.IndexOf(renamedProfile);
-        profiles[index] = renamedProfile;
-
-        if (ActiveProfileName != null && ActiveProfileName.Equals(oldProfileName, StringComparison.OrdinalIgnoreCase))
-        {
-            ActiveProfileName = renamedProfile.Name;
-            ProfileStorage.SaveActiveName(ActiveProfileName);
-        }
-
-        return true;
-    }
-
-    public bool UpdateProfile(string profileName, ModList modList)
-    {
-        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
-        if (profile == null)
-            return false;
-
-        var updatedProfile = CaptureModList(profileName, modList);
-        profile.Description = updatedProfile.Description;
-        profile.Mods = updatedProfile.Mods;
-        ProfileStorage.Save(profile);
-        return true;
-    }
-
-    public void MarkDiverged() => HasDiverged = true;
-
-    public ProfileData GetStartupProfile()
-    {
-        return profiles.Count switch
-        {
-            0 => null,
-            1 => profiles[0],
-            _ => null,
-        };
-    }
-    
-    private static ProfileData CaptureModList(string profileName, ModList modList)
-    {
-        var profile = new ProfileData { Name = profileName };
-        foreach (var mod in modList.AllMods)
-        {
-            profile.Mods.Add(new ProfileModEntry
-            {
-                DirectoryPath = mod.DirectoryPath ?? "",
-                WorkshopHandle = mod.WorkshopHandle,
-                Enabled = mod.Enabled,
-            });
-        }
-
-        return profile;
-    }
+  private static string NormalizePath(string path) =>
+    path?.Replace("\\", "/").Trim().ToLowerInvariant() ?? "";
 }

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -61,21 +61,6 @@ public class ProfileManager
     return true;
   }
 
-  public void DisableModsOutsideProfile(string profileName, ModList modList)
-  {
-    var profile = FindProfile(profileName);
-    if (profile == null)
-      return;
-
-    var included = profile.Mods
-      .Select(GetIdentity)
-      .ToHashSet(StringComparer.OrdinalIgnoreCase);
-    foreach (var mod in modList.AllMods)
-      if (!included.Contains(GetIdentity(mod)))
-        mod.Enabled = false;
-    ModConfigUtil.SaveConfig(modList.ToModConfig());
-  }
-
   public bool DeleteProfile(string profileName)
   {
     if (IsVanillaProfile(profileName))

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StationeersLaunchPad.Metadata;
+
+public class ProfileManager
+{
+    private List<ProfileData> profiles = [];
+
+    public IReadOnlyList<ProfileData> AllProfiles => profiles;
+    public string ActiveProfileName { get; private set; }
+    public bool HasDiverged { get; private set; }
+
+    public bool ProfileExists(string profileName) =>
+        profiles.Any(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+
+    public void Initialize()
+    {
+        profiles = ProfileStorage.LoadAll();
+        ActiveProfileName = ProfileStorage.LoadActiveName();
+
+        if (ActiveProfileName != null && !ProfileExists(ActiveProfileName))
+        {
+            ActiveProfileName = null;
+            ProfileStorage.ClearActiveName();
+        }
+    }
+
+    public bool CreateProfile(string profileName, ModList modList)
+    {
+        if (string.IsNullOrWhiteSpace(profileName) || ProfileExists(profileName))
+            return false;
+
+        var profile = CaptureModList(profileName, modList);
+        ProfileStorage.Save(profile);
+        profiles.Add(profile);
+        return true;
+    }
+
+    public bool LoadProfile(string profileName, ModList modList)
+    {
+        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        if (profile == null)
+            return false;
+        
+        modList.ApplyProfile(profile);
+        ActiveProfileName = profile.Name;
+        HasDiverged = false;
+        ProfileStorage.SaveActiveName(ActiveProfileName);
+        ModConfigUtil.SaveConfig(modList.ToModConfig());
+        return true;
+    }
+
+    public bool DeleteProfile(string profileName)
+    {
+        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        if (profile == null)
+            return false;
+
+        profiles.Remove(profile);
+        ProfileStorage.Delete(profileName);
+
+        if (ActiveProfileName != null && ActiveProfileName.Equals(profileName, StringComparison.OrdinalIgnoreCase))
+        {
+            ActiveProfileName = null;
+            ProfileStorage.ClearActiveName();
+        }
+
+        return true;
+    }
+
+    public bool RenameProfile(string oldProfileName, string newProfileName)
+    {
+        if (string.IsNullOrWhiteSpace(newProfileName))
+            return false;
+        
+        var existingProfile = profiles.FirstOrDefault(p => p.Name.Equals(oldProfileName, StringComparison.OrdinalIgnoreCase));
+        if (existingProfile == null)
+            return false;
+
+        if (profiles.Any(p => p != existingProfile && p.Name.Equals(newProfileName, StringComparison.OrdinalIgnoreCase)))
+            return false;
+        
+        var renamedProfile = ProfileStorage.Rename(oldProfileName, newProfileName);
+        if (renamedProfile == null)
+            return false;
+        
+        var index = profiles.IndexOf(renamedProfile);
+        profiles[index] = renamedProfile;
+
+        if (ActiveProfileName != null && ActiveProfileName.Equals(oldProfileName, StringComparison.OrdinalIgnoreCase))
+        {
+            ActiveProfileName = renamedProfile.Name;
+            ProfileStorage.SaveActiveName(ActiveProfileName);
+        }
+
+        return true;
+    }
+
+    public bool UpdateProfile(string profileName, ModList modList)
+    {
+        var profile = profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        if (profile == null)
+            return false;
+
+        var updatedProfile = CaptureModList(profileName, modList);
+        profile.Description = updatedProfile.Description;
+        profile.Mods = updatedProfile.Mods;
+        ProfileStorage.Save(profile);
+        return true;
+    }
+
+    public void MarkDiverged() => HasDiverged = true;
+
+    public ProfileData GetStartupProfile()
+    {
+        return profiles.Count switch
+        {
+            0 => null,
+            1 => profiles[0],
+            _ => null,
+        };
+    }
+    
+    private static ProfileData CaptureModList(string profileName, ModList modList)
+    {
+        var profile = new ProfileData { Name = profileName };
+        foreach (var mod in modList.AllMods)
+        {
+            profile.Mods.Add(new ProfileModEntry
+            {
+                DirectoryPath = mod.DirectoryPath ?? "",
+                WorkshopHandle = mod.WorkshopHandle,
+                Enabled = mod.Enabled,
+            });
+        }
+
+        return profile;
+    }
+}

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -15,7 +15,8 @@ public class ProfileManager
   public ProfileData ActiveProfile => FindProfile(ActiveProfileName);
   public bool WasActiveProfileApplied =>
     !string.IsNullOrEmpty(ActiveProfileName)
-    && ActiveProfileName.Equals(Configs.AppliedModProfile.Value, StringComparison.OrdinalIgnoreCase);
+    && ActiveProfileName.Equals(Configs.AppliedModProfile.Value, StringComparison.OrdinalIgnoreCase)
+    && !string.IsNullOrEmpty(Configs.AppliedModProfileHash.Value);
 
   public void Initialize()
   {
@@ -54,8 +55,7 @@ public class ProfileManager
       return false;
 
     modList.ApplyProfile(profile);
-    Configs.ModProfile.Value = profile.Name;
-    Configs.AppliedModProfile.Value = profile.Name;
+    SetAppliedProfile(profile.Name, modList);
     ModConfigUtil.SaveConfig(modList.ToModConfig());
     return true;
   }
@@ -79,8 +79,32 @@ public class ProfileManager
     if (profile == null)
       return false;
 
+    var previousMods = profile.Mods;
     profile.Mods = MergeModList(profile, modList, true);
-    return ProfileStorage.Save(profile);
+    if (!ProfileStorage.Save(profile))
+    {
+      profile.Mods = previousMods;
+      return false;
+    }
+
+    if (profile == ActiveProfile)
+      SetAppliedProfile(profile.Name, modList);
+    return true;
+  }
+
+  public bool RemoveMod(string profileName, ProfileModEntry entry)
+  {
+    var profile = FindProfile(profileName);
+    var index = profile?.Mods.IndexOf(entry) ?? -1;
+    if (index < 0)
+      return false;
+
+    profile.Mods.RemoveAt(index);
+    if (ProfileStorage.Save(profile))
+      return true;
+
+    profile.Mods.Insert(index, entry);
+    return false;
   }
 
   public bool SyncActiveProfile(ModList modList)
@@ -88,20 +112,44 @@ public class ProfileManager
     var profile = ActiveProfile;
     if (profile == null || !WasActiveProfileApplied)
       return false;
+    if (Configs.AppliedModProfileHash.Value == GetModListHash(modList))
+      return false;
 
     var mods = MergeModList(profile, modList, false);
     if (EntriesEqual(profile.Mods, mods))
       return false;
 
+    var previousMods = profile.Mods;
     profile.Mods = mods;
-    ProfileStorage.Save(profile);
+    if (!ProfileStorage.Save(profile))
+    {
+      profile.Mods = previousMods;
+      return false;
+    }
+    SetAppliedProfile(profile.Name, modList);
     return true;
+  }
+
+  public void MarkActiveProfileDirty()
+  {
+    if (ActiveProfile == null)
+      return;
+    Configs.AppliedModProfile.Value = "";
+    Configs.AppliedModProfileHash.Value = "";
+  }
+
+  public void MarkActiveProfileApplied(ModList modList)
+  {
+    var profile = ActiveProfile;
+    if (profile != null)
+      SetAppliedProfile(profile.Name, modList);
   }
 
   public void DisableProfiles()
   {
     Configs.ModProfile.Value = "";
     Configs.AppliedModProfile.Value = "";
+    Configs.AppliedModProfileHash.Value = "";
   }
 
   public bool HasDiverged(string profileName, ModList modList)
@@ -111,7 +159,11 @@ public class ProfileManager
       return false;
 
     var current = modList.EnabledMods.Select(GetIdentity);
-    var saved = profile.Mods.Where(mod => mod.Enabled).Select(GetIdentity);
+    var saved = profile.Mods
+      .Where(entry => entry.Enabled)
+      .Select(entry => FindMod(entry, modList.AllMods))
+      .Where(mod => mod != null)
+      .Select(GetIdentity);
     return !current.SequenceEqual(saved, StringComparer.OrdinalIgnoreCase);
   }
 
@@ -164,6 +216,7 @@ public class ProfileManager
 
   private static ProfileModEntry CaptureMod(ModInfo mod) => new()
   {
+    Name = mod.Name ?? "",
     Source = mod.Source,
     DirectoryPath = mod.DirectoryPath ?? "",
     WorkshopHandle = mod.WorkshopHandle,
@@ -195,4 +248,27 @@ public class ProfileManager
 
   private static string NormalizePath(string path) =>
     path?.Replace("\\", "/").Trim().ToLowerInvariant() ?? "";
+
+  private static void SetAppliedProfile(string profileName, ModList modList)
+  {
+    Configs.ModProfile.Value = profileName;
+    Configs.AppliedModProfile.Value = profileName;
+    Configs.AppliedModProfileHash.Value = GetModListHash(modList);
+  }
+
+  private static string GetModListHash(ModList modList)
+  {
+    var hash = 14695981039346656037UL;
+    foreach (var mod in modList.EnabledMods)
+    {
+      foreach (var c in GetIdentity(mod))
+      {
+        hash ^= c;
+        hash *= 1099511628211UL;
+      }
+      hash ^= 0xff;
+      hash *= 1099511628211UL;
+    }
+    return hash.ToString("x16");
+  }
 }

--- a/StationeersLaunchPad/Metadata/ProfileManager.cs
+++ b/StationeersLaunchPad/Metadata/ProfileManager.cs
@@ -186,7 +186,9 @@ public class ProfileManager
     GetIdentity(entry).Equals(GetIdentity(mod), StringComparison.OrdinalIgnoreCase);
 
   private static string GetIdentity(ProfileModEntry entry) =>
-    entry.Source == ModSourceType.Core ? "Core" : NormalizePath(entry.DirectoryPath);
+    string.IsNullOrEmpty(entry.DirectoryPath) && entry.WorkshopHandle <= 1
+      ? "Core"
+      : NormalizePath(entry.DirectoryPath);
 
   private static string GetIdentity(ModInfo mod) =>
     mod.Source == ModSourceType.Core ? "Core" : NormalizePath(mod.DirectoryPath);

--- a/StationeersLaunchPad/Metadata/ProfileStorage.cs
+++ b/StationeersLaunchPad/Metadata/ProfileStorage.cs
@@ -22,7 +22,10 @@ public static class ProfileStorage
       {
         var profile = XmlSerialization.Deserialize<ProfileData>(file);
         if (profile != null && IsValidName(profile.Name))
+        {
+          profile.Mods = profile.Mods.Where(entry => entry.LegacyEnabled).ToList();
           profiles.Add(profile);
+        }
         else
           Logger.Global.LogWarning($"Skipping invalid profile file: {file}");
       }

--- a/StationeersLaunchPad/Metadata/ProfileStorage.cs
+++ b/StationeersLaunchPad/Metadata/ProfileStorage.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+using Assets.Scripts.Serialization;
+
+namespace StationeersLaunchPad.Metadata;
+
+[XmlRoot("ActiveProfile")]
+public class ActiveProfileConfig
+{
+    [XmlAttribute("Name")]
+    public string Name;
+}
+
+public class ProfileStorage
+{
+    public static string ProfilesDirectory => Path.Join(LaunchPadPaths.SavePath, "profiles");
+    public static string ActiveConfigPath => Path.Join(LaunchPadPaths.SavePath, "active.xml");
+
+    public static List<ProfileData> LoadAll()
+    {
+        var dir = ProfilesDirectory;
+        if (!Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+            return [];
+        }
+
+        var profiles = new List<ProfileData>();
+
+        foreach (var file in Directory.GetFiles(dir, "*.xml"))
+        {
+            try
+            {
+                var profile = XmlSerialization.Deserialize<ProfileData>(file);
+                if (profile != null)
+                    profiles.Add(profile);
+                else
+                    Logger.Global.LogWarning($"Skipping corrupt profile file: {file}");
+            }
+            catch (Exception e)
+            {
+                Logger.Global.LogWarning($"Skipping corrupt profile file: {file} ({e.Message})");
+            }
+        }
+
+        return profiles;
+    }
+
+    public static ProfileData Load(string profileName)
+    {
+        var path = GetProfilePath(profileName);
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            return XmlSerialization.Deserialize<ProfileData>(path);
+        }
+        catch (Exception e)
+        {
+            Logger.Global.LogWarning($"Failed to load profile '{profileName}': {e.Message}");
+            return null;
+        }
+    }
+
+    public static void Save(ProfileData profile)
+    {
+        var dir = ProfilesDirectory;
+        if (!Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var path = GetProfilePath(profile.Name);
+        if (!profile.SaveXml(path))
+            Logger.Global.LogError($"Failed to save profile to {path}");
+    }
+
+    public static void Delete(string profileName)
+    {
+        var path = GetProfilePath(profileName);
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception e)
+        {
+            Logger.Global.LogError($"Failed to delete profile '{profileName}': {e.Message}");
+        }
+    }
+
+    public static ProfileData Rename(string oldProfileName, string newProfileName)
+    {
+        var profile = Load(oldProfileName);
+        if (profile == null)
+            return null;
+        
+        profile.Name = newProfileName;
+        Save(profile);
+        Delete(oldProfileName);
+        return profile;
+    }
+
+    public static string LoadActiveName()
+    {
+        if (!File.Exists(ActiveConfigPath))
+            return null;
+
+        try
+        {
+            var config = XmlSerialization.Deserialize<ActiveProfileConfig>(ActiveConfigPath);
+            return config?.Name;
+        }
+        catch (Exception e)
+        {
+            Logger.Global.LogError($"Failed to load active profile config: {e.Message}");
+            return null;
+        }
+    }
+
+    public static void SaveActiveName(string profileName)
+    {
+        var dir = ProfilesDirectory;
+        if (!Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var config = new ActiveProfileConfig { Name = profileName };
+        if (!config.SaveXml(ActiveConfigPath))
+            Logger.Global.LogError($"Failed to save active profile config to {ActiveConfigPath}");
+    }
+
+    public static void ClearActiveName()
+    {
+        try
+        {
+            if (File.Exists(ActiveConfigPath))
+                File.Delete(ActiveConfigPath);
+        }
+        catch (Exception e)
+        {
+            Logger.Global.LogError($"Failed to clear active profile config: {e.Message}");
+        }
+    }
+
+    private static string GetProfilePath(string profileName)
+    {
+        var sanitized = Platform.MakeValidFileName(profileName).ToLowerInvariant();
+        return Path.Join(ProfilesDirectory, $"{sanitized}.xml");
+    }
+}

--- a/StationeersLaunchPad/Metadata/ProfileStorage.cs
+++ b/StationeersLaunchPad/Metadata/ProfileStorage.cs
@@ -1,151 +1,85 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Xml.Serialization;
+using System.Linq;
 using Assets.Scripts.Serialization;
 
 namespace StationeersLaunchPad.Metadata;
 
-[XmlRoot("ActiveProfile")]
-public class ActiveProfileConfig
+public static class ProfileStorage
 {
-    [XmlAttribute("Name")]
-    public string Name;
-}
+  public static string ProfilesDirectory => Path.Join(LaunchPadPaths.SavePath, "profiles");
 
-public class ProfileStorage
-{
-    public static string ProfilesDirectory => Path.Join(LaunchPadPaths.SavePath, "profiles");
-    public static string ActiveConfigPath => Path.Join(LaunchPadPaths.SavePath, "active.xml");
+  public static List<ProfileData> LoadAll()
+  {
+    if (!Directory.Exists(ProfilesDirectory))
+      return [];
 
-    public static List<ProfileData> LoadAll()
+    var profiles = new List<ProfileData>();
+    foreach (var file in Directory.GetFiles(ProfilesDirectory, "*.xml").OrderBy(path => path))
     {
-        var dir = ProfilesDirectory;
-        if (!Directory.Exists(dir))
-        {
-            Directory.CreateDirectory(dir);
-            return [];
-        }
-
-        var profiles = new List<ProfileData>();
-
-        foreach (var file in Directory.GetFiles(dir, "*.xml"))
-        {
-            try
-            {
-                var profile = XmlSerialization.Deserialize<ProfileData>(file);
-                if (profile != null)
-                    profiles.Add(profile);
-                else
-                    Logger.Global.LogWarning($"Skipping corrupt profile file: {file}");
-            }
-            catch (Exception e)
-            {
-                Logger.Global.LogWarning($"Skipping corrupt profile file: {file} ({e.Message})");
-            }
-        }
-
-        return profiles;
+      try
+      {
+        var profile = XmlSerialization.Deserialize<ProfileData>(file);
+        if (profile != null && IsValidName(profile.Name))
+          profiles.Add(profile);
+        else
+          Logger.Global.LogWarning($"Skipping invalid profile file: {file}");
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogWarning($"Skipping invalid profile file: {file} ({ex.Message})");
+      }
     }
+    return profiles;
+  }
 
-    public static ProfileData Load(string profileName)
+  public static bool Save(ProfileData profile)
+  {
+    if (!IsValidName(profile?.Name))
+      return false;
+
+    if (!Directory.Exists(ProfilesDirectory))
+      Directory.CreateDirectory(ProfilesDirectory);
+
+    var path = GetProfilePath(profile.Name);
+    if (profile.SaveXml(path))
+      return true;
+
+    Logger.Global.LogError($"Failed to save profile to {path}");
+    return false;
+  }
+
+  public static bool Delete(string profileName)
+  {
+    if (!IsValidName(profileName))
+      return false;
+
+    try
     {
-        var path = GetProfilePath(profileName);
-        if (!File.Exists(path))
-            return null;
-
-        try
-        {
-            return XmlSerialization.Deserialize<ProfileData>(path);
-        }
-        catch (Exception e)
-        {
-            Logger.Global.LogWarning($"Failed to load profile '{profileName}': {e.Message}");
-            return null;
-        }
+      var path = GetProfilePath(profileName);
+      if (File.Exists(path))
+        File.Delete(path);
+      return true;
     }
-
-    public static void Save(ProfileData profile)
+    catch (Exception ex)
     {
-        var dir = ProfilesDirectory;
-        if (!Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
-
-        var path = GetProfilePath(profile.Name);
-        if (!profile.SaveXml(path))
-            Logger.Global.LogError($"Failed to save profile to {path}");
+      Logger.Global.LogError($"Failed to delete profile '{profileName}': {ex.Message}");
+      return false;
     }
+  }
 
-    public static void Delete(string profileName)
-    {
-        var path = GetProfilePath(profileName);
-        try
-        {
-            if (File.Exists(path))
-                File.Delete(path);
-        }
-        catch (Exception e)
-        {
-            Logger.Global.LogError($"Failed to delete profile '{profileName}': {e.Message}");
-        }
-    }
+  public static bool IsValidName(string profileName)
+  {
+    if (string.IsNullOrWhiteSpace(profileName))
+      return false;
 
-    public static ProfileData Rename(string oldProfileName, string newProfileName)
-    {
-        var profile = Load(oldProfileName);
-        if (profile == null)
-            return null;
-        
-        profile.Name = newProfileName;
-        Save(profile);
-        Delete(oldProfileName);
-        return profile;
-    }
+    var name = profileName.Trim();
+    return name == profileName
+      && name is not "." and not ".."
+      && Platform.MakeValidFileName(name) == name;
+  }
 
-    public static string LoadActiveName()
-    {
-        if (!File.Exists(ActiveConfigPath))
-            return null;
-
-        try
-        {
-            var config = XmlSerialization.Deserialize<ActiveProfileConfig>(ActiveConfigPath);
-            return config?.Name;
-        }
-        catch (Exception e)
-        {
-            Logger.Global.LogError($"Failed to load active profile config: {e.Message}");
-            return null;
-        }
-    }
-
-    public static void SaveActiveName(string profileName)
-    {
-        var dir = ProfilesDirectory;
-        if (!Directory.Exists(dir))
-            Directory.CreateDirectory(dir);
-
-        var config = new ActiveProfileConfig { Name = profileName };
-        if (!config.SaveXml(ActiveConfigPath))
-            Logger.Global.LogError($"Failed to save active profile config to {ActiveConfigPath}");
-    }
-
-    public static void ClearActiveName()
-    {
-        try
-        {
-            if (File.Exists(ActiveConfigPath))
-                File.Delete(ActiveConfigPath);
-        }
-        catch (Exception e)
-        {
-            Logger.Global.LogError($"Failed to clear active profile config: {e.Message}");
-        }
-    }
-
-    private static string GetProfilePath(string profileName)
-    {
-        var sanitized = Platform.MakeValidFileName(profileName).ToLowerInvariant();
-        return Path.Join(ProfilesDirectory, $"{sanitized}.xml");
-    }
+  private static string GetProfilePath(string profileName) =>
+    Path.Join(ProfilesDirectory, $"{profileName.ToLowerInvariant()}.xml");
 }

--- a/StationeersLaunchPad/Metadata/WorkshopPackageCode.cs
+++ b/StationeersLaunchPad/Metadata/WorkshopPackageCode.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace StationeersLaunchPad.Metadata;
+
+public static class WorkshopPackageCode
+{
+  private const string Prefix = "SLP1:";
+  private const int MaxItems = 1000;
+
+  public static string Encode(IEnumerable<ulong> workshopIds)
+  {
+    var ids = new List<ulong>(workshopIds);
+    if (ids.Count == 0 || ids.Count > MaxItems)
+      return "";
+
+    var unique = new HashSet<ulong>();
+    using var stream = new MemoryStream();
+    WriteVarUInt(stream, (ulong)ids.Count);
+    foreach (var id in ids)
+    {
+      if (id < 2 || !unique.Add(id))
+        return "";
+      WriteVarUInt(stream, id);
+    }
+
+    var payload = stream.ToArray();
+    var checksum = GetChecksum(payload, payload.Length);
+    stream.WriteByte((byte)checksum);
+    stream.WriteByte((byte)(checksum >> 8));
+    stream.WriteByte((byte)(checksum >> 16));
+    stream.WriteByte((byte)(checksum >> 24));
+    return Prefix + Convert.ToBase64String(stream.ToArray())
+      .TrimEnd(new[] { '=' })
+      .Replace('+', '-')
+      .Replace('/', '_');
+  }
+
+  public static bool TryDecode(string code, out List<ulong> workshopIds)
+  {
+    workshopIds = [];
+    if (string.IsNullOrWhiteSpace(code))
+      return false;
+
+    code = code.Trim();
+    if (!code.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase))
+      return false;
+
+    byte[] bytes;
+    try
+    {
+      var encoded = code[Prefix.Length..].Replace('-', '+').Replace('_', '/');
+      if (encoded.Length % 4 == 1)
+        return false;
+      encoded = encoded.PadRight(encoded.Length + (4 - encoded.Length % 4) % 4, '=');
+      bytes = Convert.FromBase64String(encoded);
+    }
+    catch (FormatException)
+    {
+      return false;
+    }
+
+    if (bytes.Length < 6)
+      return false;
+
+    var payloadLength = bytes.Length - 4;
+    var checksum = (uint)(bytes[payloadLength]
+      | bytes[payloadLength + 1] << 8
+      | bytes[payloadLength + 2] << 16
+      | bytes[payloadLength + 3] << 24);
+    if (checksum != GetChecksum(bytes, payloadLength))
+      return false;
+
+    var offset = 0;
+    if (!TryReadVarUInt(bytes, ref offset, payloadLength, out var count)
+      || count == 0 || count > MaxItems)
+      return false;
+
+    var unique = new HashSet<ulong>();
+    for (ulong i = 0; i < count; i++)
+    {
+      if (!TryReadVarUInt(bytes, ref offset, payloadLength, out var id)
+        || id < 2 || !unique.Add(id))
+        return false;
+      workshopIds.Add(id);
+    }
+    return offset == payloadLength;
+  }
+
+  private static void WriteVarUInt(Stream stream, ulong value)
+  {
+    while (value >= 0x80)
+    {
+      stream.WriteByte((byte)(value | 0x80));
+      value >>= 7;
+    }
+    stream.WriteByte((byte)value);
+  }
+
+  private static bool TryReadVarUInt(
+    byte[] bytes, ref int offset, int end, out ulong value)
+  {
+    value = 0;
+    for (var shift = 0; shift < 64; shift += 7)
+    {
+      if (offset >= end)
+        return false;
+      var next = bytes[offset++];
+      if (shift == 63 && (next & 0xfe) != 0)
+        return false;
+      value |= (ulong)(next & 0x7f) << shift;
+      if ((next & 0x80) == 0)
+        return true;
+    }
+    return false;
+  }
+
+  private static uint GetChecksum(byte[] bytes, int length)
+  {
+    var hash = 2166136261u;
+    for (var i = 0; i < length; i++)
+    {
+      hash ^= bytes[i];
+      hash *= 16777619;
+    }
+    return hash;
+  }
+}

--- a/StationeersLaunchPad/News/NewsData.cs
+++ b/StationeersLaunchPad/News/NewsData.cs
@@ -45,6 +45,9 @@ public class NewsTrigger
   [XmlAttribute("workshop_id")]
   public string WorkshopId;
 
+  [XmlAttribute("unless_workshop_id")]
+  public string UnlessWorkshopId;
+
   [XmlAttribute("mod_name")]
   public string ModName;
 

--- a/StationeersLaunchPad/News/NewsMatcher.cs
+++ b/StationeersLaunchPad/News/NewsMatcher.cs
@@ -22,7 +22,7 @@ public static class NewsMatcher
     var dismissedSet = dismissed ?? new HashSet<string>(StringComparer.Ordinal);
     var installedRepoModIDs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     var installedWorkshopIds = new HashSet<ulong>();
-    foreach (var mod in modList.EnabledMods)
+    foreach (var mod in modList.AllMods)
     {
       if (mod.Source == ModSourceType.Repo && !string.IsNullOrEmpty(mod.ModID))
         installedRepoModIDs.Add(mod.ModID);
@@ -47,6 +47,14 @@ public static class NewsMatcher
       if (!TriggerMatches(entry.Trigger, modList))
       {
         Logger.Global.LogDebug($"News: skipping {entry.Id} (no matching enabled mod)");
+        continue;
+      }
+
+      if (ulong.TryParse(entry.Trigger.UnlessWorkshopId, out var excludedWid)
+          && excludedWid > 1
+          && installedWorkshopIds.Contains(excludedWid))
+      {
+        Logger.Global.LogDebug($"News: skipping {entry.Id} (excluded workshop mod already installed)");
         continue;
       }
 

--- a/StationeersLaunchPad/News/NewsPopup.cs
+++ b/StationeersLaunchPad/News/NewsPopup.cs
@@ -230,9 +230,7 @@ public static class NewsPopup
       {
         var sw = Mathf.Min(180f, avail * 0.32f);
         if (ImGui.Button(entry.Actions.Secondary.Label ?? "Details", new Vector2(sw, btnH)) && canAct)
-        {
-          _ = NewsRunner.ExecuteSecondaryAction(entry);
-        }
+          OnAction(entry, entry.Actions.Secondary, -1);
         ImGui.SameLine();
         avail -= sw + spacing;
       }
@@ -362,6 +360,17 @@ public static class NewsPopup
       return;
     }
 
+    if (action.Action == "workshop_mod_subscribe")
+    {
+      isActionBusy = true;
+      actionStatus = null;
+      actionCompleted = false;
+      actionSucceeded = false;
+      actionResultMessage = null;
+      _ = DoWorkshopModSubscribe(action);
+      return;
+    }
+
     if (action.Action == "acknowledge" || action.Action == "dismiss" || string.IsNullOrEmpty(action.Action))
     {
       // just close the notice and do nothing else. Default for info type notices.
@@ -418,6 +427,27 @@ public static class NewsPopup
       actionCompleted = true;
       actionSucceeded = false;
       actionResultMessage = "Migration failed. See log.";
+    }
+  }
+
+  private static async UniTask DoWorkshopModSubscribe(NewsAction action)
+  {
+    actionStatus = null;
+    try
+    {
+      bool ok = await NewsRunner.ExecuteWorkshopModInstall(action?.WorkshopId);
+      isActionBusy = false;
+      actionCompleted = true;
+      actionSucceeded = ok;
+      actionResultMessage = ok ? "Workshop mod installed!" : "Workshop install failed. Check log.";
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      isActionBusy = false;
+      actionCompleted = true;
+      actionSucceeded = false;
+      actionResultMessage = "Workshop install failed. See log.";
     }
   }
 

--- a/StationeersLaunchPad/News/NewsRunner.cs
+++ b/StationeersLaunchPad/News/NewsRunner.cs
@@ -5,8 +5,6 @@ using Cysharp.Threading.Tasks;
 using StationeersLaunchPad;
 using StationeersLaunchPad.Metadata;
 using StationeersLaunchPad.Repos;
-using Steamworks.Data;
-using Steamworks.Ugc;
 using UnityEngine;
 
 namespace StationeersLaunchPad.News;
@@ -165,56 +163,6 @@ public static class NewsRunner
       return false;
     }
 
-    try
-    {
-      var pfid = new PublishedFileId { Value = wid };
-      var item = new Item(pfid);
-
-      Logger.Global.LogInfo($"news: subscribing to workshop item {wid}");
-      bool subOk = await item.Subscribe();
-      if (!subOk)
-      {
-        Logger.Global.LogError($"news: Subscribe() returned false for workshop {wid}");
-        return false;
-      }
-
-      Logger.Global.LogInfo($"news: downloading workshop item {wid}");
-      bool dlOk = await item.DownloadAsync();
-      if (!dlOk)
-      {
-        Logger.Global.LogError($"news: DownloadAsync() failed or was not successful for workshop {wid}");
-        return false;
-      }
-
-      Logger.Global.LogInfo($"news: workshop mod {wid} subscribed and downloaded successfully");
-
-      if (unsubscribeWorkshopId.HasValue)
-      {
-        var oldWid = unsubscribeWorkshopId.Value;
-        if (oldWid > 1 && oldWid != wid)
-        {
-          try
-          {
-            var oldPfid = new PublishedFileId { Value = oldWid };
-            var oldItem = new Item(oldPfid);
-            bool unsubOk = await oldItem.Unsubscribe();
-            Logger.Global.LogInfo($"news: unsubscribed old workshop {oldWid} (success={unsubOk})");
-          }
-          catch (Exception ex)
-          {
-            Logger.Global.LogException(ex);
-            // Unsubscribe failure should not fail the overall migration
-          }
-        }
-      }
-
-      return true;
-    }
-    catch (Exception ex)
-    {
-      Logger.Global.LogException(ex);
-      Logger.Global.LogError("news: workshop_mod_install failed");
-      return false;
-    }
+    return await Steam.SubscribeAndDownload(wid, unsubscribeWorkshopId);
   }
 }

--- a/StationeersLaunchPad/News/NewsRunner.cs
+++ b/StationeersLaunchPad/News/NewsRunner.cs
@@ -57,6 +57,11 @@ public static class NewsRunner
     {
       await ExecuteWorkshopModInstall(act.WorkshopId);
     }
+
+    if (act.Action == "workshop_mod_subscribe")
+    {
+      await ExecuteWorkshopModInstall(act.WorkshopId);
+    }
   }
 
   public static async UniTask ExecuteSecondaryAction(NewsEntry entry)
@@ -64,6 +69,9 @@ public static class NewsRunner
     var act = entry?.Actions?.Secondary;
     if (act?.Action == "open_url" && !string.IsNullOrEmpty(act.Url))
       Application.OpenURL(act.Url);
+
+    if (act?.Action == "workshop_mod_subscribe")
+      await ExecuteWorkshopModInstall(act.WorkshopId);
   }
 
   public static async UniTask<bool> ExecuteRepoModInstall(string url, string modId = null)

--- a/StationeersLaunchPad/Sources/Workshop.cs
+++ b/StationeersLaunchPad/Sources/Workshop.cs
@@ -17,25 +17,43 @@ public class WorkshopModSource : ModSource
   {
     var mods = new List<ModDefinition>();
     if (state.SteamDisabled)
-      return mods;
+      return Configs.RetainWorkshopMods.Value ? ListRetainedMods() : mods;
 
     var items = await Steam.LoadWorkshopItems();
 
     foreach (var item in items)
     {
-      var about = XmlSerialization.Deserialize<ModAboutEx>(
-        Path.Join(item.Directory, "About/About.xml"), "ModMetadata") ?? new()
-        {
-          Name = $"[Invalid About.xml] {item.Title}",
-          Author = "",
-          Version = "",
-          Description = "",
-        };
+      var about = LoadAbout(Path.Join(item.Directory, "About/About.xml"), item.Title);
       mods.Add(new WorkshopModDefinition(item, about));
     }
 
     return mods;
   }
+
+  private static List<ModDefinition> ListRetainedMods()
+  {
+    var config = ModConfigUtil.LoadConfig();
+    var mods = new List<ModDefinition>();
+    foreach (var mod in config.Mods)
+    {
+      if (mod is not WorkshopModData wmod)
+        continue;
+      if (!File.Exists(mod.AboutXmlPath))
+        continue;
+      var about = LoadAbout(mod.AboutXmlPath, mod.DirectoryPath.Value);
+      mods.Add(new FakeWorkshopModDefinition(mod.DirectoryPath, wmod.WorkshopId, about));
+    }
+    return mods;
+  }
+
+  private static ModAboutEx LoadAbout(string path, string fallbackName) =>
+    XmlSerialization.Deserialize<ModAboutEx>(path, "ModMetadata") ?? new()
+    {
+      Name = $"[Invalid About.xml] {fallbackName}",
+      Author = "",
+      Version = "",
+      Description = "",
+    };
 }
 
 public class WorkshopModDefinition(Item item, ModAboutEx about) : ModDefinition(about)
@@ -49,4 +67,18 @@ public class WorkshopModDefinition(Item item, ModAboutEx about) : ModDefinition(
     SteamTransport.ItemWrapper.WrapWorkshopItem(Item, "About/About.xml"),
     enabled
   );
+}
+
+public class FakeWorkshopModDefinition(string dir, ulong handle, ModAboutEx about) : ModDefinition(about)
+{
+  public override ModSourceType Type => ModSourceType.Workshop;
+  public override ulong WorkshopHandle { get; } = handle;
+  public override string DirectoryPath { get; } = dir;
+
+  public override ModData ToModData(bool enabled) => new WorkshopModData()
+  {
+    Enabled = enabled,
+    DirectoryPath = new(DirectoryPath),
+    WorkshopId = new(WorkshopHandle),
+  };
 }

--- a/StationeersLaunchPad/Steam.cs
+++ b/StationeersLaunchPad/Steam.cs
@@ -104,19 +104,7 @@ public static class Steam
       Logger.Global.LogInfo($"Workshop item {workshopId} subscribed and downloaded successfully");
 
       if (unsubscribeWorkshopId is > 1 && unsubscribeWorkshopId != workshopId)
-      {
-        try
-        {
-          var oldItem = new Item(new PublishedFileId { Value = unsubscribeWorkshopId.Value });
-          var unsubscribed = await oldItem.Unsubscribe();
-          Logger.Global.LogInfo($"Unsubscribed old workshop {unsubscribeWorkshopId} (success={unsubscribed})");
-        }
-        catch (Exception ex)
-        {
-          Logger.Global.LogException(ex);
-          // Unsubscribe failure should not fail the completed install
-        }
-      }
+        await Unsubscribe(unsubscribeWorkshopId.Value);
 
       return true;
     }
@@ -124,6 +112,26 @@ public static class Steam
     {
       Logger.Global.LogException(ex);
       Logger.Global.LogError($"Workshop install failed for {workshopId}");
+      return false;
+    }
+  }
+
+  public static async UniTask<bool> Unsubscribe(ulong workshopId)
+  {
+    if (workshopId < 2)
+      return false;
+
+    try
+    {
+      var item = new Item(new PublishedFileId { Value = workshopId });
+      var unsubscribed = await item.Unsubscribe();
+      Logger.Global.LogInfo($"Unsubscribed workshop item {workshopId} (success={unsubscribed})");
+      return unsubscribed;
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      Logger.Global.LogError($"Workshop unsubscribe failed for {workshopId}");
       return false;
     }
   }

--- a/StationeersLaunchPad/Steam.cs
+++ b/StationeersLaunchPad/Steam.cs
@@ -7,6 +7,7 @@ using Cysharp.Threading.Tasks;
 using StationeersLaunchPad.Metadata;
 using StationeersLaunchPad.Sources;
 using Steamworks;
+using Steamworks.Data;
 using Steamworks.Ugc;
 using UnityEngine;
 
@@ -75,6 +76,56 @@ public static class Steam
     return !result.HasValue || result.Value.ResultCount == 0
       ? []
       : [.. result.Value.Entries.Where(item => item.Result != Result.FileNotFound)];
+  }
+
+  public static async UniTask<bool> SubscribeAndDownload(ulong workshopId, ulong? unsubscribeWorkshopId = null)
+  {
+    if (workshopId < 2)
+      return false;
+
+    try
+    {
+      var item = new Item(new PublishedFileId { Value = workshopId });
+
+      Logger.Global.LogInfo($"Subscribing to workshop item {workshopId}");
+      if (!await item.Subscribe())
+      {
+        Logger.Global.LogError($"Subscribe() returned false for workshop {workshopId}");
+        return false;
+      }
+
+      Logger.Global.LogInfo($"Downloading workshop item {workshopId}");
+      if (!await item.DownloadAsync())
+      {
+        Logger.Global.LogError($"DownloadAsync() failed or was not successful for workshop {workshopId}");
+        return false;
+      }
+
+      Logger.Global.LogInfo($"Workshop item {workshopId} subscribed and downloaded successfully");
+
+      if (unsubscribeWorkshopId is > 1 && unsubscribeWorkshopId != workshopId)
+      {
+        try
+        {
+          var oldItem = new Item(new PublishedFileId { Value = unsubscribeWorkshopId.Value });
+          var unsubscribed = await oldItem.Unsubscribe();
+          Logger.Global.LogInfo($"Unsubscribed old workshop {unsubscribeWorkshopId} (success={unsubscribed})");
+        }
+        catch (Exception ex)
+        {
+          Logger.Global.LogException(ex);
+          // Unsubscribe failure should not fail the completed install
+        }
+      }
+
+      return true;
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      Logger.Global.LogError($"Workshop install failed for {workshopId}");
+      return false;
+    }
   }
 
   public static (bool, string) ValidateForWorkshop(ModInfo mod)

--- a/StationeersLaunchPad/UI/AutoLoadWindow.cs
+++ b/StationeersLaunchPad/UI/AutoLoadWindow.cs
@@ -7,7 +7,7 @@ namespace StationeersLaunchPad.UI;
 public class AutoLoadWindow
 {
   // returns true if the user clicked to stop autoloading
-  public static bool Draw(LoadStage stage, StageWait wait)
+  public static bool Draw(LoadStage stage, StageWait wait, string profileName)
   {
     var stopAuto = false;
     ImGuiHelper.Draw(() =>
@@ -24,6 +24,8 @@ public class AutoLoadWindow
         LoadStage.Initializing => "Initializing",
         LoadStage.News => "Checking notices",
         LoadStage.Searching => "Finding Mods",
+        LoadStage.Configuring when !string.IsNullOrEmpty(profileName) =>
+          $"Auto loading Mod Profile \"{profileName}\" in {wait.SecondsRemaining:0.0}s",
         LoadStage.Configuring => $"Loading Mods in {wait.SecondsRemaining:0.0}s",
         LoadStage.Loading => "Loading Mods",
         LoadStage.Loaded => $"Starting game in {wait.SecondsRemaining:0.0}s",

--- a/StationeersLaunchPad/UI/AutoLoadWindow.cs
+++ b/StationeersLaunchPad/UI/AutoLoadWindow.cs
@@ -7,7 +7,7 @@ namespace StationeersLaunchPad.UI;
 public class AutoLoadWindow
 {
   // returns true if the user clicked to stop autoloading
-  public static bool Draw(LoadStage stage, StageWait wait, string profileName)
+  public static bool Draw(LoadStage stage, StageWait wait)
   {
     var stopAuto = false;
     ImGuiHelper.Draw(() =>
@@ -24,8 +24,7 @@ public class AutoLoadWindow
         LoadStage.Initializing => "Initializing",
         LoadStage.News => "Checking notices",
         LoadStage.Searching => "Finding Mods",
-        LoadStage.Configuring when !string.IsNullOrEmpty(profileName) =>
-          $"Auto loading Mod Profile \"{profileName}\" in {wait.SecondsRemaining:0.0}s",
+        LoadStage.Configuring when !wait.Auto => "Mod loading paused",
         LoadStage.Configuring => $"Loading Mods in {wait.SecondsRemaining:0.0}s",
         LoadStage.Loading => "Loading Mods",
         LoadStage.Loaded => $"Starting game in {wait.SecondsRemaining:0.0}s",

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -81,6 +81,17 @@ public static class BetaProgramsPanel
           Steam.OpenWorkshopPage(stable.WorkshopHandle);
       }
 
+      if (beta?.Enabled == true && stable.Enabled)
+        ImGuiHelper.TextWarning("Stable and beta are both enabled.");
+      else if (beta?.Enabled == true)
+        ImGuiHelper.TextWarning("Beta is active.");
+      else if (stable.Enabled)
+        ImGuiHelper.TextDisabled("Stable is active.");
+      else if (beta != null)
+        ImGuiHelper.TextDisabled("Both versions are disabled.");
+      else
+        ImGuiHelper.TextDisabled("Stable is disabled.");
+
       if (statuses.TryGetValue(stable.BetaWorkshopHandle, out var status))
         ImGuiHelper.TextDisabled(status);
       ImGui.Separator();
@@ -129,7 +140,9 @@ public static class BetaProgramsPanel
     stable.Enabled = !enabled;
     beta.Enabled = enabled;
     Logger.Global.LogInfo($"Switched {stable.Name} to {(enabled ? "beta" : "stable")}");
-    if (!enabled)
+    if (enabled)
+      statuses.Remove(beta.WorkshopHandle);
+    else
       UnsubscribeFromBeta(stable, beta, modList).Forget();
     return true;
   }
@@ -151,7 +164,7 @@ public static class BetaProgramsPanel
 
       stable.Enabled = false;
       ModConfigUtil.SaveConfig(modList.ToModConfig());
-      statuses[workshopId] = "Beta downloaded and enabled.";
+      statuses.Remove(workshopId);
       LaunchPadConfig.ReloadMods();
     }
     finally
@@ -178,7 +191,7 @@ public static class BetaProgramsPanel
         return;
       }
 
-      statuses[workshopId] = "Beta unsubscribed.";
+      statuses.Remove(workshopId);
       LaunchPadConfig.ReloadMods();
     }
     finally

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -8,10 +8,10 @@ namespace StationeersLaunchPad.UI;
 
 public static class BetaProgramsPanel
 {
-  private static readonly HashSet<ulong> downloads = [];
+  private static readonly HashSet<ulong> operations = [];
   private static readonly Dictionary<ulong, string> statuses = [];
 
-  public static bool Busy => downloads.Count > 0;
+  public static bool Busy => operations.Count > 0;
 
   public static bool Draw(LoadStage stage, ModList modList)
   {
@@ -24,7 +24,7 @@ public static class BetaProgramsPanel
       .GroupBy(mod => mod.BetaWorkshopHandle)
       .Select(mods => mods.FirstOrDefault(mod => mod.Enabled) ?? mods.First())
       .ToList();
-    var betaMods = modList.AllMods.Where(mod => mod.IsBetaProgramMod).ToList();
+    var betaMods = modList.AllMods.Where(modList.IsBetaMod).ToList();
 
     ImGui.BeginDisabled(stage != LoadStage.Configuring || Busy);
     if (ImGui.Button("Refresh subscribed betas"))
@@ -45,7 +45,7 @@ public static class BetaProgramsPanel
     {
       var beta = modList.AllMods.FirstOrDefault(mod =>
         mod.WorkshopHandle == stable.BetaWorkshopHandle);
-      var downloading = downloads.Contains(stable.BetaWorkshopHandle);
+      var busy = operations.Contains(stable.BetaWorkshopHandle);
 
       ImGui.PushID($"beta-{stable.BetaWorkshopHandle}");
       ImGui.Spacing();
@@ -57,21 +57,23 @@ public static class BetaProgramsPanel
 
       if (beta == null)
       {
-        ImGui.BeginDisabled(stage != LoadStage.Configuring || downloading);
-        if (ImGui.Button(downloading ? "Downloading..." : "Subscribe to Beta"))
+        ImGui.BeginDisabled(stage != LoadStage.Configuring || busy);
+        if (ImGui.Button(busy ? "Downloading..." : "Subscribe to Beta"))
           SubscribeToBeta(stable, modList).Forget();
         ImGui.EndDisabled();
       }
       else
       {
         var useBeta = beta.Enabled;
-        ImGui.BeginDisabled(stage != LoadStage.Configuring);
+        ImGui.BeginDisabled(stage != LoadStage.Configuring || busy);
         if (ImGui.Checkbox("Use Beta Version", ref useBeta))
         {
           stable.Enabled = !useBeta;
           beta.Enabled = useBeta;
           changed = true;
           Logger.Global.LogInfo($"Switched {stable.Name} to {(useBeta ? "beta" : "stable")}");
+          if (!useBeta)
+            UnsubscribeFromBeta(stable, beta, modList).Forget();
         }
         ImGui.EndDisabled();
       }
@@ -109,7 +111,7 @@ public static class BetaProgramsPanel
   private static async UniTask SubscribeToBeta(ModInfo stable, ModList modList)
   {
     var workshopId = stable.BetaWorkshopHandle;
-    if (!downloads.Add(workshopId))
+    if (!operations.Add(workshopId))
       return;
 
     statuses[workshopId] = "Subscribing and downloading...";
@@ -128,7 +130,34 @@ public static class BetaProgramsPanel
     }
     finally
     {
-      downloads.Remove(workshopId);
+      operations.Remove(workshopId);
+    }
+  }
+
+  private static async UniTask UnsubscribeFromBeta(ModInfo stable, ModInfo beta, ModList modList)
+  {
+    var workshopId = beta.WorkshopHandle;
+    if (!operations.Add(workshopId))
+      return;
+
+    stable.Enabled = true;
+    beta.Enabled = false;
+    ModConfigUtil.SaveConfig(modList.ToModConfig());
+    statuses[workshopId] = "Unsubscribing from beta...";
+    try
+    {
+      if (!await Steam.Unsubscribe(workshopId))
+      {
+        statuses[workshopId] = "Unsubscribe failed. The beta remains disabled.";
+        return;
+      }
+
+      statuses[workshopId] = "Beta unsubscribed.";
+      LaunchPadConfig.ReloadMods();
+    }
+    finally
+    {
+      operations.Remove(workshopId);
     }
   }
 }

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -67,14 +67,7 @@ public static class BetaProgramsPanel
         var useBeta = beta.Enabled;
         ImGui.BeginDisabled(stage != LoadStage.Configuring || busy);
         if (ImGui.Checkbox("Use Beta Version", ref useBeta))
-        {
-          stable.Enabled = !useBeta;
-          beta.Enabled = useBeta;
-          changed = true;
-          Logger.Global.LogInfo($"Switched {stable.Name} to {(useBeta ? "beta" : "stable")}");
-          if (!useBeta)
-            UnsubscribeFromBeta(stable, beta, modList).Forget();
-        }
+          changed = SetBetaEnabled(stable, beta, modList, useBeta);
         ImGui.EndDisabled();
       }
 
@@ -106,6 +99,39 @@ public static class BetaProgramsPanel
 
     ImGui.EndTabItem();
     return changed;
+  }
+
+  public static bool SetModEnabled(ModList modList, ModInfo mod, bool enabled)
+  {
+    if (modList.IsBetaMod(mod))
+    {
+      var stable = modList.AllMods.FirstOrDefault(stable => stable.IsBetaProgramFor(mod));
+      if (stable != null)
+        return SetBetaEnabled(stable, mod, modList, enabled);
+    }
+    else if (enabled && mod.HasBetaProgram)
+    {
+      var beta = modList.AllMods.FirstOrDefault(beta =>
+        beta.WorkshopHandle == mod.BetaWorkshopHandle);
+      if (beta?.Enabled == true)
+        return SetBetaEnabled(mod, beta, modList, false);
+    }
+
+    mod.Enabled = enabled;
+    return true;
+  }
+
+  private static bool SetBetaEnabled(ModInfo stable, ModInfo beta, ModList modList, bool enabled)
+  {
+    if (operations.Contains(beta.WorkshopHandle))
+      return false;
+
+    stable.Enabled = !enabled;
+    beta.Enabled = enabled;
+    Logger.Global.LogInfo($"Switched {stable.Name} to {(enabled ? "beta" : "stable")}");
+    if (!enabled)
+      UnsubscribeFromBeta(stable, beta, modList).Forget();
+    return true;
   }
 
   private static async UniTask SubscribeToBeta(ModInfo stable, ModList modList)

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using System.Linq;
+using Cysharp.Threading.Tasks;
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+
+namespace StationeersLaunchPad.UI;
+
+public static class BetaProgramsPanel
+{
+  private static readonly HashSet<ulong> downloads = [];
+  private static readonly Dictionary<ulong, string> statuses = [];
+
+  public static bool Busy => downloads.Count > 0;
+
+  public static bool Draw(LoadStage stage, ModList modList)
+  {
+    var changed = false;
+    if (!ImGui.BeginTabItem("Betas"))
+      return changed;
+
+    var stableMods = modList.AllMods
+      .Where(mod => mod.HasBetaProgram)
+      .GroupBy(mod => mod.BetaWorkshopHandle)
+      .Select(mods => mods.FirstOrDefault(mod => mod.Enabled) ?? mods.First())
+      .ToList();
+    var betaMods = modList.AllMods.Where(mod => mod.IsBetaProgramMod).ToList();
+
+    ImGui.BeginDisabled(stage != LoadStage.Configuring || Busy);
+    if (ImGui.Button("Refresh subscribed betas"))
+      LaunchPadConfig.ReloadMods();
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(stage == LoadStage.Configuring
+      ? "Reload the current local and workshop mod list."
+      : "The mod list can only be refreshed before loading mods.",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
+
+    if (stableMods.Count == 0 && betaMods.Count == 0)
+    {
+      ImGui.Spacing();
+      ImGuiHelper.TextDisabled("No installed mods advertise a beta program.");
+    }
+
+    foreach (var stable in stableMods)
+    {
+      var beta = modList.AllMods.FirstOrDefault(mod =>
+        mod.WorkshopHandle == stable.BetaWorkshopHandle);
+      var downloading = downloads.Contains(stable.BetaWorkshopHandle);
+
+      ImGui.PushID($"beta-{stable.BetaWorkshopHandle}");
+      ImGui.Spacing();
+      ImGuiHelper.Text(stable.Name);
+      ImGuiHelper.TextDisabled($"Stable: {stable.About?.Version ?? "Unknown"} ({stable.WorkshopHandle})");
+      ImGuiHelper.TextDisabled(beta == null
+        ? $"Beta: not subscribed ({stable.BetaWorkshopHandle})"
+        : $"Beta: {beta.About?.Version ?? "Unknown"} ({beta.WorkshopHandle})");
+
+      if (beta == null)
+      {
+        ImGui.BeginDisabled(stage != LoadStage.Configuring || downloading);
+        if (ImGui.Button(downloading ? "Downloading..." : "Subscribe to Beta"))
+          SubscribeToBeta(stable, modList).Forget();
+        ImGui.EndDisabled();
+      }
+      else
+      {
+        var useBeta = beta.Enabled;
+        ImGui.BeginDisabled(stage != LoadStage.Configuring);
+        if (ImGui.Checkbox("Use Beta Version", ref useBeta))
+        {
+          stable.Enabled = !useBeta;
+          beta.Enabled = useBeta;
+          changed = true;
+          Logger.Global.LogInfo($"Switched {stable.Name} to {(useBeta ? "beta" : "stable")}");
+        }
+        ImGui.EndDisabled();
+      }
+
+      ImGui.SameLine();
+      if (ImGui.Button("Open Beta Workshop Page"))
+        Steam.OpenWorkshopPage(stable.BetaWorkshopHandle);
+      if (stable.WorkshopHandle > 1)
+      {
+        ImGui.SameLine();
+        if (ImGui.Button("Open Stable Workshop Page"))
+          Steam.OpenWorkshopPage(stable.WorkshopHandle);
+      }
+
+      if (statuses.TryGetValue(stable.BetaWorkshopHandle, out var status))
+        ImGuiHelper.TextDisabled(status);
+      ImGui.Separator();
+      ImGui.PopID();
+    }
+
+    var linkedBetaHandles = stableMods.Select(mod => mod.BetaWorkshopHandle).ToHashSet();
+    var unlinkedBetas = betaMods.Where(mod => !linkedBetaHandles.Contains(mod.WorkshopHandle)).ToList();
+    if (unlinkedBetas.Count > 0)
+    {
+      ImGui.Spacing();
+      ImGuiHelper.Text("Other beta program mods");
+      foreach (var beta in unlinkedBetas)
+        ImGuiHelper.TextDisabled($"{beta.Name} {beta.About?.Version} ({(beta.Enabled ? "Active" : "Disabled")})");
+    }
+
+    ImGui.EndTabItem();
+    return changed;
+  }
+
+  private static async UniTask SubscribeToBeta(ModInfo stable, ModList modList)
+  {
+    var workshopId = stable.BetaWorkshopHandle;
+    if (!downloads.Add(workshopId))
+      return;
+
+    statuses[workshopId] = "Subscribing and downloading...";
+    try
+    {
+      if (!await Steam.SubscribeAndDownload(workshopId))
+      {
+        statuses[workshopId] = "Subscription or download failed. See logs for details.";
+        return;
+      }
+
+      stable.Enabled = false;
+      ModConfigUtil.SaveConfig(modList.ToModConfig());
+      statuses[workshopId] = "Beta downloaded and enabled.";
+      LaunchPadConfig.ReloadMods();
+    }
+    finally
+    {
+      downloads.Remove(workshopId);
+    }
+  }
+}

--- a/StationeersLaunchPad/UI/BetaProgramsPanel.cs
+++ b/StationeersLaunchPad/UI/BetaProgramsPanel.cs
@@ -26,8 +26,9 @@ public static class BetaProgramsPanel
       .ToList();
     var betaMods = modList.AllMods.Where(modList.IsBetaMod).ToList();
 
+    ImGuiHelper.TextDisabled("Switch installed mods between their stable and beta Workshop versions.");
     ImGui.BeginDisabled(stage != LoadStage.Configuring || Busy);
-    if (ImGui.Button("Refresh subscribed betas"))
+    if (ImGui.Button("Refresh Subscribed Betas"))
       LaunchPadConfig.ReloadMods();
     ImGui.EndDisabled();
     ImGuiHelper.ItemTooltip(stage == LoadStage.Configuring

--- a/StationeersLaunchPad/UI/ConfigPanel.cs
+++ b/StationeersLaunchPad/UI/ConfigPanel.cs
@@ -82,7 +82,7 @@ internal static class ConfigPanel
 
     if (requireRestartOriginalValues.Count > 0)
     {
-      ImGuiHelper.TextColored("Changes in configuration require a restart to apply", new Color(0.863f, 0.078f, 0.235f));
+      ImGuiHelper.TextError("Changes in configuration require a restart to apply");
     }
     else
       ImGuiHelper.TextDisabled("These configurations may require a restart to apply");

--- a/StationeersLaunchPad/UI/ImGuiHelper.cs
+++ b/StationeersLaunchPad/UI/ImGuiHelper.cs
@@ -125,6 +125,7 @@ public static partial class ImGuiHelper
   public static void Draw(Action drawFunc)
   {
     PushDefaultStyle();
+    var accentColors = LaunchPadTheme.PushAccent();
 
     try
     {
@@ -136,6 +137,8 @@ public static partial class ImGuiHelper
       Logger.Global.LogException(ex);
     }
 
+    if (accentColors > 0)
+      ImGui.PopStyleColor(accentColors);
     PopDefaultStyle();
   }
 
@@ -241,12 +244,15 @@ public static partial class ImGuiHelper
     ImGui.PushStyleVar(ImGuiStyleVar.CellPadding, new Vector2(3, 2));
     ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(3, 2));
     ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 3);
+    ImGui.PushStyleVar(ImGuiStyleVar.ChildRounding, 2);
+    ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 2);
+    ImGui.PushStyleVar(ImGuiStyleVar.TabRounding, 2);
     ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 1.0f);
   }
 
   public static void PopDefaultStyle()
   {
-    ImGui.PopStyleVar(4);
+    ImGui.PopStyleVar(7);
     ImGui.PopStyleColor((int)ImGuiCol.COUNT);
   }
 

--- a/StationeersLaunchPad/UI/LaunchPadTheme.cs
+++ b/StationeersLaunchPad/UI/LaunchPadTheme.cs
@@ -140,6 +140,11 @@ public static class LaunchPadTheme
     UiAccentColor.Orange => Hex(0xF47A2A),
     UiAccentColor.Blue => Hex(0x4A90E2),
     UiAccentColor.Green => Hex(0x5FAF5F),
+    UiAccentColor.Pink => Hex(0xE66AA5),
+    UiAccentColor.Yellow => Hex(0xE0B83F),
+    UiAccentColor.Purple => Hex(0x9B7AE6),
+    UiAccentColor.Teal => Hex(0x45B8AC),
+    UiAccentColor.Dark => Hex(0x8B93A7),
     _ => StyleColor(ImGuiCol.CheckMark),
   };
 

--- a/StationeersLaunchPad/UI/LaunchPadTheme.cs
+++ b/StationeersLaunchPad/UI/LaunchPadTheme.cs
@@ -1,0 +1,104 @@
+using ImGuiNET;
+using UnityEngine;
+
+namespace StationeersLaunchPad.UI;
+
+// Color palette and ImGui style for the LaunchPad UI (dark panels with a single accent).
+// The accent is defined once (AccentRgb) and every accent shade is derived from it, so the
+// whole UI can be retinted by changing that one value. No view should reference a raw hex
+// color or a color-specific name; use the semantic fields below instead.
+public static class LaunchPadTheme
+{
+  public static Color Hex(uint rgb, float a = 1f) =>
+    new(((rgb >> 16) & 0xFF) / 255f, ((rgb >> 8) & 0xFF) / 255f, (rgb & 0xFF) / 255f, a);
+
+  public static readonly Color Bg = Hex(0x1E2027);
+  public static readonly Color Panel = Hex(0x2B2F3B);
+  public static readonly Color PanelAlt = Hex(0x252833);
+  public static readonly Color Deep = Hex(0x14161C);
+  public static readonly Color Sidebar = Hex(0x191C23);
+  public static readonly Color Toolbar = Hex(0x181B22);
+  public static readonly Color Border = new(1f, 1f, 1f, 0.07f);
+  public static readonly Color RowAlt = new(1f, 1f, 1f, 0.025f);
+
+  // Single source of truth for the accent. Swap this one value to retheme the UI.
+  public const uint AccentRgb = 0xF47A2A;
+
+  public static readonly Color Accent = Hex(AccentRgb);
+  public static readonly Color AccentFaint = Hex(AccentRgb, 0.10f);
+  public static readonly Color AccentSoft = Hex(AccentRgb, 0.16f);
+  public static readonly Color AccentStrong = Hex(AccentRgb, 0.22f);
+  public static readonly Color AccentBorder = Hex(AccentRgb, 0.25f);
+
+  public static readonly Color Text = Hex(0xF1F3F6);
+  public static readonly Color TextSub = Hex(0xB7BDC9);
+  public static readonly Color TextMuted = Hex(0x6A728A);
+  public static readonly Color TextDim = Hex(0x4A5266);
+
+  public static readonly Color Ok = Hex(0x5FAF5F);
+  public static readonly Color Warn = Hex(0xD8B14A);
+  public static readonly Color Err = Hex(0xD9534F);
+
+  private static int colors;
+  private static int vars;
+
+  public static void Push()
+  {
+    colors = 0;
+    vars = 0;
+
+    void C(ImGuiCol c, Color col) { ImGui.PushStyleColor(c, (Vector4)col); colors++; }
+    void V1(ImGuiStyleVar v, float f) { ImGui.PushStyleVar(v, f); vars++; }
+    void V2(ImGuiStyleVar v, Vector2 f) { ImGui.PushStyleVar(v, f); vars++; }
+
+    C(ImGuiCol.WindowBg, Bg);
+    C(ImGuiCol.ChildBg, new Color(0f, 0f, 0f, 0f));
+    C(ImGuiCol.PopupBg, Panel);
+    C(ImGuiCol.Border, Border);
+    C(ImGuiCol.Text, Text);
+    C(ImGuiCol.TextDisabled, TextMuted);
+    C(ImGuiCol.FrameBg, Deep);
+    C(ImGuiCol.FrameBgHovered, PanelAlt);
+    C(ImGuiCol.FrameBgActive, PanelAlt);
+    C(ImGuiCol.Button, new Color(1f, 1f, 1f, 0.04f));
+    C(ImGuiCol.ButtonHovered, new Color(1f, 1f, 1f, 0.09f));
+    C(ImGuiCol.ButtonActive, AccentFaint);
+    C(ImGuiCol.Header, AccentSoft);
+    C(ImGuiCol.HeaderHovered, new Color(1f, 1f, 1f, 0.09f));
+    C(ImGuiCol.HeaderActive, AccentStrong);
+    C(ImGuiCol.CheckMark, Accent);
+    C(ImGuiCol.Separator, Border);
+    C(ImGuiCol.ScrollbarBg, new Color(0f, 0f, 0f, 0f));
+    C(ImGuiCol.ScrollbarGrab, new Color(1f, 1f, 1f, 0.10f));
+    C(ImGuiCol.ScrollbarGrabHovered, new Color(1f, 1f, 1f, 0.18f));
+
+    V1(ImGuiStyleVar.FrameRounding, 3f);
+    V1(ImGuiStyleVar.ChildRounding, 3f);
+    V1(ImGuiStyleVar.FrameBorderSize, 1f);
+    V2(ImGuiStyleVar.ItemSpacing, new Vector2(6f, 5f));
+  }
+
+  public static void Pop()
+  {
+    ImGui.PopStyleVar(vars);
+    ImGui.PopStyleColor(colors);
+  }
+
+  // -- Draw helpers ----------------------------------------------
+  public static void Fill(Rect r, Color c) =>
+    ImGui.GetWindowDrawList().AddRectFilled(r.Min, r.Max, U32(c));
+
+  public static void Stroke(Rect r, Color c) =>
+    ImGui.GetWindowDrawList().AddRect(r.Min, r.Max, U32(c));
+
+  public static void HLine(Vector2 a, Vector2 b, Color c) =>
+    ImGui.GetWindowDrawList().AddLine(a, b, U32(c));
+
+  public static void TextAt(Vector2 pos, string text, Color c)
+  {
+    ImGui.SetCursorScreenPos(pos);
+    ImGuiHelper.TextColored(text, c);
+  }
+
+  private static uint U32(Color c) => ImGui.ColorConvertFloat4ToU32((Vector4)c);
+}

--- a/StationeersLaunchPad/UI/LaunchPadTheme.cs
+++ b/StationeersLaunchPad/UI/LaunchPadTheme.cs
@@ -3,10 +3,7 @@ using UnityEngine;
 
 namespace StationeersLaunchPad.UI;
 
-// Color palette and ImGui style for the LaunchPad UI (dark panels with a single accent).
-// The accent is defined once (AccentRgb) and every accent shade is derived from it, so the
-// whole UI can be retinted by changing that one value. No view should reference a raw hex
-// color or a color-specific name; use the semantic fields below instead.
+// Color palette and ImGui style for the LaunchPad UI.
 public static class LaunchPadTheme
 {
   public static Color Hex(uint rgb, float a = 1f) =>
@@ -21,14 +18,11 @@ public static class LaunchPadTheme
   public static readonly Color Border = new(1f, 1f, 1f, 0.07f);
   public static readonly Color RowAlt = new(1f, 1f, 1f, 0.025f);
 
-  // Single source of truth for the accent. Swap this one value to retheme the UI.
-  public const uint AccentRgb = 0xF47A2A;
-
-  public static readonly Color Accent = Hex(AccentRgb);
-  public static readonly Color AccentFaint = Hex(AccentRgb, 0.10f);
-  public static readonly Color AccentSoft = Hex(AccentRgb, 0.16f);
-  public static readonly Color AccentStrong = Hex(AccentRgb, 0.22f);
-  public static readonly Color AccentBorder = Hex(AccentRgb, 0.25f);
+  public static Color Accent => AccentColor();
+  public static Color AccentFaint => WithAlpha(Accent, 0.10f);
+  public static Color AccentSoft => WithAlpha(Accent, 0.16f);
+  public static Color AccentStrong => WithAlpha(Accent, 0.22f);
+  public static Color AccentBorder => WithAlpha(Accent, 0.25f);
 
   public static readonly Color Text = Hex(0xF1F3F6);
   public static readonly Color TextSub = Hex(0xB7BDC9);
@@ -41,6 +35,44 @@ public static class LaunchPadTheme
 
   private static int colors;
   private static int vars;
+
+  public static int PushAccent()
+  {
+    if (Configs.UiAccent?.Value is null or UiAccentColor.Classic)
+      return 0;
+
+    var count = 0;
+    void C(ImGuiCol color, float alpha)
+    {
+      ImGui.PushStyleColor(color, (Vector4)WithAlpha(Accent, alpha));
+      count++;
+    }
+
+    C(ImGuiCol.Button, 0.40f);
+    C(ImGuiCol.ButtonHovered, 0.80f);
+    C(ImGuiCol.ButtonActive, 1f);
+    C(ImGuiCol.FrameBgHovered, 0.40f);
+    C(ImGuiCol.FrameBgActive, 0.67f);
+    C(ImGuiCol.Header, 0.31f);
+    C(ImGuiCol.HeaderHovered, 0.80f);
+    C(ImGuiCol.HeaderActive, 1f);
+    C(ImGuiCol.Tab, 0.25f);
+    C(ImGuiCol.TabHovered, 0.80f);
+    C(ImGuiCol.TabActive, 0.65f);
+    C(ImGuiCol.TabUnfocused, 0.20f);
+    C(ImGuiCol.TabUnfocusedActive, 0.35f);
+    C(ImGuiCol.CheckMark, 1f);
+    C(ImGuiCol.SliderGrab, 0.54f);
+    C(ImGuiCol.SliderGrabActive, 1f);
+    C(ImGuiCol.SeparatorHovered, 0.78f);
+    C(ImGuiCol.SeparatorActive, 1f);
+    C(ImGuiCol.ResizeGrip, 0.20f);
+    C(ImGuiCol.ResizeGripHovered, 0.67f);
+    C(ImGuiCol.ResizeGripActive, 0.95f);
+    C(ImGuiCol.TextSelectedBg, 0.35f);
+    C(ImGuiCol.NavHighlight, 1f);
+    return count;
+  }
 
   public static void Push()
   {
@@ -101,4 +133,21 @@ public static class LaunchPadTheme
   }
 
   private static uint U32(Color c) => ImGui.ColorConvertFloat4ToU32((Vector4)c);
+
+  private static Color AccentColor() => Configs.UiAccent?.Value switch
+  {
+    UiAccentColor.Orange => Hex(0xF47A2A),
+    UiAccentColor.Blue => Hex(0x4A90E2),
+    UiAccentColor.Green => Hex(0x5FAF5F),
+    _ => StyleColor(ImGuiCol.CheckMark),
+  };
+
+  private static Color StyleColor(ImGuiCol color)
+  {
+    var value = ImGui.GetStyle().Colors[(int)color];
+    return new(value.x, value.y, value.z, value.w);
+  }
+
+  private static Color WithAlpha(Color color, float alpha) =>
+    new(color.r, color.g, color.b, alpha);
 }

--- a/StationeersLaunchPad/UI/LaunchPadTheme.cs
+++ b/StationeersLaunchPad/UI/LaunchPadTheme.cs
@@ -32,6 +32,7 @@ public static class LaunchPadTheme
   public static readonly Color Ok = Hex(0x5FAF5F);
   public static readonly Color Warn = Hex(0xD8B14A);
   public static readonly Color Err = Hex(0xD9534F);
+  public static readonly Color Info = Hex(0x4A90E2);
 
   private static int colors;
   private static int vars;

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -291,8 +291,9 @@ public static class ManualLoadWindow
 
       ImGui.SetCursorScreenPos(row.Column(0).TL);
       ImGui.BeginDisabled(mod.Source is ModSourceType.Core);
-      if (ImGui.Checkbox("##enable", ref mod.Enabled))
-        changed = true;
+      var enabled = mod.Enabled;
+      if (ImGui.Checkbox("##enable", ref enabled))
+        changed |= BetaProgramsPanel.SetModEnabled(modList, mod, enabled);
       ImGui.EndDisabled();
 
       var c12 = row.ColumnsFrom(1);

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -138,7 +138,7 @@ public static class ManualLoadWindow
     ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, Vector2.zero);
     var (nextEnabled, nextText) = stage switch
     {
-      LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Downloading Beta..."),
+      LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Updating Betas..."),
       LoadStage.Configuring => (true, "Load Mods"),
       LoadStage.Loaded or LoadStage.Failed => (true, "Start Game"),
       _ => (false, "..."),
@@ -287,6 +287,7 @@ public static class ManualLoadWindow
     foreach (var mod in modList.AllMods)
     {
       ImGui.PushID(idx);
+      var isBeta = modList.IsBetaMod(mod);
 
       ImGui.SetCursorScreenPos(row.Column(0).TL);
       ImGui.BeginDisabled(mod.Source is ModSourceType.Core);
@@ -310,7 +311,13 @@ public static class ManualLoadWindow
 
       ImGuiHelper.TextCentered(row.Column(1), $"{mod.Source}");
 
-      ImGuiHelper.Text(row.Column(2), mod.IsBetaProgramMod ? $"{mod.Name} (Beta)" : mod.Name);
+      ImGui.SetCursorScreenPos(row.Column(2).TL);
+      if (isBeta)
+        ImGuiHelper.TextColored($"{mod.Name} [BETA]", ImGuiHelper.Yellow);
+      else
+        ImGuiHelper.Text(mod.Name);
+      if (isBeta)
+        ImGuiHelper.ItemTooltip("This item is a beta version of an installed mod.");
 
       if (draggingMod != null)
         if (mod.SortBefore(draggingMod))
@@ -367,7 +374,11 @@ public static class ManualLoadWindow
 
       ImGuiHelper.TextCentered(row.Column(1), $"{info.Source}");
 
-      ImGuiHelper.Text(row.Column(2), info.Name);
+      ImGui.SetCursorScreenPos(row.Column(2).TL);
+      if (modList.IsBetaMod(info))
+        ImGuiHelper.TextColored($"{info.Name} [BETA]", ImGuiHelper.Yellow);
+      else
+        ImGuiHelper.Text(info.Name);
 
       ImGui.PopID();
       idx++;

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using ImGuiNET;
 using StationeersLaunchPad.Loading;
 using StationeersLaunchPad.Metadata;
@@ -16,7 +17,6 @@ public static class ManualLoadWindow
     Mods = 1 << 0,
     AutoSort = 1 << 1,
     NextStep = 1 << 2,
-    Profile = 1 << 3,
   }
 
   private static LoadStage lastStage;
@@ -33,10 +33,18 @@ public static class ManualLoadWindow
     ProfilePanel.SelectActive();
   }
 
+  public static void OpenModInfoTab()
+  {
+    openProfiles = false;
+    openInfo = true;
+  }
+
   public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort, ProfileManager profileManager)
   {
     Platform.SetBackgroundEnabled(false);
     var changed = ChangeFlags.None;
+    profileManager.Initialize();
+    var vanillaActive = ProfileManager.IsVanillaProfile(profileManager.ActiveProfileName);
 
     // when we move into the loading step, clear the selected mod so all the logs are visible
     if (lastStage < LoadStage.Loaded && stage >= LoadStage.Loading)
@@ -56,7 +64,7 @@ public static class ManualLoadWindow
 
       leftRect.SplitOY(ImGui.GetTextLineHeight(), out var statusRect, out leftRect);
 
-      if (DrawStatusLine(statusRect, stage))
+      if (DrawStatusLine(statusRect, stage, profileManager, modList))
         changed |= ChangeFlags.NextStep;
 
       ImGui.SetCursorScreenPos(leftRect.Min);
@@ -69,10 +77,16 @@ public static class ManualLoadWindow
 
       if (stage is LoadStage.Searching or LoadStage.Configuring)
       {
+        if (vanillaActive)
+          ImGuiHelper.TextDisabled(
+            "Vanilla profile active: choose another profile or Disable Profiles to edit mods.");
+        ImGui.BeginDisabled(vanillaActive);
         changed |= DrawModSelectOptions(modList, autoSort);
+        ImGui.EndDisabled();
         leftRect = leftRect.From(ImGui.GetCursorScreenPos());
         ImGui.BeginChild("##modselect", leftRect.Size);
-        if (DrawModSelectTable(modList, stage == LoadStage.Configuring, autoSort))
+        if (DrawModSelectTable(
+          modList, stage == LoadStage.Configuring && !vanillaActive, autoSort))
           changed |= ChangeFlags.Mods;
         ImGui.EndChild();
       }
@@ -87,22 +101,25 @@ public static class ManualLoadWindow
 
       ImGui.SetCursorScreenPos(rightRect.Min);
       ImGui.BeginChild("##right", rightRect.Size);
+      var tabBorderSize = style.TabBorderSize;
+      style.TabBorderSize = 0f;
       if (ImGui.BeginTabBar("##right"))
       {
         DrawModInfoTab(stage);
         DrawModConfigTab(stage);
         if (DrawProfilesTab(stage, profileManager, modList))
-          changed |= ChangeFlags.Mods | ChangeFlags.Profile;
+          changed |= ChangeFlags.Mods;
 
         if (BetaProgramsPanel.Draw(stage, modList))
           changed |= ChangeFlags.Mods;
 
         // If we changed launchpad config and haven't loaded mods yet, mark mods changed to apply disable/sort behaviour
-        if (DrawLaunchPadConfigTab() && stage <= LoadStage.Configuring)
+        if (DrawLaunchPadConfigTab(stage) && stage <= LoadStage.Configuring)
           changed |= ChangeFlags.Mods;
 
         ImGui.EndTabBar();
       }
+      style.TabBorderSize = tabBorderSize;
       ImGui.EndChild();
 
       ImGuiHelper.SeparatorLine(bottomRect.TL, bottomRect.TR);
@@ -123,25 +140,32 @@ public static class ManualLoadWindow
     return changed;
   }
 
-  private static bool DrawStatusLine(Rect rect, LoadStage stage)
+  private static bool DrawStatusLine(
+    Rect rect, LoadStage stage, ProfileManager profileManager, ModList modList)
   {
     var next = false;
+    var activeProfile = profileManager.ActiveProfile;
+    var missingMods = stage == LoadStage.Configuring && activeProfile != null
+      ? profileManager.GetMissingMods(activeProfile.Name, modList).Count
+      : 0;
     ImGui.SetCursorScreenPos(rect.Min);
 
     ImGuiHelper.TextDisabled($"SLP {LaunchPadInfo.VERSION}");
     ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextDisabled("|"), true);
 
-    ImGuiHelper.Text(stage switch
-    {
-      LoadStage.Updating => "Checking for updates to StationeersLaunchPad",
-      LoadStage.Initializing => "Initializing core components",
-      LoadStage.Searching => "Locating installed local and workshop mods",
-      LoadStage.Configuring => "Ready to load mods",
-      LoadStage.Loading => "Loading selected mods",
-      LoadStage.Loaded => "Ready to start game",
-      LoadStage.Failed => "Mods failed to load. Game may not function properly",
-      _ => "",
-    });
+    ImGuiHelper.Text(missingMods > 0
+      ? $"Loading paused: {activeProfile.Name} is missing {missingMods} required mod{(missingMods == 1 ? "" : "s")}"
+      : stage switch
+      {
+        LoadStage.Updating => "Checking for updates to StationeersLaunchPad",
+        LoadStage.Initializing => "Initializing core components",
+        LoadStage.Searching => "Locating installed local and workshop mods",
+        LoadStage.Configuring => "Ready to load mods",
+        LoadStage.Loading => "Loading selected mods",
+        LoadStage.Loaded => "Ready to start game",
+        LoadStage.Failed => "Mods failed to load. Game may not function properly",
+        _ => "",
+      });
 
     rect.SplitOX(-150f, out _, out var buttonRect);
     buttonRect = buttonRect.Shift(-ImGui.GetStyle().ItemSpacing.x, 0f);
@@ -150,6 +174,8 @@ public static class ManualLoadWindow
     {
       LoadStage.Configuring when ProfilePanel.Busy => (false, ProfilePanel.BusyText),
       LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Updating Betas..."),
+      LoadStage.Configuring when missingMods > 0 =>
+        (true, $"Resolve {missingMods} Missing"),
       LoadStage.Configuring => (true, "Load Mods"),
       LoadStage.Loaded or LoadStage.Failed => (true, "Start Game"),
       _ => (false, "..."),
@@ -164,6 +190,8 @@ public static class ManualLoadWindow
     if (ImGui.Button(nextText, buttonRect.Size))
       next = true;
     ImGui.EndDisabled();
+    if (missingMods > 0)
+      ImGuiHelper.ItemTooltip("Restore the missing mods or remove them from the active profile before loading.");
     if (nextEnabled)
       ImGui.PopStyleColor();
     ImGui.PopStyleVar();
@@ -258,7 +286,8 @@ public static class ManualLoadWindow
     return changed;
   }
 
-  private static bool DrawModSelectTable(ModList modList, bool edit = false, bool autoSort = false)
+  private static bool DrawModSelectTable(
+    ModList modList, bool edit = false, bool autoSort = false)
   {
     var changed = false;
     if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
@@ -455,19 +484,38 @@ public static class ManualLoadWindow
     }
   }
 
-  private static bool DrawLaunchPadConfigTab()
+  private static bool DrawLaunchPadConfigTab(LoadStage stage)
   {
     var changed = false;
     if (ImGui.BeginTabItem("LaunchPad Settings"))
     {
       DrawAppearanceSettings();
       DrawExportButton();
+      DrawAdvancedSettings(stage);
       ImGui.Separator();
       changed = ConfigPanel.DrawConfigFile(Configs.Sorted,
         category => category != "Internal" && category != "Appearance");
       ImGui.EndTabItem();
     }
     return changed;
+  }
+
+  private static void DrawAdvancedSettings(LoadStage stage)
+  {
+    if (!ImGui.CollapsingHeader("Advanced"))
+      return;
+
+    var canReload = stage == LoadStage.Configuring && !ProfilePanel.Busy
+      && !BetaProgramsPanel.Busy;
+    ImGui.BeginDisabled(!canReload);
+    if (ImGui.Button("Reload Mod List"))
+      LaunchPadConfig.ReloadMods();
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      canReload
+        ? "Re-scan local, Workshop, and repository mod files from disk."
+        : "The mod list can only be reloaded while configuring mods.",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
   }
 
   private static void DrawAppearanceSettings()

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -84,6 +84,9 @@ public static class ManualLoadWindow
         DrawModInfoTab(stage);
         DrawModConfigTab(stage);
 
+        if (BetaProgramsPanel.Draw(stage, modList))
+          changed |= ChangeFlags.Mods;
+
         // If we changed launchpad config and haven't loaded mods yet, mark mods changed to apply disable/sort behaviour
         if (DrawLaunchPadConfigTab() && stage <= LoadStage.Configuring)
           changed |= ChangeFlags.Mods;
@@ -135,6 +138,7 @@ public static class ManualLoadWindow
     ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, Vector2.zero);
     var (nextEnabled, nextText) = stage switch
     {
+      LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Downloading Beta..."),
       LoadStage.Configuring => (true, "Load Mods"),
       LoadStage.Loaded or LoadStage.Failed => (true, "Start Game"),
       _ => (false, "..."),
@@ -306,7 +310,7 @@ public static class ManualLoadWindow
 
       ImGuiHelper.TextCentered(row.Column(1), $"{mod.Source}");
 
-      ImGuiHelper.Text(row.Column(2), $"{mod.Name}");
+      ImGuiHelper.Text(row.Column(2), mod.IsBetaProgramMod ? $"{mod.Name} (Beta)" : mod.Name);
 
       if (draggingMod != null)
         if (mod.SortBefore(draggingMod))

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -16,6 +16,7 @@ public static class ManualLoadWindow
     Mods = 1 << 0,
     AutoSort = 1 << 1,
     NextStep = 1 << 2,
+    Profile = 1 << 3,
   }
 
   private static LoadStage lastStage;
@@ -91,7 +92,7 @@ public static class ManualLoadWindow
         DrawModInfoTab(stage);
         DrawModConfigTab(stage);
         if (DrawProfilesTab(stage, profileManager, modList))
-          changed |= ChangeFlags.Mods;
+          changed |= ChangeFlags.Mods | ChangeFlags.Profile;
 
         if (BetaProgramsPanel.Draw(stage, modList))
           changed |= ChangeFlags.Mods;
@@ -147,6 +148,7 @@ public static class ManualLoadWindow
     ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, Vector2.zero);
     var (nextEnabled, nextText) = stage switch
     {
+      LoadStage.Configuring when ProfilePanel.Busy => (false, "Subscribing..."),
       LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Updating Betas..."),
       LoadStage.Configuring => (true, "Load Mods"),
       LoadStage.Loaded or LoadStage.Failed => (true, "Start Game"),
@@ -482,7 +484,7 @@ public static class ManualLoadWindow
       return false;
 
     ImGui.BeginChild("##profiles");
-    var changed = ProfilePanel.Draw(profileManager, modList);
+    var changed = ProfilePanel.Draw(stage, profileManager, modList);
     ImGui.EndChild();
     ImGui.EndTabItem();
     return changed;

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -453,14 +453,15 @@ public static class ManualLoadWindow
   {
     var disabled = stage is not LoadStage.Searching and not LoadStage.Configuring;
     ImGui.BeginDisabled(disabled);
-    var flags = openProfiles ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None;
+    var flags = openProfiles && !disabled ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None;
     var open = ImGui.BeginTabItem("Mod Profiles", flags);
     ImGui.EndDisabled();
     ImGuiHelper.ItemTooltip(
       disabled ? "Profiles can only be changed before mods load" : "Save and switch local mod configurations",
       hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled
     );
-    openProfiles = false;
+    if (!disabled)
+      openProfiles = false;
     if (!open)
       return false;
 

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -128,7 +128,7 @@ public static class ManualLoadWindow
     var next = false;
     ImGui.SetCursorScreenPos(rect.Min);
 
-    ImGuiHelper.TextDisabled(LaunchPadInfo.VERSION);
+    ImGuiHelper.TextDisabled($"SLP {LaunchPadInfo.VERSION}");
     ImGuiHelper.DrawSameLine(() => ImGuiHelper.TextDisabled("|"), true);
 
     ImGuiHelper.Text(stage switch
@@ -148,7 +148,7 @@ public static class ManualLoadWindow
     ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, Vector2.zero);
     var (nextEnabled, nextText) = stage switch
     {
-      LoadStage.Configuring when ProfilePanel.Busy => (false, "Subscribing..."),
+      LoadStage.Configuring when ProfilePanel.Busy => (false, ProfilePanel.BusyText),
       LoadStage.Configuring when BetaProgramsPanel.Busy => (false, "Updating Betas..."),
       LoadStage.Configuring => (true, "Load Mods"),
       LoadStage.Loaded or LoadStage.Failed => (true, "Start Game"),
@@ -177,13 +177,13 @@ public static class ManualLoadWindow
 
     ImGui.AlignTextToFramePadding();
 
-    if (ImGui.Checkbox("AutoSort", ref autoSort))
+    if (ImGui.Checkbox("Auto-sort", ref autoSort))
       changed |= ChangeFlags.AutoSort;
 
     ImGui.SameLine();
     ImGuiHelper.TextDisabled("|", true);
     ImGui.SameLine();
-    ImGuiHelper.Text("Enable:");
+    ImGuiHelper.Text("Enable mods:");
 
     const byte hasEnabled = 1;
     const byte hasDisabled = 2;
@@ -417,7 +417,7 @@ public static class ManualLoadWindow
 
   private static void DrawExportButton()
   {
-    if (ImGui.Button("Export Mod Package"))
+    if (ImGui.Button("Export Server Package"))
       LaunchPadConfig.ExportModPackage();
     ImGuiHelper.ItemTooltip("Package enabled mods into a zip file for dedicated servers.");
   }
@@ -442,7 +442,7 @@ public static class ManualLoadWindow
   {
     var disabled = stage <= LoadStage.Loading;
     ImGui.BeginDisabled(disabled);
-    var open = ImGui.BeginTabItem("Mod Configuration");
+    var open = ImGui.BeginTabItem("Mod Settings");
     ImGui.EndDisabled();
     ImGuiHelper.ItemTooltip(
       disabled ? "Mods must be loaded to edit configuration" : "Edit mod specific configuration",
@@ -458,13 +458,38 @@ public static class ManualLoadWindow
   private static bool DrawLaunchPadConfigTab()
   {
     var changed = false;
-    if (ImGui.BeginTabItem("LaunchPad Configuration"))
+    if (ImGui.BeginTabItem("LaunchPad Settings"))
     {
+      DrawAppearanceSettings();
       DrawExportButton();
-      changed = ConfigPanel.DrawConfigFile(Configs.Sorted, category => category != "Internal");
+      ImGui.Separator();
+      changed = ConfigPanel.DrawConfigFile(Configs.Sorted,
+        category => category != "Internal" && category != "Appearance");
       ImGui.EndTabItem();
     }
     return changed;
+  }
+
+  private static void DrawAppearanceSettings()
+  {
+    if (!ImGui.CollapsingHeader("Appearance", ImGuiTreeNodeFlags.DefaultOpen))
+      return;
+
+    ImGuiHelper.Text("Accent color");
+    ImGui.SameLine();
+    ImGui.SetNextItemWidth(140f);
+    var accent = Configs.UiAccent.Value;
+    var open = ImGui.BeginCombo("##accentcolor", accent.ToString());
+    ImGuiHelper.ItemTooltip("Classic keeps StationeersLaunchPad's existing colors.");
+    if (open)
+    {
+      foreach (var value in (UiAccentColor[])Enum.GetValues(typeof(UiAccentColor)))
+      {
+        if (ImGui.Selectable(value.ToString(), value == accent))
+          Configs.UiAccent.Value = value;
+      }
+      ImGui.EndCombo();
+    }
   }
 
   private static bool DrawProfilesTab(LoadStage stage, ProfileManager profileManager, ModList modList)

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -24,8 +24,15 @@ public static class ManualLoadWindow
   private static bool openInfo = false;
   private static ModInfo draggingMod = null;
   private static bool dragged = false;
+  private static bool openProfiles = false;
 
-  public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort)
+  public static void OpenProfilesTab()
+  {
+    openProfiles = true;
+    ProfilePanel.SelectActive();
+  }
+
+  public static ChangeFlags Draw(LoadStage stage, ModList modList, bool autoSort, ProfileManager profileManager)
   {
     Platform.SetBackgroundEnabled(false);
     var changed = ChangeFlags.None;
@@ -83,6 +90,8 @@ public static class ManualLoadWindow
       {
         DrawModInfoTab(stage);
         DrawModConfigTab(stage);
+        if (DrawProfilesTab(stage, profileManager, modList))
+          changed |= ChangeFlags.Mods;
 
         // If we changed launchpad config and haven't loaded mods yet, mark mods changed to apply disable/sort behaviour
         if (DrawLaunchPadConfigTab() && stage <= LoadStage.Configuring)
@@ -437,6 +446,28 @@ public static class ManualLoadWindow
       changed = ConfigPanel.DrawConfigFile(Configs.Sorted, category => category != "Internal");
       ImGui.EndTabItem();
     }
+    return changed;
+  }
+
+  private static bool DrawProfilesTab(LoadStage stage, ProfileManager profileManager, ModList modList)
+  {
+    var disabled = stage is not LoadStage.Searching and not LoadStage.Configuring;
+    ImGui.BeginDisabled(disabled);
+    var flags = openProfiles ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None;
+    var open = ImGui.BeginTabItem("Mod Profiles", flags);
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      disabled ? "Profiles can only be changed before mods load" : "Save and switch local mod configurations",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled
+    );
+    openProfiles = false;
+    if (!open)
+      return false;
+
+    ImGui.BeginChild("##profiles");
+    var changed = ProfilePanel.Draw(profileManager, modList);
+    ImGui.EndChild();
+    ImGui.EndTabItem();
     return changed;
   }
 }

--- a/StationeersLaunchPad/UI/ModInfoPanel.cs
+++ b/StationeersLaunchPad/UI/ModInfoPanel.cs
@@ -13,7 +13,7 @@ public class ModInfoPanel
   {
     if (mod == null)
     {
-      ImGuiHelper.TextDisabled("Selected a mod to view detailed info");
+      ImGuiHelper.TextDisabled("Select a mod on the left to view its details.");
       return;
     }
 
@@ -74,7 +74,7 @@ public class ModInfoPanel
     if (mod.IsBetaProgramMod)
       DrawOneLine("Beta Program:", "Yes");
     if (!string.IsNullOrEmpty(about.Author))
-      DrawOneLine("Author", about.Author.Trim());
+      DrawOneLine("Author:", about.Author.Trim());
     if (!string.IsNullOrEmpty(about.Version))
       DrawOneLine("Version:", about.Version.Trim());
     if (!string.IsNullOrEmpty(about.ChangeLog))

--- a/StationeersLaunchPad/UI/ModInfoPanel.cs
+++ b/StationeersLaunchPad/UI/ModInfoPanel.cs
@@ -65,6 +65,14 @@ public class ModInfoPanel
       DrawOneLine("ModID:", mod.ModID);
     if (mod.WorkshopHandle > 1)
       DrawOneLine("Workshop ID:", $"{mod.WorkshopHandle}");
+    if (mod.HasBetaProgram)
+    {
+      DrawOneLine("Beta Workshop ID:", $"{mod.BetaWorkshopHandle}");
+      if (ImGui.Button("Open Beta Workshop Page"))
+        Steam.OpenWorkshopPage(mod.BetaWorkshopHandle);
+    }
+    if (mod.IsBetaProgramMod)
+      DrawOneLine("Beta Program:", "Yes");
     if (!string.IsNullOrEmpty(about.Author))
       DrawOneLine("Author", about.Author.Trim());
     if (!string.IsNullOrEmpty(about.Version))

--- a/StationeersLaunchPad/UI/ProfileLaunchWindow.cs
+++ b/StationeersLaunchPad/UI/ProfileLaunchWindow.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cysharp.Threading.Tasks;
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+using UnityEngine;
+
+namespace StationeersLaunchPad.UI;
+
+public enum ProfileLaunchAction
+{
+  None,
+  OpenSelector,
+  Continue,
+  OpenMenu,
+}
+
+public static class ProfileLaunchWindow
+{
+  private static string message = "";
+  private static ProfileStatusKind messageKind = ProfileStatusKind.Saved;
+  private static bool busy;
+
+  public static ProfileLaunchAction Draw(
+    LoadStage stage, ProfileManager manager, ModList modList,
+    bool expanded, out bool profileChanged)
+  {
+    var changed = false;
+    profileChanged = false;
+    if (stage != LoadStage.Configuring || manager.ActiveProfile == null)
+      return ProfileLaunchAction.None;
+
+    var action = ProfileLaunchAction.None;
+    ImGuiHelper.Draw(() =>
+    {
+      var profile = manager.ActiveProfile;
+      var status = ProfileStatusIndicator.Evaluate(manager, profile, modList);
+      var missingMods = manager.GetMissingMods(profile.Name, modList);
+
+      var screen = ImGuiHelper.ScreenRect().Shrink(25f);
+      screen.SplitOY(-100f, out _, out var bottomRect);
+      var anchor = new Vector2(screen.Min.x, bottomRect.Min.y - 8f);
+      var maxHeight = Math.Max(1f, anchor.y - screen.Min.y);
+      ImGui.SetNextWindowPos(anchor, ImGuiCond.Always, new Vector2(0f, 1f));
+      ImGui.SetNextWindowSizeConstraints(
+        new Vector2(screen.Size.x, 0f), new Vector2(screen.Size.x, maxHeight));
+      ImGui.Begin("##profilelaunch",
+        ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoMove
+        | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings
+        | ImGuiWindowFlags.AlwaysAutoResize);
+
+      var railColor = status.Kind == ProfileStatusKind.Saved
+        ? LaunchPadTheme.Accent
+        : ProfileStatusIndicator.ColorFor(status.Kind);
+      var windowMin = ImGui.GetWindowPos();
+      var windowMax = windowMin + ImGui.GetWindowSize();
+      LaunchPadTheme.Fill(
+        new Rect(windowMin, new Vector2(windowMin.x + 4f, windowMax.y)),
+        railColor);
+      ImGui.Indent(8f);
+
+      ImGuiHelper.TextDisabled("ACTIVE MOD PROFILE");
+      ImGuiHelper.TextColored(profile.Name, LaunchPadTheme.Accent);
+
+      if (!expanded)
+      {
+        if (status.Kind == ProfileStatusKind.Error)
+          ProfileStatusIndicator.Draw(status);
+        else
+        {
+          ImGui.SameLine();
+          ImGuiHelper.TextRightDisabled("Click to switch profile");
+        }
+
+        if (ImGui.IsWindowHovered() && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+          action = ProfileLaunchAction.OpenSelector;
+        if (ImGui.IsWindowHovered())
+          ImGuiHelper.TextTooltip("Pause startup and choose which mod profile to load.");
+        ImGui.Unindent(8f);
+        ImGui.End();
+        return;
+      }
+
+      ImGui.Spacing();
+      ImGuiHelper.TextDisabled("Choose profile");
+      ImGui.SetNextItemWidth(-float.Epsilon);
+      if (ImGui.BeginCombo("##launchprofile", profile.Name))
+      {
+        foreach (var candidate in manager.AllProfiles)
+        {
+          var missing = manager.GetMissingMods(candidate.Name, modList).Count;
+          var label = missing > 0
+            ? $"{candidate.Name}  [{missing} missing]"
+            : candidate.Name;
+          if (missing > 0)
+            ImGui.PushStyleColor(
+              ImGuiCol.Text, (Vector4)ProfileStatusIndicator.ColorFor(ProfileStatusKind.Error));
+          var selected = ImGui.Selectable(label, candidate == profile);
+          if (missing > 0)
+            ImGui.PopStyleColor();
+          if (!selected || candidate == profile)
+            continue;
+          if (manager.ApplyProfile(candidate.Name, modList))
+          {
+            changed = true;
+            message = $"Switched to {candidate.Name}";
+            messageKind = ProfileStatusKind.Saved;
+          }
+          else
+          {
+            message = $"Could not load {candidate.Name}";
+            messageKind = ProfileStatusKind.Error;
+          }
+        }
+        ImGui.EndCombo();
+      }
+
+      profile = manager.ActiveProfile;
+      missingMods = manager.GetMissingMods(profile.Name, modList);
+
+      ImGui.Separator();
+      if (missingMods.Count > 0)
+        DrawMissingMods(manager, modList, profile, missingMods, ref changed, ref action);
+      else
+        DrawReadyActions(profile.Name, ref action);
+
+      if (!string.IsNullOrEmpty(message))
+      {
+        ImGui.Spacing();
+        ProfileStatusIndicator.Draw(messageKind, message);
+      }
+
+      ImGui.Unindent(8f);
+      ImGui.End();
+    });
+    profileChanged = changed;
+    return action;
+  }
+
+  private static void DrawMissingMods(
+    ProfileManager manager, ModList modList, ProfileData profile,
+    List<ProfileModEntry> missingMods, ref bool changed, ref ProfileLaunchAction action)
+  {
+    ProfileStatusIndicator.Draw(ProfileStatusKind.Error,
+      $"{missingMods.Count} required mod{(missingMods.Count == 1 ? " is" : "s are")} missing");
+    ImGuiHelper.TextDisabled(
+      "Loading is paused. Restore missing Workshop mods or remove them from the profile.");
+    DrawModNames(missingMods.Select(GetFallbackName), missingMods.Count);
+
+    var workshopMods = missingMods
+      .Where(entry => entry.WorkshopHandle > 1)
+      .GroupBy(entry => entry.WorkshopHandle)
+      .Select(group => group.First())
+      .ToList();
+    ImGui.Spacing();
+    var available = ImGui.GetContentRegionAvail().x;
+    var spacing = ImGui.GetStyle().ItemSpacing.x;
+    var buttonCount = workshopMods.Count > 0 ? 2 : 1;
+    var buttonWidth = (available - spacing * (buttonCount - 1)) / buttonCount;
+    ImGui.BeginDisabled(busy);
+    if (workshopMods.Count > 0)
+    {
+      var subscribeText = busy ? "Restoring Workshop Mods..." : "Resubscribe Workshop Mods";
+      if (ImGui.Button(subscribeText, new Vector2(buttonWidth, 0)))
+        Resubscribe(workshopMods).Forget();
+      ImGui.SameLine();
+    }
+    if (ImGui.Button("Remove from Profile & Continue", new Vector2(buttonWidth, 0)))
+    {
+      if (manager.RemoveMods(profile.Name, missingMods)
+        && manager.ApplyProfile(profile.Name, modList))
+      {
+        changed = true;
+        message = $"Removed {missingMods.Count} missing mod{(missingMods.Count == 1 ? "" : "s")} from {profile.Name}";
+        messageKind = ProfileStatusKind.Saved;
+        action = ProfileLaunchAction.Continue;
+      }
+      else
+      {
+        message = $"Could not update {profile.Name}";
+        messageKind = ProfileStatusKind.Error;
+      }
+    }
+    ImGui.EndDisabled();
+
+    if (missingMods.Any(entry => entry.WorkshopHandle <= 1))
+      ImGuiHelper.TextDisabled(
+        "Local and Repo mods must be reinstalled outside this dialog or removed from the profile.");
+    DrawOpenMenuButton(ref action);
+  }
+
+  private static void DrawReadyActions(string profileName, ref ProfileLaunchAction action)
+  {
+    var available = ImGui.GetContentRegionAvail().x;
+    var spacing = ImGui.GetStyle().ItemSpacing.x;
+    var buttonWidth = (available - spacing) / 2f;
+    if (ImGui.Button($"Load {profileName} & Continue", new Vector2(buttonWidth, 0)))
+      action = ProfileLaunchAction.Continue;
+    ImGui.SameLine();
+    if (ImGui.Button("Open SLP Menu", new Vector2(buttonWidth, 0)))
+      action = ProfileLaunchAction.OpenMenu;
+    ImGuiHelper.ItemTooltip("Open the full LaunchPad menu on the Mod Profiles tab.");
+  }
+
+  private static void DrawOpenMenuButton(ref ProfileLaunchAction action)
+  {
+    ImGui.Spacing();
+    ImGui.BeginDisabled(busy);
+    if (ImGui.Button("Open SLP Menu"))
+      action = ProfileLaunchAction.OpenMenu;
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip("Open the full LaunchPad menu on the Mod Profiles tab.");
+  }
+
+  private static void DrawModNames(IEnumerable<string> names, int total)
+  {
+    var visible = names.Where(name => !string.IsNullOrWhiteSpace(name)).Take(4).ToList();
+    foreach (var name in visible)
+      ImGui.BulletText(name);
+    if (total > visible.Count)
+      ImGuiHelper.TextDisabled($"...and {total - visible.Count} more");
+  }
+
+  private static async UniTask Resubscribe(List<ProfileModEntry> workshopMods)
+  {
+    if (busy)
+      return;
+    busy = true;
+    message = $"Restoring {workshopMods.Count} Workshop mod{(workshopMods.Count == 1 ? "" : "s")}...";
+    messageKind = ProfileStatusKind.Info;
+    try
+    {
+      foreach (var entry in workshopMods)
+      {
+        if (await Steam.SubscribeAndDownload(entry.WorkshopHandle))
+          continue;
+        message = $"Could not restore {GetFallbackName(entry)}";
+        messageKind = ProfileStatusKind.Error;
+        return;
+      }
+
+      message = "Workshop mods restored; refreshing the mod list";
+      messageKind = ProfileStatusKind.Saved;
+      LaunchPadConfig.ReloadMods();
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      message = "Workshop mods could not be restored";
+      messageKind = ProfileStatusKind.Error;
+    }
+    finally
+    {
+      busy = false;
+    }
+  }
+
+  private static string GetFallbackName(ProfileModEntry entry)
+  {
+    if (!string.IsNullOrEmpty(entry.Name))
+      return entry.Name;
+    if (!string.IsNullOrEmpty(entry.ModID))
+      return entry.ModID;
+    if (entry.WorkshopHandle > 1)
+      return $"Workshop {entry.WorkshopHandle}";
+    var name = Path.GetFileName(entry.DirectoryPath?.TrimEnd('/', '\\'));
+    return string.IsNullOrEmpty(name) ? "Unknown mod" : name;
+  }
+}

--- a/StationeersLaunchPad/UI/ProfilePanel.cs
+++ b/StationeersLaunchPad/UI/ProfilePanel.cs
@@ -1,0 +1,133 @@
+using System.Linq;
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+
+namespace StationeersLaunchPad.UI;
+
+public static class ProfilePanel
+{
+  private static string selectedName = "";
+  private static string newProfileName = "";
+  private static string message = "";
+  private static bool selectActive;
+
+  public static void SelectActive() => selectActive = true;
+
+  public static bool Draw(ProfileManager manager, ModList modList)
+  {
+    manager.Initialize();
+    if (selectActive)
+    {
+      selectedName = manager.ActiveProfileName;
+      selectActive = false;
+    }
+    if (!string.IsNullOrEmpty(selectedName) && manager.FindProfile(selectedName) == null)
+      selectedName = "";
+
+    var changed = false;
+    var activeName = string.IsNullOrEmpty(manager.ActiveProfileName)
+      ? "Off (normal mod configuration)"
+      : manager.ActiveProfileName;
+    ImGuiHelper.Text($"Active: {activeName}");
+    ImGui.Spacing();
+
+    var selected = manager.FindProfile(selectedName);
+    ImGui.SetNextItemWidth(-float.Epsilon);
+    if (ImGui.BeginCombo("##profiles", selected?.Name ?? "Off (normal mod configuration)"))
+    {
+      if (ImGui.Selectable("Off (normal mod configuration)", selected == null))
+        selectedName = "";
+      foreach (var profile in manager.AllProfiles)
+      {
+        if (ImGui.Selectable(profile.Name, profile == selected))
+          selectedName = profile.Name;
+      }
+      ImGui.EndCombo();
+    }
+
+    selected = manager.FindProfile(selectedName);
+    if (selected == null)
+    {
+      ImGui.BeginDisabled(string.IsNullOrEmpty(manager.ActiveProfileName));
+      if (ImGui.Button("Use Normal Mod Configuration"))
+      {
+        manager.DisableProfiles();
+        message = "Profiles are off";
+      }
+      ImGui.EndDisabled();
+      ImGuiHelper.TextDisabled("LaunchPad will keep using its normal mod configuration.");
+    }
+    else
+    {
+      if (ImGui.Button("Use Profile"))
+      {
+        changed = manager.ApplyProfile(selected.Name, modList);
+        message = changed ? $"Loaded {selected.Name}" : "Profile could not be loaded";
+      }
+      ImGui.SameLine();
+      if (ImGui.Button("Update from Current Mods"))
+        message = manager.UpdateProfile(selected.Name, modList)
+          ? $"Updated {selected.Name}"
+          : "Profile could not be updated";
+      ImGui.SameLine();
+      if (ImGui.Button("Delete"))
+      {
+        message = manager.DeleteProfile(selected.Name)
+          ? $"Deleted {selected.Name}"
+          : "Profile could not be deleted";
+        selectedName = "";
+      }
+
+      var enabled = selected.Mods.Count(mod => mod.Enabled);
+      ImGuiHelper.TextDisabled($"{enabled} enabled, {selected.Mods.Count} installed when last updated");
+      if (manager.HasDiverged(selected.Name, modList))
+        ImGuiHelper.TextWarning("The current enabled mods or load order differ from this profile.");
+
+      var newMods = manager.GetNewMods(selected.Name, modList);
+      if (newMods.Count > 0)
+      {
+        ImGui.Separator();
+        ImGuiHelper.TextWarning($"{newMods.Count} new mod{(newMods.Count == 1 ? " is" : "s are")} not in this profile:");
+        foreach (var mod in newMods.Take(8))
+          ImGui.BulletText($"{mod.Name} ({mod.Source})");
+        if (newMods.Count > 8)
+          ImGuiHelper.TextDisabled($"...and {newMods.Count - 8} more");
+
+        if (ImGui.Button("Add to Profile"))
+        {
+          var updated = manager.UpdateProfile(selected.Name, modList);
+          changed = updated && manager.ApplyProfile(selected.Name, modList);
+          message = changed ? $"Added new mods to {selected.Name}" : "Profile could not be updated";
+        }
+        ImGui.SameLine();
+        if (ImGui.Button("Keep Profile Unchanged"))
+        {
+          changed = manager.ApplyProfile(selected.Name, modList);
+          message = changed ? $"Loaded {selected.Name} without the new mods" : "Profile could not be loaded";
+        }
+      }
+    }
+
+    ImGui.Separator();
+    ImGui.SetNextItemWidth(-120f);
+    var create = ImGui.InputText("##newprofile", ref newProfileName, 80, ImGuiInputTextFlags.EnterReturnsTrue);
+    ImGui.SameLine();
+    create |= ImGui.Button("Create Profile");
+    if (create)
+    {
+      if (manager.CreateProfile(newProfileName, modList))
+      {
+        selectedName = newProfileName;
+        manager.ApplyProfile(selectedName, modList);
+        message = $"Created {selectedName}";
+        newProfileName = "";
+      }
+      else
+        message = "Use a unique name without file name characters";
+    }
+
+    if (!string.IsNullOrEmpty(message))
+      ImGuiHelper.TextDisabled(message);
+    return changed;
+  }
+}

--- a/StationeersLaunchPad/UI/ProfilePanel.cs
+++ b/StationeersLaunchPad/UI/ProfilePanel.cs
@@ -22,10 +22,12 @@ public static class ProfilePanel
   private static string confirmEmptySave = "";
   private static string pendingProfileName = "";
   private static string packageCode = "";
+  private static string importedProfileName = "";
   private static DateTime confirmationExpires;
   private static bool selectActive;
   private static bool confirmProfileSwitch;
   private static bool importingPackage;
+  private static bool importedProfileReady;
   private static readonly HashSet<ulong> subscriptions = [];
   private static ModList indexedModList;
   private static IReadOnlyDictionary<string, ModInfo> modIndex;
@@ -81,6 +83,7 @@ public static class ProfilePanel
       else
         ImGuiHelper.TextColored($"Selected: {selected.Name}", LaunchPadTheme.Accent);
       DrawWorkshopPackage(stage, manager, modList, selected, modIndex);
+      changed |= DrawImportedProfileCreate(stage, manager, modList);
       DrawMessage();
       ImGui.EndTabItem();
     }
@@ -394,17 +397,7 @@ public static class ProfilePanel
     ImGui.Separator();
     ImGuiHelper.Text("Create from the current mod list");
 
-    const string buttonText = "Create Profile";
-    var style = ImGui.GetStyle();
-    var buttonWidth = ImGui.CalcTextSize(buttonText).x + style.FramePadding.x * 2;
-    var inputWidth = Math.Max(80f, ImGui.GetContentRegionAvail().x - buttonWidth - style.ItemSpacing.x);
-    ImGui.SetNextItemWidth(inputWidth);
-    var create = ImGui.InputTextWithHint(
-      "##newprofile", "Profile name", ref newProfileName, 80,
-      ImGuiInputTextFlags.EnterReturnsTrue);
-    ImGui.SameLine();
-    create |= ImGui.Button(buttonText);
-    if (!create)
+    if (!DrawCreateProfileRow("newprofile", ref newProfileName))
       return;
 
     if (manager.CreateProfile(newProfileName, modList))
@@ -417,6 +410,59 @@ public static class ProfilePanel
     }
     else
       SetMessage("Use a unique name without special characters", ProfileStatusKind.Error);
+  }
+
+  private static bool DrawImportedProfileCreate(
+    LoadStage stage, ProfileManager manager, ModList modList)
+  {
+    if (!importedProfileReady)
+      return false;
+
+    ImGui.Separator();
+    ImGuiHelper.Text("Save the imported SLP1 mod list");
+    ImGui.BeginDisabled(stage != LoadStage.Configuring || Busy);
+    var create = DrawCreateProfileRow("importedprofile", ref importedProfileName);
+    ImGui.EndDisabled();
+    if (!create)
+      return false;
+
+    if (!manager.CreateProfile(importedProfileName, modList))
+    {
+      SetMessage("Use a unique name without special characters", ProfileStatusKind.Error);
+      return false;
+    }
+
+    selectedName = importedProfileName;
+    ClearConfirmations();
+    var applied = manager.ApplyProfile(selectedName, modList);
+    SetMessage(applied
+        ? $"Created and switched to {selectedName}"
+        : "Profile was created but could not be loaded",
+      applied ? ProfileStatusKind.Saved : ProfileStatusKind.Error);
+    if (applied)
+    {
+      importedProfileName = "";
+      importedProfileReady = false;
+    }
+    return applied;
+  }
+
+  private static bool DrawCreateProfileRow(string id, ref string profileName)
+  {
+    const string buttonText = "Create Profile";
+    var style = ImGui.GetStyle();
+    var buttonWidth = ImGui.CalcTextSize(buttonText).x + style.FramePadding.x * 2;
+    var inputWidth = Math.Max(80f, ImGui.GetContentRegionAvail().x - buttonWidth - style.ItemSpacing.x);
+
+    ImGui.PushID(id);
+    ImGui.SetNextItemWidth(inputWidth);
+    var create = ImGui.InputTextWithHint(
+      "##profilename", "Profile name", ref profileName, 80,
+      ImGuiInputTextFlags.EnterReturnsTrue);
+    ImGui.SameLine();
+    create |= ImGui.Button(buttonText);
+    ImGui.PopID();
+    return create;
   }
 
   private static void DrawProfileContents(
@@ -573,6 +619,8 @@ public static class ProfilePanel
       return;
 
     importingPackage = true;
+    importedProfileReady = false;
+    importedProfileName = "";
     SetMessage($"Loading {workshopIds.Count} Workshop mods from SLP1...",
       ProfileStatusKind.Info);
     try
@@ -629,6 +677,7 @@ public static class ProfilePanel
 
       SetMessage($"Loaded {workshopIds.Count} Workshop mods from SLP1",
         ProfileStatusKind.Saved);
+      importedProfileReady = true;
       LaunchPadConfig.ReloadMods();
     }
     catch (Exception ex)

--- a/StationeersLaunchPad/UI/ProfilePanel.cs
+++ b/StationeersLaunchPad/UI/ProfilePanel.cs
@@ -17,11 +17,14 @@ public static class ProfilePanel
   private static string selectedName = "";
   private static string newProfileName = "";
   private static string message = "";
+  private static ProfileStatusKind messageKind = ProfileStatusKind.Saved;
   private static string confirmDelete = "";
   private static string confirmEmptySave = "";
+  private static string pendingProfileName = "";
   private static string packageCode = "";
   private static DateTime confirmationExpires;
   private static bool selectActive;
+  private static bool confirmProfileSwitch;
   private static bool importingPackage;
   private static readonly HashSet<ulong> subscriptions = [];
   private static ModList indexedModList;
@@ -31,6 +34,14 @@ public static class ProfilePanel
   public static string BusyText => importingPackage ? "Importing SLP1..." : "Subscribing...";
 
   public static void SelectActive() => selectActive = true;
+
+  public static void ShowLoadBlocked(string profileName, int missingModCount)
+  {
+    selectedName = profileName;
+    SetMessage(
+      $"Loading paused. Restore or remove {missingModCount} missing mod{(missingModCount == 1 ? "" : "s")} from {profileName}.",
+      ProfileStatusKind.Error);
+  }
 
   public static bool Draw(LoadStage stage, ProfileManager manager, ModList modList)
   {
@@ -96,55 +107,114 @@ public static class ProfilePanel
   private static bool DrawProfilePicker(ProfileManager manager, ModList modList)
   {
     var changed = false;
-    ImGuiHelper.Text("Profile");
-    ImGui.SameLine();
-    if (string.IsNullOrEmpty(manager.ActiveProfileName))
-      ImGuiHelper.TextDisabled("Off");
-    else
-      ImGuiHelper.TextColored($"Selected: {manager.ActiveProfileName}", LaunchPadTheme.Accent);
+    ImGuiHelper.Text("Active Mod Profile");
 
     var selected = manager.FindProfile(selectedName);
     ImGui.SetNextItemWidth(-float.Epsilon);
-    if (!ImGui.BeginCombo("##profiles", selected?.Name ?? "Off (normal mod configuration)"))
+    if (ImGui.BeginCombo("##profiles", selected?.Name ?? "Disable Profiles"))
+    {
+      if (ImGui.Selectable("Disable Profiles", selected == null)
+        && selected != null)
+        changed |= RequestProfileSwitch("", manager, modList);
+      foreach (var profile in manager.AllProfiles)
+      {
+        var missing = manager.GetMissingMods(profile.Name, modList).Count;
+        var label = missing > 0
+          ? $"{profile.Name}  [{missing} missing]"
+          : profile.Name;
+        if (missing > 0)
+          ImGui.PushStyleColor(
+            ImGuiCol.Text, (Vector4)ProfileStatusIndicator.ColorFor(ProfileStatusKind.Error));
+        var picked = ImGui.Selectable(label, profile == selected);
+        if (missing > 0)
+          ImGui.PopStyleColor();
+        if (picked && profile != selected)
+          changed |= RequestProfileSwitch(profile.Name, manager, modList);
+      }
+      ImGui.EndCombo();
+    }
+
+    changed |= DrawProfileSwitchConfirmation(manager, modList);
+    return changed;
+  }
+
+  private static bool RequestProfileSwitch(
+    string profileName, ProfileManager manager, ModList modList)
+  {
+    var active = manager.ActiveProfile;
+    var hasPendingChanges = active != null
+      && manager.HasDiverged(active.Name, modList);
+    if (!hasPendingChanges)
+      return SwitchProfile(profileName, manager, modList);
+
+    pendingProfileName = profileName;
+    confirmProfileSwitch = true;
+    ImGui.OpenPopup("Discard unsaved profile changes?##switchprofile");
+    return false;
+  }
+
+  private static bool DrawProfileSwitchConfirmation(ProfileManager manager, ModList modList)
+  {
+    const string popupName = "Discard unsaved profile changes?##switchprofile";
+    if (confirmProfileSwitch)
+      ImGui.OpenPopup(popupName);
+    if (!ImGui.BeginPopupModal(popupName,
+      ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings))
       return false;
 
-    if (ImGui.Selectable("Off (normal mod configuration)", selected == null))
-    {
-      selectedName = "";
-      packageCode = "";
-      ClearConfirmations();
-      manager.DisableProfiles();
-      message = "Profiles are off. The current mod list is unchanged.";
-    }
-    foreach (var profile in manager.AllProfiles)
-    {
-      if (!ImGui.Selectable(profile.Name, profile == selected))
-        continue;
-      if (profile == selected)
-        continue;
+    var activeName = manager.ActiveProfileName;
+    var targetName = string.IsNullOrEmpty(pendingProfileName)
+      ? "disabled profiles"
+      : pendingProfileName;
+    ImGuiHelper.TextWrapped($"{activeName} has unsaved changes. Discard them and switch to {targetName}?");
+    ImGui.Spacing();
 
-      var active = manager.ActiveProfile;
-      if (active != null && (manager.HasDiverged(active.Name, modList)
-        || manager.GetNewMods(active.Name, modList).Count > 0))
-      {
-        message = $"Save or revert changes to {active.Name} before switching profiles";
-        continue;
-      }
-
-      selectedName = profile.Name;
-      packageCode = "";
-      ClearConfirmations();
-      changed |= manager.ApplyProfile(profile.Name, modList);
-      message = changed ? $"Switched to {profile.Name}" : "Profile could not be loaded";
+    var changed = false;
+    PushPrimaryButton();
+    if (ImGui.Button("Discard and Switch"))
+    {
+      changed = SwitchProfile(pendingProfileName, manager, modList);
+      confirmProfileSwitch = false;
+      pendingProfileName = "";
+      ImGui.CloseCurrentPopup();
     }
-    ImGui.EndCombo();
+    ImGui.PopStyleColor(3);
+    ImGui.SameLine();
+    if (ImGui.Button("Cancel"))
+    {
+      confirmProfileSwitch = false;
+      pendingProfileName = "";
+      ImGui.CloseCurrentPopup();
+    }
+    ImGui.EndPopup();
     return changed;
+  }
+
+  private static bool SwitchProfile(
+    string profileName, ProfileManager manager, ModList modList)
+  {
+    selectedName = profileName;
+    packageCode = "";
+    ClearConfirmations();
+    if (string.IsNullOrEmpty(profileName))
+    {
+      manager.DisableProfiles();
+      SetMessage("Profiles disabled. The current mod list is unchanged.",
+        ProfileStatusKind.Info);
+      return false;
+    }
+
+    var applied = manager.ApplyProfile(profileName, modList);
+    SetMessage(applied ? $"Switched to {profileName}" : "Profile could not be loaded",
+      applied ? ProfileStatusKind.Saved : ProfileStatusKind.Error);
+    return applied;
   }
 
   private static void DrawOffState(ProfileManager manager)
   {
-    ImGuiHelper.TextWrapped("Profiles are optional. Create one from the mod list on the left, or select an existing profile above.");
-    if (!string.IsNullOrEmpty(manager.ActiveProfileName) && ImGui.Button("Turn Profiles Off"))
+    ImGuiHelper.TextWrapped(
+      "Profiles are disabled. Select Vanilla to load no mods, create a profile from the list on the left, or choose an existing profile.");
+    if (!string.IsNullOrEmpty(manager.ActiveProfileName) && ImGui.Button("Disable Profiles"))
       manager.DisableProfiles();
     DrawMessage();
   }
@@ -154,111 +224,90 @@ public static class ProfilePanel
     IReadOnlyDictionary<string, ModInfo> modIndex)
   {
     var changed = false;
+    var status = ProfileStatusIndicator.Evaluate(manager, selected, modList);
     var diverged = manager.HasDiverged(selected.Name, modList, modIndex);
-    var newMods = manager.GetNewMods(selected.Name, modList);
-    var hasPendingChanges = diverged || newMods.Count > 0;
-    if (diverged)
-    {
-      ImGuiHelper.TextWarning($"Unsaved changes to {selected.Name}");
-      ImGuiHelper.TextDisabled("The mod list on the left is a working copy. Save it, or revert to the saved profile.");
-    }
-    else if (newMods.Count > 0)
-    {
-      ImGuiHelper.TextWarning($"{newMods.Count} new mod{(newMods.Count == 1 ? " needs" : "s need")} a profile decision");
-      ImGuiHelper.TextDisabled("Save Changes to include their current state, or keep the saved profile.");
-    }
-    else
-    {
-      ImGuiHelper.TextSuccess($"{selected.Name} matches the mod list on the left.");
-      ImGuiHelper.TextDisabled("Changes made on the left are not saved to this profile automatically.");
-    }
+    var missingMods = manager.GetMissingMods(selected.Name, modList);
+    var isVanilla = ProfileManager.IsVanillaProfile(selected.Name);
+    var hasPendingChanges = diverged;
+    ProfileStatusIndicator.Draw(status, prominent: true);
+    if (missingMods.Count > 0)
+      ImGuiHelper.TextWrapped(
+        "Loading is paused. Subscribe to the missing Workshop mods or remove them from the profile below.");
 
-    ImGui.BeginDisabled(!hasPendingChanges);
-    PushPrimaryButton();
     var emptySave = modList.EnabledMods.All(mod => mod.Source == ModSourceType.Core)
-      && selected.Mods.Any(entry => entry.Enabled && !IsCore(entry));
+      && selected.Mods.Any(entry => !IsCore(entry));
     if (!emptySave)
       confirmEmptySave = "";
     var saveText = emptySave && confirmEmptySave == selected.Name
       ? "Confirm Save Empty"
       : "Save Changes";
+    ImGui.BeginDisabled(!hasPendingChanges || isVanilla);
     if (ImGui.Button(saveText))
     {
       if (emptySave && confirmEmptySave != selected.Name)
       {
         confirmEmptySave = selected.Name;
         confirmationExpires = DateTime.UtcNow.AddSeconds(5);
-        message = $"Click again to save {selected.Name} with no enabled mods";
+        SetMessage($"Click again to save {selected.Name} with no enabled mods",
+          ProfileStatusKind.Unsaved);
       }
       else
       {
-        message = manager.UpdateProfile(selected.Name, modList)
-          ? $"Saved changes to {selected.Name}"
-          : "Profile could not be updated";
+        var saved = manager.UpdateProfile(selected.Name, modList);
+        SetMessage(saved ? $"Saved changes to {selected.Name}" : "Profile could not be updated",
+          saved ? ProfileStatusKind.Saved : ProfileStatusKind.Error);
         confirmEmptySave = "";
       }
     }
-    ImGui.PopStyleColor(3);
     ImGui.EndDisabled();
     ImGuiHelper.ItemTooltip(
-      $"Update {selected.Name} with the mod states and load order shown on the left.",
+      isVanilla
+        ? "Vanilla is built in and cannot be changed. Create a profile to save a custom mod list."
+        : hasPendingChanges
+        ? $"Update {selected.Name} with the mod states and load order shown on the left."
+        : "The working mod list already matches this profile.",
       hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
 
     ImGui.SameLine();
     ImGui.BeginDisabled(!hasPendingChanges);
-    var revertText = newMods.Count > 0 ? "Keep Saved Profile" : "Revert Changes";
-    if (ImGui.Button(revertText))
+    if (ImGui.Button("Revert Changes"))
     {
       ClearConfirmations();
       var applied = manager.ApplyProfile(selected.Name, modList);
       changed |= applied;
-      var remembered = applied
-        && (newMods.Count == 0 || manager.UpdateProfile(selected.Name, modList));
-      message = !applied
-        ? "Profile could not be loaded"
-        : !remembered
-          ? "The new mod decision could not be saved"
-          : newMods.Count > 0
-            ? $"Kept {selected.Name} unchanged and disabled new mods"
-            : $"Reverted to the saved {selected.Name} profile";
+      SetMessage(applied
+          ? $"Reverted to the saved {selected.Name} profile"
+          : "Profile could not be loaded",
+        applied ? ProfileStatusKind.Saved : ProfileStatusKind.Error);
     }
     ImGui.EndDisabled();
     ImGuiHelper.ItemTooltip(
-      newMods.Count > 0
-        ? $"Keep the saved {selected.Name} mods and remember new mods as disabled."
-        : $"Discard pending changes and restore the saved {selected.Name} profile.",
+      $"Discard pending changes and restore the saved {selected.Name} profile.",
       hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
     ImGui.SameLine();
     var deleteText = confirmDelete == selected.Name ? "Confirm Delete" : "Delete Profile";
+    ImGui.BeginDisabled(isVanilla);
     if (ImGui.Button(deleteText))
     {
       if (confirmDelete != selected.Name)
       {
         confirmDelete = selected.Name;
         confirmationExpires = DateTime.UtcNow.AddSeconds(5);
-        message = $"Click again to delete {selected.Name}";
+        SetMessage($"Click again to delete {selected.Name}", ProfileStatusKind.Unsaved);
       }
       else
       {
-        message = manager.DeleteProfile(selected.Name)
-          ? $"Deleted {selected.Name}"
-          : "Profile could not be deleted";
+        var deleted = manager.DeleteProfile(selected.Name);
+        SetMessage(deleted ? $"Deleted {selected.Name}" : "Profile could not be deleted",
+          deleted ? ProfileStatusKind.Saved : ProfileStatusKind.Error);
         selectedName = "";
         ClearConfirmations();
       }
     }
-
-    if (newMods.Count > 0)
-    {
-      ImGui.Spacing();
-      ImGuiHelper.TextWarning($"{newMods.Count} new mod{(newMods.Count == 1 ? " is" : "s are")} not in this profile:");
-      foreach (var mod in newMods.Take(5))
-        ImGui.BulletText($"{mod.Name} ({mod.Source})");
-      if (newMods.Count > 5)
-        ImGuiHelper.TextDisabled($"...and {newMods.Count - 5} more");
-
-      ImGuiHelper.TextDisabled("Save Changes includes them; Keep Saved Profile remembers them as disabled.");
-    }
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      isVanilla ? "Vanilla is a built-in profile and cannot be deleted." : $"Delete {selected.Name}.",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
 
     DrawMessage();
     return changed;
@@ -269,7 +318,7 @@ public static class ProfilePanel
     IReadOnlyDictionary<string, ModInfo> modIndex)
   {
     var entries = profile?.Mods
-      .Where(entry => entry.Enabled && !IsCore(entry))
+      .Where(entry => !IsCore(entry))
       .ToList() ?? [];
     var savedCanCopy = entries.Count > 0 && entries.All(entry =>
       entry.Source == ModSourceType.Workshop && entry.WorkshopHandle > 1);
@@ -279,8 +328,7 @@ public static class ProfilePanel
     var currentCanCopy = currentMods.Count > 0 && currentMods.All(mod =>
       mod.Source == ModSourceType.Workshop && mod.WorkshopHandle > 1);
     var hasPendingChanges = profile != null
-      && (manager.HasDiverged(profile.Name, modList, modIndex)
-        || manager.GetNewMods(profile.Name, modList).Count > 0);
+      && manager.HasDiverged(profile.Name, modList, modIndex);
     var canCopy = savedCanCopy && !hasPendingChanges;
     var showCopy = canCopy || currentCanCopy;
     var copyRequirement = profile == null
@@ -290,11 +338,14 @@ public static class ProfilePanel
         : "Remove non-Workshop entries from the saved profile before copying an SLP1 code.";
 
     ImGuiHelper.Text("Shareable SLP1 codes");
-    ImGuiHelper.TextDisabled(savedCanCopy
+    var shareDescription = savedCanCopy
       ? "Copy this Workshop-only profile's mod IDs and load order."
       : profile != null && entries.Count > 0
-        ? "Only Workshop-only profiles can be copied. You can still load an SLP1 code below."
-        : "SLP1 codes share Workshop mod IDs and load order. Paste one below to load it.");
+        ? "Only Workshop-only profiles can be copied. The selected profile does not meet this requirement. You can still load an SLP1 code below."
+        : "SLP1 codes share Workshop mod IDs and load order. Paste one below to load it.";
+    ImGui.PushStyleColor(ImGuiCol.Text, (Vector4)LaunchPadTheme.TextMuted);
+    ImGuiHelper.TextWrapped(shareDescription);
+    ImGui.PopStyleColor();
     if (showCopy && !canCopy)
       ImGuiHelper.TextWarning(copyRequirement);
     ImGuiHelper.TextDisabled("They contain IDs and order, not mod files; missing Workshop items are downloaded.");
@@ -309,7 +360,7 @@ public static class ProfilePanel
       {
         packageCode = WorkshopPackageCode.Encode(entries.Select(entry => entry.WorkshopHandle));
         GameManager.Clipboard = packageCode;
-        message = "Shareable SLP1 code copied";
+        SetMessage("Shareable SLP1 code copied", ProfileStatusKind.Saved);
       }
       ImGui.EndDisabled();
       ImGuiHelper.ItemTooltip(
@@ -325,7 +376,7 @@ public static class ProfilePanel
     if (import)
     {
       if (!WorkshopPackageCode.TryDecode(packageCode, out var workshopIds))
-        message = "That SLP1 code is invalid";
+        SetMessage("That SLP1 code is invalid", ProfileStatusKind.Error);
       else
         ImportPackage(manager, modList, workshopIds).Forget();
     }
@@ -361,11 +412,11 @@ public static class ProfilePanel
       selectedName = newProfileName;
       ClearConfirmations();
       changed |= manager.ApplyProfile(selectedName, modList);
-      message = $"Created {selectedName}";
+      SetMessage($"Created {selectedName}", ProfileStatusKind.Saved);
       newProfileName = "";
     }
     else
-      message = "Use a unique name without file name characters";
+      SetMessage("Use a unique name without special characters", ProfileStatusKind.Error);
   }
 
   private static void DrawProfileContents(
@@ -380,10 +431,10 @@ public static class ProfilePanel
     }
 
     var entries = selected.Mods
-      .Where(entry => entry.Enabled && !IsCore(entry))
+      .Where(entry => !IsCore(entry))
       .ToList();
     var currentCount = modList.EnabledMods.Count(mod => mod.Source != ModSourceType.Core);
-    ImGuiHelper.Text($"Saved mods in {selected.Name}");
+    ImGuiHelper.Text($"Enabled mods in {selected.Name}");
     ImGui.SameLine();
     ImGuiHelper.TextDisabled($"{entries.Count} saved, {currentCount} currently enabled");
     ImGuiHelper.TextDisabled("The list on the left is your working copy. Use Save Changes to update this profile.");
@@ -395,16 +446,6 @@ public static class ProfilePanel
     if (entries.Count == 0)
       ImGuiHelper.TextDisabled("This profile has no enabled mods.");
 
-    var unavailable = selected.Mods
-      .Where(entry => !entry.Enabled && !IsCore(entry)
-        && ProfileManager.FindMod(entry, modIndex) == null)
-      .ToList();
-    if (unavailable.Count > 0)
-    {
-      ImGui.Separator();
-      ImGuiHelper.Text("Unavailable saved mods");
-      DrawProfileMods(stage, manager, selected, unavailable, entries.Count, modList, modIndex);
-    }
     ImGui.EndChild();
     ImGui.PopStyleColor(2);
   }
@@ -469,9 +510,13 @@ public static class ProfilePanel
       }
       ImGui.SameLine();
       if (ImGui.Button("Remove from Profile"))
-        message = manager.RemoveMod(profile.Name, entry)
-          ? $"Removed {name} from {profile.Name}"
-          : $"Could not remove {name}";
+      {
+        var removed = manager.RemoveMod(profile.Name, entry);
+        SetMessage(removed
+            ? $"Removed {name} from {profile.Name}"
+            : $"Could not remove {name}",
+          removed ? ProfileStatusKind.Saved : ProfileStatusKind.Error);
+      }
     }
     else if (!mod.Enabled)
     {
@@ -486,12 +531,14 @@ public static class ProfilePanel
     if (!subscriptions.Add(entry.WorkshopHandle))
       return;
 
-    message = $"Subscribing to Workshop item {entry.WorkshopHandle}...";
+    SetMessage($"Subscribing to Workshop item {entry.WorkshopHandle}...",
+      ProfileStatusKind.Info);
     try
     {
       if (!await Steam.SubscribeAndDownload(entry.WorkshopHandle))
       {
-        message = $"Could not subscribe to Workshop item {entry.WorkshopHandle}";
+        SetMessage($"Could not subscribe to Workshop item {entry.WorkshopHandle}",
+          ProfileStatusKind.Error);
         return;
       }
 
@@ -504,12 +551,13 @@ public static class ProfilePanel
         workshop = new();
         config.Mods.Add(workshop);
       }
-      workshop.Enabled = entry.Enabled;
+      workshop.Enabled = true;
       workshop.DirectoryPath = new(entry.DirectoryPath);
       workshop.WorkshopId = new(entry.WorkshopHandle);
       ModConfigUtil.SaveConfig(config);
 
-      message = $"Subscribed to Workshop item {entry.WorkshopHandle}";
+      SetMessage($"Subscribed to Workshop item {entry.WorkshopHandle}",
+        ProfileStatusKind.Saved);
       LaunchPadConfig.ReloadMods();
     }
     finally
@@ -525,7 +573,8 @@ public static class ProfilePanel
       return;
 
     importingPackage = true;
-    message = $"Loading {workshopIds.Count} Workshop mods from SLP1...";
+    SetMessage($"Loading {workshopIds.Count} Workshop mods from SLP1...",
+      ProfileStatusKind.Info);
     try
     {
       var installed = modList.AllMods
@@ -536,7 +585,8 @@ public static class ProfilePanel
       {
         if (!await Steam.SubscribeAndDownload(workshopId))
         {
-          message = $"Could not install Workshop item {workshopId}";
+          SetMessage($"Could not install Workshop item {workshopId}",
+            ProfileStatusKind.Error);
           return;
         }
       }
@@ -575,16 +625,16 @@ public static class ProfilePanel
       }
       config.Mods.Clear();
       config.Mods.AddRange(reordered);
-      manager.MarkActiveProfileDirty();
       ModConfigUtil.SaveConfig(config);
 
-      message = $"Loaded {workshopIds.Count} Workshop mods from SLP1";
+      SetMessage($"Loaded {workshopIds.Count} Workshop mods from SLP1",
+        ProfileStatusKind.Saved);
       LaunchPadConfig.ReloadMods();
     }
     catch (Exception ex)
     {
       Logger.Global.LogException(ex);
-      message = "The SLP1 code could not be loaded";
+      SetMessage("The SLP1 code could not be loaded", ProfileStatusKind.Error);
     }
     finally
     {
@@ -610,7 +660,13 @@ public static class ProfilePanel
   private static void DrawMessage()
   {
     if (!string.IsNullOrEmpty(message))
-      ImGuiHelper.TextDisabled(message);
+      ProfileStatusIndicator.Draw(messageKind, message);
+  }
+
+  private static void SetMessage(string text, ProfileStatusKind kind)
+  {
+    message = text;
+    messageKind = kind;
   }
 
   private static void PushPrimaryButton()

--- a/StationeersLaunchPad/UI/ProfilePanel.cs
+++ b/StationeersLaunchPad/UI/ProfilePanel.cs
@@ -24,8 +24,11 @@ public static class ProfilePanel
   private static bool selectActive;
   private static bool importingPackage;
   private static readonly HashSet<ulong> subscriptions = [];
+  private static ModList indexedModList;
+  private static IReadOnlyDictionary<string, ModInfo> modIndex;
 
   public static bool Busy => subscriptions.Count > 0 || importingPackage;
+  public static string BusyText => importingPackage ? "Importing SLP1..." : "Subscribing...";
 
   public static void SelectActive() => selectActive = true;
 
@@ -44,19 +47,49 @@ public static class ProfilePanel
       selectedName = manager.ActiveProfileName;
     if (!string.IsNullOrEmpty(selectedName) && manager.FindProfile(selectedName) == null)
       selectedName = "";
+    if (!ReferenceEquals(indexedModList, modList))
+    {
+      indexedModList = modList;
+      modIndex = ProfileManager.BuildModIndex(modList.AllMods);
+    }
 
+    var changed = false;
+    if (!ImGui.BeginTabBar("##profileviews"))
+      return false;
+
+    if (ImGui.BeginTabItem("Profile"))
+    {
+      changed |= DrawProfileManagement(stage, manager, modList, modIndex);
+      ImGui.EndTabItem();
+    }
+    if (ImGui.BeginTabItem("Share Profile"))
+    {
+      var selected = manager.FindProfile(selectedName);
+      if (selected == null)
+        ImGuiHelper.TextDisabled("No profile selected. You can still load a shared SLP1 code.");
+      else
+        ImGuiHelper.TextColored($"Selected: {selected.Name}", LaunchPadTheme.Accent);
+      DrawWorkshopPackage(stage, manager, modList, selected, modIndex);
+      DrawMessage();
+      ImGui.EndTabItem();
+    }
+    ImGui.EndTabBar();
+    return changed;
+  }
+
+  private static bool DrawProfileManagement(
+    LoadStage stage, ProfileManager manager, ModList modList,
+    IReadOnlyDictionary<string, ModInfo> modIndex)
+  {
     var changed = DrawProfilePicker(manager, modList);
     var selected = manager.FindProfile(selectedName);
     if (selected == null)
-    {
       DrawOffState(manager);
-      DrawWorkshopPackage(stage, manager, modList, null);
-    }
     else
-      changed |= DrawProfileActions(stage, manager, modList, selected);
+      changed |= DrawProfileActions(stage, manager, modList, selected, modIndex);
 
     DrawCreateProfile(manager, modList, ref changed);
-    DrawProfileContents(stage, manager, selected, modList);
+    DrawProfileContents(stage, manager, selected, modList, modIndex);
     return changed;
   }
 
@@ -87,6 +120,16 @@ public static class ProfilePanel
     {
       if (!ImGui.Selectable(profile.Name, profile == selected))
         continue;
+      if (profile == selected)
+        continue;
+
+      var active = manager.ActiveProfile;
+      if (active != null && (manager.HasDiverged(active.Name, modList)
+        || manager.GetNewMods(active.Name, modList).Count > 0))
+      {
+        message = $"Save or revert changes to {active.Name} before switching profiles";
+        continue;
+      }
 
       selectedName = profile.Name;
       packageCode = "";
@@ -107,27 +150,38 @@ public static class ProfilePanel
   }
 
   private static bool DrawProfileActions(
-    LoadStage stage, ProfileManager manager, ModList modList, ProfileData selected)
+    LoadStage stage, ProfileManager manager, ModList modList, ProfileData selected,
+    IReadOnlyDictionary<string, ModInfo> modIndex)
   {
     var changed = false;
-    var diverged = manager.HasDiverged(selected.Name, modList);
+    var diverged = manager.HasDiverged(selected.Name, modList, modIndex);
+    var newMods = manager.GetNewMods(selected.Name, modList);
+    var hasPendingChanges = diverged || newMods.Count > 0;
     if (diverged)
     {
-      ImGuiHelper.TextWarning("The current mod list differs from this saved profile.");
-      ImGuiHelper.TextDisabled("Save the current list, or apply the saved profile to discard these changes.");
+      ImGuiHelper.TextWarning($"Unsaved changes to {selected.Name}");
+      ImGuiHelper.TextDisabled("The mod list on the left is a working copy. Save it, or revert to the saved profile.");
+    }
+    else if (newMods.Count > 0)
+    {
+      ImGuiHelper.TextWarning($"{newMods.Count} new mod{(newMods.Count == 1 ? " needs" : "s need")} a profile decision");
+      ImGuiHelper.TextDisabled("Save Changes to include their current state, or keep the saved profile.");
     }
     else
-      ImGuiHelper.TextDisabled("The mod list on the left matches this profile.");
+    {
+      ImGuiHelper.TextSuccess($"{selected.Name} matches the mod list on the left.");
+      ImGuiHelper.TextDisabled("Changes made on the left are not saved to this profile automatically.");
+    }
 
-    ImGui.BeginDisabled(!diverged);
+    ImGui.BeginDisabled(!hasPendingChanges);
     PushPrimaryButton();
     var emptySave = modList.EnabledMods.All(mod => mod.Source == ModSourceType.Core)
       && selected.Mods.Any(entry => entry.Enabled && !IsCore(entry));
     if (!emptySave)
       confirmEmptySave = "";
     var saveText = emptySave && confirmEmptySave == selected.Name
-      ? "Confirm Empty Profile"
-      : "Save Current List";
+      ? "Confirm Save Empty"
+      : "Save Changes";
     if (ImGui.Button(saveText))
     {
       if (emptySave && confirmEmptySave != selected.Name)
@@ -139,21 +193,41 @@ public static class ProfilePanel
       else
       {
         message = manager.UpdateProfile(selected.Name, modList)
-          ? $"Saved current mod list to {selected.Name}"
+          ? $"Saved changes to {selected.Name}"
           : "Profile could not be updated";
         confirmEmptySave = "";
       }
     }
     ImGui.PopStyleColor(3);
     ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      $"Update {selected.Name} with the mod states and load order shown on the left.",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
 
     ImGui.SameLine();
-    if (ImGui.Button("Apply Saved Profile"))
+    ImGui.BeginDisabled(!hasPendingChanges);
+    var revertText = newMods.Count > 0 ? "Keep Saved Profile" : "Revert Changes";
+    if (ImGui.Button(revertText))
     {
       ClearConfirmations();
-      changed |= manager.ApplyProfile(selected.Name, modList);
-      message = changed ? $"Applied {selected.Name}" : "Profile could not be loaded";
+      var applied = manager.ApplyProfile(selected.Name, modList);
+      changed |= applied;
+      var remembered = applied
+        && (newMods.Count == 0 || manager.UpdateProfile(selected.Name, modList));
+      message = !applied
+        ? "Profile could not be loaded"
+        : !remembered
+          ? "The new mod decision could not be saved"
+          : newMods.Count > 0
+            ? $"Kept {selected.Name} unchanged and disabled new mods"
+            : $"Reverted to the saved {selected.Name} profile";
     }
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      newMods.Count > 0
+        ? $"Keep the saved {selected.Name} mods and remember new mods as disabled."
+        : $"Discard pending changes and restore the saved {selected.Name} profile.",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
     ImGui.SameLine();
     var deleteText = confirmDelete == selected.Name ? "Confirm Delete" : "Delete Profile";
     if (ImGui.Button(deleteText))
@@ -174,7 +248,6 @@ public static class ProfilePanel
       }
     }
 
-    var newMods = manager.GetNewMods(selected.Name, modList);
     if (newMods.Count > 0)
     {
       ImGui.Spacing();
@@ -184,70 +257,85 @@ public static class ProfilePanel
       if (newMods.Count > 5)
         ImGuiHelper.TextDisabled($"...and {newMods.Count - 5} more");
 
-      if (ImGui.Button("Add to Profile"))
-      {
-        var updated = manager.UpdateProfile(selected.Name, modList);
-        changed |= updated && manager.ApplyProfile(selected.Name, modList);
-        message = changed ? $"Added new mods to {selected.Name}" : "Profile could not be updated";
-      }
-      ImGui.SameLine();
-      if (ImGui.Button("Keep Profile Unchanged"))
-      {
-        changed |= manager.ApplyProfile(selected.Name, modList);
-        message = changed ? $"Loaded {selected.Name} without the new mods" : "Profile could not be loaded";
-      }
+      ImGuiHelper.TextDisabled("Save Changes includes them; Keep Saved Profile remembers them as disabled.");
     }
 
-    DrawWorkshopPackage(stage, manager, modList, selected);
     DrawMessage();
     return changed;
   }
 
   private static void DrawWorkshopPackage(
-    LoadStage stage, ProfileManager manager, ModList modList, ProfileData profile)
+    LoadStage stage, ProfileManager manager, ModList modList, ProfileData profile,
+    IReadOnlyDictionary<string, ModInfo> modIndex)
   {
     var entries = profile?.Mods
       .Where(entry => entry.Enabled && !IsCore(entry))
       .ToList() ?? [];
-    var canCopy = entries.Count > 0 && entries.All(entry =>
+    var savedCanCopy = entries.Count > 0 && entries.All(entry =>
       entry.Source == ModSourceType.Workshop && entry.WorkshopHandle > 1);
+    var currentMods = modList.EnabledMods
+      .Where(mod => mod.Source != ModSourceType.Core)
+      .ToList();
+    var currentCanCopy = currentMods.Count > 0 && currentMods.All(mod =>
+      mod.Source == ModSourceType.Workshop && mod.WorkshopHandle > 1);
+    var hasPendingChanges = profile != null
+      && (manager.HasDiverged(profile.Name, modList, modIndex)
+        || manager.GetNewMods(profile.Name, modList).Count > 0);
+    var canCopy = savedCanCopy && !hasPendingChanges;
+    var showCopy = canCopy || currentCanCopy;
+    var copyRequirement = profile == null
+      ? "Create a profile from the current selection on the Profile tab before copying an SLP1 code."
+      : hasPendingChanges
+        ? "Use Save Changes on the Profile tab before copying this SLP1 code."
+        : "Remove non-Workshop entries from the saved profile before copying an SLP1 code.";
 
-    ImGui.Spacing();
-    ImGuiHelper.Text("Workshop package");
-    ImGuiHelper.TextDisabled(canCopy
-      ? "Share this profile's Workshop items and load order as a package code."
-      : "Import a Workshop package into the current mod list.");
+    ImGuiHelper.Text("Shareable SLP1 codes");
+    ImGuiHelper.TextDisabled(savedCanCopy
+      ? "Copy this Workshop-only profile's mod IDs and load order."
+      : profile != null && entries.Count > 0
+        ? "Only Workshop-only profiles can be copied. You can still load an SLP1 code below."
+        : "SLP1 codes share Workshop mod IDs and load order. Paste one below to load it.");
+    if (showCopy && !canCopy)
+      ImGuiHelper.TextWarning(copyRequirement);
+    ImGuiHelper.TextDisabled("They contain IDs and order, not mod files; missing Workshop items are downloaded.");
     var import = ImGui.InputTextWithHint(
-      "##packagecode", "SLP1 package code", ref packageCode, 16384,
+      "##packagecode", "Paste an SLP1 code", ref packageCode, 16384,
       ImGuiInputTextFlags.EnterReturnsTrue);
 
-    if (canCopy && ImGui.Button("Copy Code"))
+    if (showCopy)
     {
-      packageCode = WorkshopPackageCode.Encode(entries.Select(entry => entry.WorkshopHandle));
-      GameManager.Clipboard = packageCode;
-      message = "Workshop package code copied";
-    }
-    if (canCopy)
+      ImGui.BeginDisabled(!canCopy);
+      if (ImGui.Button("Copy SLP1 Code"))
+      {
+        packageCode = WorkshopPackageCode.Encode(entries.Select(entry => entry.WorkshopHandle));
+        GameManager.Clipboard = packageCode;
+        message = "Shareable SLP1 code copied";
+      }
+      ImGui.EndDisabled();
+      ImGuiHelper.ItemTooltip(
+        canCopy ? "Copy the saved profile as an SLP1 code" : copyRequirement,
+        hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
       ImGui.SameLine();
+    }
     var canImport = stage == LoadStage.Configuring
       && !Busy && !string.IsNullOrWhiteSpace(packageCode);
     ImGui.BeginDisabled(!canImport);
-    import = ImGui.Button(importingPackage ? "Importing..." : "Import Code")
+    import = ImGui.Button(importingPackage ? "Importing..." : "Load SLP1 Code")
       || import && canImport;
     if (import)
     {
       if (!WorkshopPackageCode.TryDecode(packageCode, out var workshopIds))
-        message = "That Workshop package code is invalid";
+        message = "That SLP1 code is invalid";
       else
         ImportPackage(manager, modList, workshopIds).Forget();
     }
     ImGui.EndDisabled();
     ImGuiHelper.ItemTooltip(
       stage == LoadStage.Configuring
-        ? "Replace the current enabled mods with this Workshop package"
-        : "Packages can only be imported before loading mods",
+        ? "Replace the current enabled mods with this SLP1 code"
+        : "SLP1 codes can only be loaded before loading mods",
       hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
-    ImGuiHelper.TextDisabled("Import changes the current mod list. Save it to the profile when ready.");
+    ImGuiHelper.TextDisabled("Loading a code changes the list on the left. Save Changes when ready.");
   }
 
   private static void DrawCreateProfile(ProfileManager manager, ModList modList, ref bool changed)
@@ -281,7 +369,8 @@ public static class ProfilePanel
   }
 
   private static void DrawProfileContents(
-    LoadStage stage, ProfileManager manager, ProfileData selected, ModList modList)
+    LoadStage stage, ProfileManager manager, ProfileData selected, ModList modList,
+    IReadOnlyDictionary<string, ModInfo> modIndex)
   {
     ImGui.Separator();
     if (selected == null)
@@ -297,36 +386,58 @@ public static class ProfilePanel
     ImGuiHelper.Text($"Saved mods in {selected.Name}");
     ImGui.SameLine();
     ImGuiHelper.TextDisabled($"{entries.Count} saved, {currentCount} currently enabled");
-    ImGuiHelper.TextDisabled("Edit using the mod list on the left, then save the changes here.");
+    ImGuiHelper.TextDisabled("The list on the left is your working copy. Use Save Changes to update this profile.");
 
     ImGui.PushStyleColor(ImGuiCol.ChildBg, (Vector4)LaunchPadTheme.PanelAlt);
     ImGui.PushStyleColor(ImGuiCol.Border, (Vector4)LaunchPadTheme.Border);
     ImGui.BeginChild("##profilecontents", new Vector2(0, 0), true);
-    for (var i = 0; i < entries.Count; i++)
-      DrawProfileMod(stage, manager, selected, entries[i], i, modList);
+    DrawProfileMods(stage, manager, selected, entries, 0, modList, modIndex);
     if (entries.Count == 0)
       ImGuiHelper.TextDisabled("This profile has no enabled mods.");
 
     var unavailable = selected.Mods
       .Where(entry => !entry.Enabled && !IsCore(entry)
-        && ProfileManager.FindMod(entry, modList.AllMods) == null)
+        && ProfileManager.FindMod(entry, modIndex) == null)
       .ToList();
     if (unavailable.Count > 0)
     {
       ImGui.Separator();
       ImGuiHelper.Text("Unavailable saved mods");
-      foreach (var (entry, index) in unavailable.Select((entry, index) => (entry, index)))
-        DrawProfileMod(stage, manager, selected, entry, entries.Count + index, modList);
+      DrawProfileMods(stage, manager, selected, unavailable, entries.Count, modList, modIndex);
     }
     ImGui.EndChild();
     ImGui.PopStyleColor(2);
   }
 
+  private static void DrawProfileMods(
+    LoadStage stage, ProfileManager manager, ProfileData profile,
+    IReadOnlyList<ProfileModEntry> entries, int indexOffset, ModList modList,
+    IReadOnlyDictionary<string, ModInfo> modIndex)
+  {
+    if (entries.Count == 0)
+      return;
+
+    var rowHeight = ImGui.GetFrameHeightWithSpacing();
+    var start = ImGui.GetCursorPos();
+    var visibleStart = Math.Max(0,
+      (int)((ImGui.GetScrollY() - start.y) / rowHeight) - 1);
+    var visibleEnd = Math.Min(entries.Count,
+      (int)Math.Ceiling((ImGui.GetScrollY() + ImGui.GetWindowHeight() - start.y) / rowHeight) + 1);
+
+    for (var i = visibleStart; i < visibleEnd; i++)
+    {
+      ImGui.SetCursorPos(new Vector2(start.x, start.y + i * rowHeight));
+      DrawProfileMod(stage, manager, profile, entries[i], indexOffset + i, modList, modIndex);
+    }
+    ImGui.SetCursorPos(new Vector2(start.x, start.y + entries.Count * rowHeight));
+  }
+
   private static void DrawProfileMod(
     LoadStage stage, ProfileManager manager, ProfileData profile,
-    ProfileModEntry entry, int index, ModList modList)
+    ProfileModEntry entry, int index, ModList modList,
+    IReadOnlyDictionary<string, ModInfo> modIndex)
   {
-    var mod = ProfileManager.FindMod(entry, modList.AllMods);
+    var mod = ProfileManager.FindMod(entry, modIndex);
     var source = mod?.Source.ToString() ?? (entry.Source == ModSourceType.Core ? "Mod" : entry.Source.ToString());
     var name = mod?.Name ?? GetFallbackName(entry);
     if (mod != null && modList.IsBetaMod(mod))
@@ -414,7 +525,7 @@ public static class ProfilePanel
       return;
 
     importingPackage = true;
-    message = $"Importing {workshopIds.Count} Workshop mods...";
+    message = $"Loading {workshopIds.Count} Workshop mods from SLP1...";
     try
     {
       var installed = modList.AllMods
@@ -429,6 +540,12 @@ public static class ProfilePanel
           return;
         }
       }
+
+      var selectedIds = workshopIds.ToHashSet();
+      foreach (var mod in modList.AllMods)
+        if (mod.Source != ModSourceType.Core)
+          mod.Enabled = mod.Source == ModSourceType.Workshop
+            && selectedIds.Contains(mod.WorkshopHandle);
 
       var config = modList.ToModConfig();
       var original = config.Mods.ToList();
@@ -461,13 +578,13 @@ public static class ProfilePanel
       manager.MarkActiveProfileDirty();
       ModConfigUtil.SaveConfig(config);
 
-      message = $"Imported {workshopIds.Count} Workshop mods";
+      message = $"Loaded {workshopIds.Count} Workshop mods from SLP1";
       LaunchPadConfig.ReloadMods();
     }
     catch (Exception ex)
     {
       Logger.Global.LogException(ex);
-      message = "Workshop package could not be imported";
+      message = "The SLP1 code could not be loaded";
     }
     finally
     {

--- a/StationeersLaunchPad/UI/ProfilePanel.cs
+++ b/StationeersLaunchPad/UI/ProfilePanel.cs
@@ -1,6 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using Assets.Scripts.Networking.Transports;
+using Cysharp.Threading.Tasks;
 using ImGuiNET;
 using StationeersLaunchPad.Metadata;
+using StationeersLaunchPad.Sources;
+using UnityEngine;
 
 namespace StationeersLaunchPad.UI;
 
@@ -9,125 +16,372 @@ public static class ProfilePanel
   private static string selectedName = "";
   private static string newProfileName = "";
   private static string message = "";
+  private static string confirmDelete = "";
+  private static string confirmEmptySave = "";
+  private static DateTime confirmationExpires;
   private static bool selectActive;
+  private static readonly HashSet<ulong> subscriptions = [];
+
+  public static bool Busy => subscriptions.Count > 0;
 
   public static void SelectActive() => selectActive = true;
 
-  public static bool Draw(ProfileManager manager, ModList modList)
+  public static bool Draw(LoadStage stage, ProfileManager manager, ModList modList)
   {
+    if ((!string.IsNullOrEmpty(confirmDelete) || !string.IsNullOrEmpty(confirmEmptySave))
+      && DateTime.UtcNow > confirmationExpires)
+      ClearConfirmations();
     manager.Initialize();
     if (selectActive)
     {
       selectedName = manager.ActiveProfileName;
       selectActive = false;
     }
+    else if (string.IsNullOrEmpty(selectedName) && !string.IsNullOrEmpty(manager.ActiveProfileName))
+      selectedName = manager.ActiveProfileName;
     if (!string.IsNullOrEmpty(selectedName) && manager.FindProfile(selectedName) == null)
       selectedName = "";
 
+    var changed = DrawProfilePicker(manager, modList);
+    var selected = manager.FindProfile(selectedName);
+    if (selected == null)
+      DrawOffState(manager);
+    else
+      changed |= DrawProfileActions(manager, modList, selected);
+
+    DrawCreateProfile(manager, modList, ref changed);
+    DrawProfileContents(stage, manager, selected, modList);
+    return changed;
+  }
+
+  private static bool DrawProfilePicker(ProfileManager manager, ModList modList)
+  {
     var changed = false;
-    var activeName = string.IsNullOrEmpty(manager.ActiveProfileName)
-      ? "Off (normal mod configuration)"
-      : manager.ActiveProfileName;
-    ImGuiHelper.Text($"Active: {activeName}");
-    ImGui.Spacing();
+    ImGuiHelper.Text("Profile");
+    ImGui.SameLine();
+    if (string.IsNullOrEmpty(manager.ActiveProfileName))
+      ImGuiHelper.TextDisabled("Off");
+    else
+      ImGuiHelper.TextColored($"Selected: {manager.ActiveProfileName}", LaunchPadTheme.Accent);
 
     var selected = manager.FindProfile(selectedName);
     ImGui.SetNextItemWidth(-float.Epsilon);
-    if (ImGui.BeginCombo("##profiles", selected?.Name ?? "Off (normal mod configuration)"))
-    {
-      if (ImGui.Selectable("Off (normal mod configuration)", selected == null))
-        selectedName = "";
-      foreach (var profile in manager.AllProfiles)
-      {
-        if (ImGui.Selectable(profile.Name, profile == selected))
-          selectedName = profile.Name;
-      }
-      ImGui.EndCombo();
-    }
+    if (!ImGui.BeginCombo("##profiles", selected?.Name ?? "Off (normal mod configuration)"))
+      return false;
 
-    selected = manager.FindProfile(selectedName);
-    if (selected == null)
+    if (ImGui.Selectable("Off (normal mod configuration)", selected == null))
     {
-      ImGui.BeginDisabled(string.IsNullOrEmpty(manager.ActiveProfileName));
-      if (ImGui.Button("Use Normal Mod Configuration"))
-      {
-        manager.DisableProfiles();
-        message = "Profiles are off";
-      }
-      ImGui.EndDisabled();
-      ImGuiHelper.TextDisabled("LaunchPad will keep using its normal mod configuration.");
+      selectedName = "";
+      ClearConfirmations();
+      manager.DisableProfiles();
+      message = "Profiles are off. The current mod list is unchanged.";
+    }
+    foreach (var profile in manager.AllProfiles)
+    {
+      if (!ImGui.Selectable(profile.Name, profile == selected))
+        continue;
+
+      selectedName = profile.Name;
+      ClearConfirmations();
+      changed |= manager.ApplyProfile(profile.Name, modList);
+      message = changed ? $"Switched to {profile.Name}" : "Profile could not be loaded";
+    }
+    ImGui.EndCombo();
+    return changed;
+  }
+
+  private static void DrawOffState(ProfileManager manager)
+  {
+    ImGuiHelper.TextWrapped("Profiles are optional. Create one from the mod list on the left, or select an existing profile above.");
+    if (!string.IsNullOrEmpty(manager.ActiveProfileName) && ImGui.Button("Turn Profiles Off"))
+      manager.DisableProfiles();
+    DrawMessage();
+  }
+
+  private static bool DrawProfileActions(ProfileManager manager, ModList modList, ProfileData selected)
+  {
+    var changed = false;
+    var diverged = manager.HasDiverged(selected.Name, modList);
+    if (diverged)
+    {
+      ImGuiHelper.TextWarning("The current mod list differs from this saved profile.");
+      ImGuiHelper.TextDisabled("Save the current list, or apply the saved profile to discard these changes.");
     }
     else
+      ImGuiHelper.TextDisabled("The mod list on the left matches this profile.");
+
+    ImGui.BeginDisabled(!diverged);
+    PushPrimaryButton();
+    var emptySave = modList.EnabledMods.All(mod => mod.Source == ModSourceType.Core)
+      && selected.Mods.Any(entry => entry.Enabled && !IsCore(entry));
+    if (!emptySave)
+      confirmEmptySave = "";
+    var saveText = emptySave && confirmEmptySave == selected.Name
+      ? "Confirm Empty Profile"
+      : "Save Current List";
+    if (ImGui.Button(saveText))
     {
-      if (ImGui.Button("Use Profile"))
+      if (emptySave && confirmEmptySave != selected.Name)
       {
-        changed = manager.ApplyProfile(selected.Name, modList);
-        message = changed ? $"Loaded {selected.Name}" : "Profile could not be loaded";
+        confirmEmptySave = selected.Name;
+        confirmationExpires = DateTime.UtcNow.AddSeconds(5);
+        message = $"Click again to save {selected.Name} with no enabled mods";
       }
-      ImGui.SameLine();
-      if (ImGui.Button("Update from Current Mods"))
+      else
+      {
         message = manager.UpdateProfile(selected.Name, modList)
-          ? $"Updated {selected.Name}"
+          ? $"Saved current mod list to {selected.Name}"
           : "Profile could not be updated";
-      ImGui.SameLine();
-      if (ImGui.Button("Delete"))
+        confirmEmptySave = "";
+      }
+    }
+    ImGui.PopStyleColor(3);
+    ImGui.EndDisabled();
+
+    ImGui.SameLine();
+    if (ImGui.Button("Apply Saved Profile"))
+    {
+      ClearConfirmations();
+      changed |= manager.ApplyProfile(selected.Name, modList);
+      message = changed ? $"Applied {selected.Name}" : "Profile could not be loaded";
+    }
+    ImGui.SameLine();
+    var deleteText = confirmDelete == selected.Name ? "Confirm Delete" : "Delete Profile";
+    if (ImGui.Button(deleteText))
+    {
+      if (confirmDelete != selected.Name)
+      {
+        confirmDelete = selected.Name;
+        confirmationExpires = DateTime.UtcNow.AddSeconds(5);
+        message = $"Click again to delete {selected.Name}";
+      }
+      else
       {
         message = manager.DeleteProfile(selected.Name)
           ? $"Deleted {selected.Name}"
           : "Profile could not be deleted";
         selectedName = "";
-      }
-
-      var enabled = selected.Mods.Count(mod => mod.Enabled);
-      ImGuiHelper.TextDisabled($"{enabled} enabled, {selected.Mods.Count} installed when last updated");
-      if (manager.HasDiverged(selected.Name, modList))
-        ImGuiHelper.TextWarning("The current enabled mods or load order differ from this profile.");
-
-      var newMods = manager.GetNewMods(selected.Name, modList);
-      if (newMods.Count > 0)
-      {
-        ImGui.Separator();
-        ImGuiHelper.TextWarning($"{newMods.Count} new mod{(newMods.Count == 1 ? " is" : "s are")} not in this profile:");
-        foreach (var mod in newMods.Take(8))
-          ImGui.BulletText($"{mod.Name} ({mod.Source})");
-        if (newMods.Count > 8)
-          ImGuiHelper.TextDisabled($"...and {newMods.Count - 8} more");
-
-        if (ImGui.Button("Add to Profile"))
-        {
-          var updated = manager.UpdateProfile(selected.Name, modList);
-          changed = updated && manager.ApplyProfile(selected.Name, modList);
-          message = changed ? $"Added new mods to {selected.Name}" : "Profile could not be updated";
-        }
-        ImGui.SameLine();
-        if (ImGui.Button("Keep Profile Unchanged"))
-        {
-          changed = manager.ApplyProfile(selected.Name, modList);
-          message = changed ? $"Loaded {selected.Name} without the new mods" : "Profile could not be loaded";
-        }
+        ClearConfirmations();
       }
     }
 
-    ImGui.Separator();
-    ImGui.SetNextItemWidth(-120f);
-    var create = ImGui.InputText("##newprofile", ref newProfileName, 80, ImGuiInputTextFlags.EnterReturnsTrue);
-    ImGui.SameLine();
-    create |= ImGui.Button("Create Profile");
-    if (create)
+    var newMods = manager.GetNewMods(selected.Name, modList);
+    if (newMods.Count > 0)
     {
-      if (manager.CreateProfile(newProfileName, modList))
+      ImGui.Spacing();
+      ImGuiHelper.TextWarning($"{newMods.Count} new mod{(newMods.Count == 1 ? " is" : "s are")} not in this profile:");
+      foreach (var mod in newMods.Take(5))
+        ImGui.BulletText($"{mod.Name} ({mod.Source})");
+      if (newMods.Count > 5)
+        ImGuiHelper.TextDisabled($"...and {newMods.Count - 5} more");
+
+      if (ImGui.Button("Add to Profile"))
       {
-        selectedName = newProfileName;
-        manager.ApplyProfile(selectedName, modList);
-        message = $"Created {selectedName}";
-        newProfileName = "";
+        var updated = manager.UpdateProfile(selected.Name, modList);
+        changed |= updated && manager.ApplyProfile(selected.Name, modList);
+        message = changed ? $"Added new mods to {selected.Name}" : "Profile could not be updated";
       }
-      else
-        message = "Use a unique name without file name characters";
+      ImGui.SameLine();
+      if (ImGui.Button("Keep Profile Unchanged"))
+      {
+        changed |= manager.ApplyProfile(selected.Name, modList);
+        message = changed ? $"Loaded {selected.Name} without the new mods" : "Profile could not be loaded";
+      }
     }
 
+    DrawMessage();
+    return changed;
+  }
+
+  private static void DrawCreateProfile(ProfileManager manager, ModList modList, ref bool changed)
+  {
+    ImGui.Separator();
+    ImGuiHelper.Text("Create from the current mod list");
+
+    const string buttonText = "Create Profile";
+    var style = ImGui.GetStyle();
+    var buttonWidth = ImGui.CalcTextSize(buttonText).x + style.FramePadding.x * 2;
+    var inputWidth = Math.Max(80f, ImGui.GetContentRegionAvail().x - buttonWidth - style.ItemSpacing.x);
+    ImGui.SetNextItemWidth(inputWidth);
+    var create = ImGui.InputTextWithHint(
+      "##newprofile", "Profile name", ref newProfileName, 80,
+      ImGuiInputTextFlags.EnterReturnsTrue);
+    ImGui.SameLine();
+    create |= ImGui.Button(buttonText);
+    if (!create)
+      return;
+
+    if (manager.CreateProfile(newProfileName, modList))
+    {
+      selectedName = newProfileName;
+      ClearConfirmations();
+      changed |= manager.ApplyProfile(selectedName, modList);
+      message = $"Created {selectedName}";
+      newProfileName = "";
+    }
+    else
+      message = "Use a unique name without file name characters";
+  }
+
+  private static void DrawProfileContents(
+    LoadStage stage, ProfileManager manager, ProfileData selected, ModList modList)
+  {
+    ImGui.Separator();
+    if (selected == null)
+    {
+      ImGuiHelper.TextDisabled("No profile selected.");
+      return;
+    }
+
+    var entries = selected.Mods
+      .Where(entry => entry.Enabled && !IsCore(entry))
+      .ToList();
+    var currentCount = modList.EnabledMods.Count(mod => mod.Source != ModSourceType.Core);
+    ImGuiHelper.Text($"Saved mods in {selected.Name}");
+    ImGui.SameLine();
+    ImGuiHelper.TextDisabled($"{entries.Count} saved, {currentCount} currently enabled");
+    ImGuiHelper.TextDisabled("Edit using the mod list on the left, then save the changes here.");
+
+    ImGui.PushStyleColor(ImGuiCol.ChildBg, (Vector4)LaunchPadTheme.PanelAlt);
+    ImGui.PushStyleColor(ImGuiCol.Border, (Vector4)LaunchPadTheme.Border);
+    ImGui.BeginChild("##profilecontents", new Vector2(0, 0), true);
+    for (var i = 0; i < entries.Count; i++)
+      DrawProfileMod(stage, manager, selected, entries[i], i, modList);
+    if (entries.Count == 0)
+      ImGuiHelper.TextDisabled("This profile has no enabled mods.");
+
+    var unavailable = selected.Mods
+      .Where(entry => !entry.Enabled && !IsCore(entry)
+        && ProfileManager.FindMod(entry, modList.AllMods) == null)
+      .ToList();
+    if (unavailable.Count > 0)
+    {
+      ImGui.Separator();
+      ImGuiHelper.Text("Unavailable saved mods");
+      foreach (var (entry, index) in unavailable.Select((entry, index) => (entry, index)))
+        DrawProfileMod(stage, manager, selected, entry, entries.Count + index, modList);
+    }
+    ImGui.EndChild();
+    ImGui.PopStyleColor(2);
+  }
+
+  private static void DrawProfileMod(
+    LoadStage stage, ProfileManager manager, ProfileData profile,
+    ProfileModEntry entry, int index, ModList modList)
+  {
+    var mod = ProfileManager.FindMod(entry, modList.AllMods);
+    var source = mod?.Source.ToString() ?? (entry.Source == ModSourceType.Core ? "Mod" : entry.Source.ToString());
+    var name = mod?.Name ?? GetFallbackName(entry);
+    if (mod != null && modList.IsBetaMod(mod))
+      name += " [BETA]";
+
+    ImGui.PushID(index);
+    ImGuiHelper.TextDisabled($"{index + 1}.");
+    ImGui.SameLine();
+    ImGuiHelper.TextColored(source, LaunchPadTheme.TextMuted);
+    ImGui.SameLine();
+    ImGuiHelper.Text(name);
+    if (mod == null)
+    {
+      ImGui.SameLine();
+      ImGuiHelper.TextWarning("Not installed");
+      if (entry.WorkshopHandle > 1)
+      {
+        ImGui.SameLine();
+        var busy = subscriptions.Contains(entry.WorkshopHandle);
+        ImGui.BeginDisabled(stage != LoadStage.Configuring || busy);
+        if (ImGui.Button(busy ? "Subscribing..." : "Subscribe"))
+          Subscribe(entry).Forget();
+        ImGui.EndDisabled();
+        ImGuiHelper.ItemTooltip(
+          stage == LoadStage.Configuring
+            ? $"Subscribe to Workshop item {entry.WorkshopHandle}"
+            : "Workshop items can only be subscribed before loading mods",
+          hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
+      }
+      ImGui.SameLine();
+      if (ImGui.Button("Remove from Profile"))
+        message = manager.RemoveMod(profile.Name, entry)
+          ? $"Removed {name} from {profile.Name}"
+          : $"Could not remove {name}";
+    }
+    else if (!mod.Enabled)
+    {
+      ImGui.SameLine();
+      ImGuiHelper.TextWarning("Pending removal");
+    }
+    ImGui.PopID();
+  }
+
+  private static async UniTask Subscribe(ProfileModEntry entry)
+  {
+    if (!subscriptions.Add(entry.WorkshopHandle))
+      return;
+
+    message = $"Subscribing to Workshop item {entry.WorkshopHandle}...";
+    try
+    {
+      if (!await Steam.SubscribeAndDownload(entry.WorkshopHandle))
+      {
+        message = $"Could not subscribe to Workshop item {entry.WorkshopHandle}";
+        return;
+      }
+
+      var config = ModConfigUtil.LoadConfig();
+      var workshop = config.Mods
+        .OfType<WorkshopModData>()
+        .FirstOrDefault(mod => (ulong)mod.WorkshopId == entry.WorkshopHandle);
+      if (workshop == null)
+      {
+        workshop = new();
+        config.Mods.Add(workshop);
+      }
+      workshop.Enabled = entry.Enabled;
+      workshop.DirectoryPath = new(entry.DirectoryPath);
+      workshop.WorkshopId = new(entry.WorkshopHandle);
+      ModConfigUtil.SaveConfig(config);
+
+      message = $"Subscribed to Workshop item {entry.WorkshopHandle}";
+      LaunchPadConfig.ReloadMods();
+    }
+    finally
+    {
+      subscriptions.Remove(entry.WorkshopHandle);
+    }
+  }
+
+  private static string GetFallbackName(ProfileModEntry entry)
+  {
+    if (!string.IsNullOrEmpty(entry.Name))
+      return entry.Name;
+    if (!string.IsNullOrEmpty(entry.ModID))
+      return entry.ModID;
+    if (entry.WorkshopHandle > 1)
+      return $"Workshop {entry.WorkshopHandle}";
+    var name = Path.GetFileName(entry.DirectoryPath?.TrimEnd('/', '\\'));
+    return string.IsNullOrEmpty(name) ? "Unknown mod" : name;
+  }
+
+  private static bool IsCore(ProfileModEntry entry) =>
+    string.IsNullOrEmpty(entry.DirectoryPath) && entry.WorkshopHandle <= 1;
+
+  private static void DrawMessage()
+  {
     if (!string.IsNullOrEmpty(message))
       ImGuiHelper.TextDisabled(message);
-    return changed;
+  }
+
+  private static void PushPrimaryButton()
+  {
+    ImGui.PushStyleColor(ImGuiCol.Button, (Vector4)LaunchPadTheme.AccentSoft);
+    ImGui.PushStyleColor(ImGuiCol.ButtonHovered, (Vector4)LaunchPadTheme.AccentStrong);
+    ImGui.PushStyleColor(ImGuiCol.ButtonActive, (Vector4)LaunchPadTheme.AccentBorder);
+  }
+
+  private static void ClearConfirmations()
+  {
+    confirmDelete = "";
+    confirmEmptySave = "";
+    confirmationExpires = DateTime.MinValue;
   }
 }

--- a/StationeersLaunchPad/UI/ProfilePanel.cs
+++ b/StationeersLaunchPad/UI/ProfilePanel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Assets.Scripts;
 using Assets.Scripts.Networking.Transports;
 using Cysharp.Threading.Tasks;
 using ImGuiNET;
@@ -18,11 +19,13 @@ public static class ProfilePanel
   private static string message = "";
   private static string confirmDelete = "";
   private static string confirmEmptySave = "";
+  private static string packageCode = "";
   private static DateTime confirmationExpires;
   private static bool selectActive;
+  private static bool importingPackage;
   private static readonly HashSet<ulong> subscriptions = [];
 
-  public static bool Busy => subscriptions.Count > 0;
+  public static bool Busy => subscriptions.Count > 0 || importingPackage;
 
   public static void SelectActive() => selectActive = true;
 
@@ -45,9 +48,12 @@ public static class ProfilePanel
     var changed = DrawProfilePicker(manager, modList);
     var selected = manager.FindProfile(selectedName);
     if (selected == null)
+    {
       DrawOffState(manager);
+      DrawWorkshopPackage(stage, manager, modList, null);
+    }
     else
-      changed |= DrawProfileActions(manager, modList, selected);
+      changed |= DrawProfileActions(stage, manager, modList, selected);
 
     DrawCreateProfile(manager, modList, ref changed);
     DrawProfileContents(stage, manager, selected, modList);
@@ -72,6 +78,7 @@ public static class ProfilePanel
     if (ImGui.Selectable("Off (normal mod configuration)", selected == null))
     {
       selectedName = "";
+      packageCode = "";
       ClearConfirmations();
       manager.DisableProfiles();
       message = "Profiles are off. The current mod list is unchanged.";
@@ -82,6 +89,7 @@ public static class ProfilePanel
         continue;
 
       selectedName = profile.Name;
+      packageCode = "";
       ClearConfirmations();
       changed |= manager.ApplyProfile(profile.Name, modList);
       message = changed ? $"Switched to {profile.Name}" : "Profile could not be loaded";
@@ -98,7 +106,8 @@ public static class ProfilePanel
     DrawMessage();
   }
 
-  private static bool DrawProfileActions(ProfileManager manager, ModList modList, ProfileData selected)
+  private static bool DrawProfileActions(
+    LoadStage stage, ProfileManager manager, ModList modList, ProfileData selected)
   {
     var changed = false;
     var diverged = manager.HasDiverged(selected.Name, modList);
@@ -189,8 +198,56 @@ public static class ProfilePanel
       }
     }
 
+    DrawWorkshopPackage(stage, manager, modList, selected);
     DrawMessage();
     return changed;
+  }
+
+  private static void DrawWorkshopPackage(
+    LoadStage stage, ProfileManager manager, ModList modList, ProfileData profile)
+  {
+    var entries = profile?.Mods
+      .Where(entry => entry.Enabled && !IsCore(entry))
+      .ToList() ?? [];
+    var canCopy = entries.Count > 0 && entries.All(entry =>
+      entry.Source == ModSourceType.Workshop && entry.WorkshopHandle > 1);
+
+    ImGui.Spacing();
+    ImGuiHelper.Text("Workshop package");
+    ImGuiHelper.TextDisabled(canCopy
+      ? "Share this profile's Workshop items and load order as a package code."
+      : "Import a Workshop package into the current mod list.");
+    var import = ImGui.InputTextWithHint(
+      "##packagecode", "SLP1 package code", ref packageCode, 16384,
+      ImGuiInputTextFlags.EnterReturnsTrue);
+
+    if (canCopy && ImGui.Button("Copy Code"))
+    {
+      packageCode = WorkshopPackageCode.Encode(entries.Select(entry => entry.WorkshopHandle));
+      GameManager.Clipboard = packageCode;
+      message = "Workshop package code copied";
+    }
+    if (canCopy)
+      ImGui.SameLine();
+    var canImport = stage == LoadStage.Configuring
+      && !Busy && !string.IsNullOrWhiteSpace(packageCode);
+    ImGui.BeginDisabled(!canImport);
+    import = ImGui.Button(importingPackage ? "Importing..." : "Import Code")
+      || import && canImport;
+    if (import)
+    {
+      if (!WorkshopPackageCode.TryDecode(packageCode, out var workshopIds))
+        message = "That Workshop package code is invalid";
+      else
+        ImportPackage(manager, modList, workshopIds).Forget();
+    }
+    ImGui.EndDisabled();
+    ImGuiHelper.ItemTooltip(
+      stage == LoadStage.Configuring
+        ? "Replace the current enabled mods with this Workshop package"
+        : "Packages can only be imported before loading mods",
+      hoverFlags: ImGuiHoveredFlags.AllowWhenDisabled);
+    ImGuiHelper.TextDisabled("Import changes the current mod list. Save it to the profile when ready.");
   }
 
   private static void DrawCreateProfile(ProfileManager manager, ModList modList, ref bool changed)
@@ -347,6 +404,74 @@ public static class ProfilePanel
     finally
     {
       subscriptions.Remove(entry.WorkshopHandle);
+    }
+  }
+
+  private static async UniTask ImportPackage(
+    ProfileManager manager, ModList modList, List<ulong> workshopIds)
+  {
+    if (importingPackage)
+      return;
+
+    importingPackage = true;
+    message = $"Importing {workshopIds.Count} Workshop mods...";
+    try
+    {
+      var installed = modList.AllMods
+        .Where(mod => mod.Source == ModSourceType.Workshop)
+        .Select(mod => mod.WorkshopHandle)
+        .ToHashSet();
+      foreach (var workshopId in workshopIds.Where(id => !installed.Contains(id)))
+      {
+        if (!await Steam.SubscribeAndDownload(workshopId))
+        {
+          message = $"Could not install Workshop item {workshopId}";
+          return;
+        }
+      }
+
+      var config = modList.ToModConfig();
+      var original = config.Mods.ToList();
+      var reordered = original.Where(mod => mod is CoreModData).ToList();
+      var workshopBase = SteamTransport.WorkshopType.Mod.GetLocalDirInfo().FullName;
+      foreach (var workshopId in workshopIds)
+      {
+        var workshop = original
+          .OfType<WorkshopModData>()
+          .FirstOrDefault(mod => (ulong)mod.WorkshopId == workshopId);
+        if (workshop == null)
+        {
+          workshop = new()
+          {
+            DirectoryPath = new(Path.Combine(workshopBase, workshopId.ToString())),
+            WorkshopId = new(workshopId),
+          };
+        }
+        workshop.Enabled = true;
+        reordered.Add(workshop);
+      }
+
+      foreach (var mod in original.Where(mod => !reordered.Contains(mod)))
+      {
+        mod.Enabled = false;
+        reordered.Add(mod);
+      }
+      config.Mods.Clear();
+      config.Mods.AddRange(reordered);
+      manager.MarkActiveProfileDirty();
+      ModConfigUtil.SaveConfig(config);
+
+      message = $"Imported {workshopIds.Count} Workshop mods";
+      LaunchPadConfig.ReloadMods();
+    }
+    catch (Exception ex)
+    {
+      Logger.Global.LogException(ex);
+      message = "Workshop package could not be imported";
+    }
+    finally
+    {
+      importingPackage = false;
     }
   }
 

--- a/StationeersLaunchPad/UI/ProfileStatusIndicator.cs
+++ b/StationeersLaunchPad/UI/ProfileStatusIndicator.cs
@@ -1,0 +1,100 @@
+using ImGuiNET;
+using StationeersLaunchPad.Metadata;
+using UnityEngine;
+
+namespace StationeersLaunchPad.UI;
+
+public enum ProfileStatusKind
+{
+  Saved,
+  Unsaved,
+  Info,
+  Error,
+}
+
+public readonly struct ProfileStatusInfo(
+  ProfileStatusKind kind, string label, string tooltip)
+{
+  public readonly ProfileStatusKind Kind = kind;
+  public readonly string Label = label;
+  public readonly string Tooltip = tooltip;
+}
+
+public static class ProfileStatusIndicator
+{
+  public static ProfileStatusInfo Evaluate(
+    ProfileManager manager, ProfileData profile, ModList modList)
+  {
+    if (profile == null)
+      return new(ProfileStatusKind.Error, "Profile unavailable",
+        "The selected profile could not be loaded.");
+
+    var modIndex = ProfileManager.BuildModIndex(modList.AllMods);
+    var missing = manager.GetMissingMods(profile.Name, modList).Count;
+    var diverged = manager.HasDiverged(profile.Name, modList, modIndex);
+
+    if (missing > 0)
+      return new(ProfileStatusKind.Error,
+        $"{missing} required mod{(missing == 1 ? " is" : "s are")} missing",
+        "Loading is paused. Restore the missing mods or remove them from this profile.");
+    if (diverged)
+      return new(ProfileStatusKind.Unsaved, "Unsaved changes",
+        "The working mod list differs from this saved profile. Save it or revert the changes.");
+    if (ProfileManager.IsVanillaProfile(profile.Name))
+      return new(ProfileStatusKind.Saved, "Built-in: Mods disabled",
+        "Vanilla is a built-in profile that loads Stationeers without mods.");
+    return new(ProfileStatusKind.Saved, "Saved", "This profile matches the working mod list.");
+  }
+
+  public static void Draw(ProfileStatusInfo status, bool prominent = false) =>
+    Draw(status.Kind, status.Label, status.Tooltip, prominent);
+
+  public static void Draw(
+    ProfileStatusKind kind, string label, string tooltip = null, bool prominent = false)
+  {
+    var color = ColorFor(kind);
+    var size = prominent ? 14f : 11f;
+    var start = ImGui.GetCursorScreenPos();
+    var lineHeight = ImGui.GetTextLineHeight();
+    var center = start + new Vector2(size / 2f, lineHeight / 2f);
+    var radius = size * 0.42f;
+    var drawList = ImGui.GetWindowDrawList();
+    var u32 = ImGui.ColorConvertFloat4ToU32((Vector4)color);
+
+    switch (kind)
+    {
+      case ProfileStatusKind.Saved:
+        drawList.AddQuadFilled(
+          center + new Vector2(0, -radius), center + new Vector2(radius, 0),
+          center + new Vector2(0, radius), center + new Vector2(-radius, 0), u32);
+        break;
+      case ProfileStatusKind.Unsaved:
+        drawList.AddTriangleFilled(
+          center + new Vector2(0, -radius),
+          center + new Vector2(radius, radius),
+          center + new Vector2(-radius, radius), u32);
+        break;
+      case ProfileStatusKind.Info:
+        drawList.AddCircleFilled(center, radius, u32, 16);
+        break;
+      case ProfileStatusKind.Error:
+        drawList.AddNgonFilled(center, radius, u32, 6);
+        break;
+    }
+
+    ImGui.Dummy(new Vector2(size, lineHeight));
+    ImGui.SameLine();
+    ImGuiHelper.TextColored(label, color);
+    if (!string.IsNullOrEmpty(tooltip))
+      ImGuiHelper.ItemTooltip(tooltip);
+  }
+
+  public static Color ColorFor(ProfileStatusKind kind) => kind switch
+  {
+    ProfileStatusKind.Saved => LaunchPadTheme.Ok,
+    ProfileStatusKind.Unsaved => LaunchPadTheme.Warn,
+    ProfileStatusKind.Info => LaunchPadTheme.Info,
+    ProfileStatusKind.Error => LaunchPadTheme.Err,
+    _ => LaunchPadTheme.TextMuted,
+  };
+}


### PR DESCRIPTION
Adds opt-in Mod Profiles, shareable SLP1 codes, Workshop beta-program support, offline Workshop persistence, dependency-aware load ordering, and a focused UI/UX polish pass for v0.5.0.

Profiles remain completely optional. With profiles disabled, SLP continues using the normal mod configuration workflow. Each profile stores one ordered list of enabled Local, Workshop, and Repo mods.

## Behavior

<details>
<summary><b>Mod Profiles</b></summary>

- Create, select, update, revert, and delete profiles from the new Mod Profiles tab.
- Use the built-in Vanilla profile to launch without mods.
- The existing mod list remains the working copy; explicit status indicators show saved, unsaved, and missing-mod states.
- The selected profile persists and is applied on startup, with a quick selector available before loading continues.
- Empty-profile saves, deletions, and profile switches with pending changes require confirmation.
- Newly installed or reordered mods appear as unsaved changes and can be saved to the profile or reverted.
- Missing mods pause loading and are shown by name where available. Missing Workshop items can be resubscribed, while any missing entry can be removed from the profile.
- Working selections are preserved across mod-list refreshes.

</details>

<details>
<summary><b>Shareable SLP1 Codes</b></summary>

- Workshop-only profiles can be shared as compact `SLP1` codes.
- Codes contain Workshop IDs, enabled load order, and an integrity checksum - never mod files, local/repository mods, or configuration data.
- Loading a code subscribes to missing Workshop items and applies its selection and order to the working list.
- An imported list can be saved immediately as a named profile.
- The UI explains when a profile cannot be copied because it has non-Workshop mods, unsaved changes, or has not yet been created.

</details>

<details>
<summary><b>Workshop Beta Programs</b></summary>

- Mods can advertise an optional Workshop beta version through metadata.
- The new Betas tab can subscribe to a beta, switch between stable and beta, return to stable, and open either Workshop page.
- Returning to stable unsubscribes the beta item; action status and failures are shown in the UI.
- Beta versions are marked `[BETA]` in yellow in the mod list.
- The main mod list and Betas tab stay synchronized, and stable/beta pairs are not treated as duplicates.

</details>

<details>
<summary><b>Workshop Persistence Without Steam</b></summary>

- When Steam is unavailable or disabled, SLP reconstructs locally available Workshop mods from the existing mod configuration.
- Controlled by `RetainWorkshopMods`, enabled by default.

</details>

<details>
<summary><b>Dependency Load Ordering</b></summary>

- `DependsOn` relationships now participate in SLP's order graph, ensuring dependencies load before dependents even when the initial Workshop or collection order is reversed.
- Fixes cases such as Modular Consoles loading before LibConstruct.

</details>

<details>
<summary><b>News System Improvements</b></summary>

- Notices can hide themselves with `unless_workshop_id` when the relevant item is already installed.
- Either notice button can subscribe to and download a Workshop item through `workshop_mod_subscribe`.
- Subscribe actions provide clear success or failure feedback.

</details>

<details>
<summary><b>UI and Wording Polish</b></summary>

- Refined spacing, alignment, rounding, labels, profile controls, and status feedback while retaining the default SLP appearance.
- Optional accent presets: Classic, Orange, Blue, Green, Pink, Yellow, Purple, Teal, and Dark.
- Renamed several labels for clarity and space: `AutoSort` to `Auto-sort`, `Mod Configuration` to `Mod Settings`, `LaunchPad Configuration` to `LaunchPad Settings`, and `Export Mod Package` to `Export Server Package`.

</details>

<details>
<summary><b>Optional Mod-Side Metadata</b></summary>

- Mod metadata can now declare `ModSide` as `Both`, `Client`, or `Server`.
- The field is optional, defaults to `Unknown`, and is reserved for future tooling.

</details>

## Credit

This release incorporates and preserves work from:

- **Tom Holmes** - Workshop persistence when Steam is unavailable.
- **TinyPandas** (#139) - initial profile storage and manager foundation, carried forward with authorship preserved.
- **FraOri03** - LaunchPad theme and configurable-accent foundation.
- **JacksonTheMaster** - integration, profile workflow, SLP1 sharing, beta support, news actions, dependency ordering, and UX work.
- **tsholmes** - #139 review feedback that shaped active-profile storage and ordered-list divergence detection.

### Related PRs

- **#139** - profile foundation and design review.
- **#141** (@tsholmes) - offline Workshop fallback.
- **#143** - alternative JSON snapshot format; not used. Profiles reuse the existing ModConfig XML model.
- **#146** - theme abstraction and configurable-accent foundation.

## Compatibility

- Existing installations remain in normal mod configuration mode until a profile is explicitly selected.
- Existing mod metadata remains valid; beta and mod-side metadata are optional.
- Existing news feeds remain valid; the new condition and action are optional.
- Profile files are stored separately as XML under the SLP save path.