### PR TITLE
Unload and safe mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,43 +2,47 @@
 
 # StationeersLaunchPad
 
-A Stationeers mod loader that allows you to edit mod configuration at game startup. This is compatible with Bepinex and StationeersMods mods installed locally in the home folder or downloaded from steam workshop.
+A Stationeers mod loader that allows you to edit mod configuration at game startup. This is compatible with BepInEx and StationeersMods mods installed locally in the home folder or downloaded from Steam Workshop.
 
 Visit the [StationeersLaunchPad docs](https://stationeerslaunchpad.github.io/docs/) for more info on StationeersLaunchPad and modding Stationeers.
 
 ## Installation
 
 ### Fresh
-- Install BepInEx into game folder
-  - [Download BepInEx 5.4](https://github.com/BepInEx/BepInEx/releases/download/v5.4.23.3/BepInEx_win_x64_5.4.23.3.zip) and extract into game folder (right click game in steam, `Manage->Browse local files`).
-  - should end up with `BepInEx` folder and `doorstop_config.ini` file in same folder as rocketstation.exe
-  - run game once to create folder structure
-  - __Linux/Steam Deck Only:__ If running on Linux/Steam Deck via Proton/Wine, you will need to [perform some additional installation steps](https://docs.bepinex.dev/articles/advanced/proton_wine.html)
-    - Since you are running a windows executable via Proton, make sure to use the Windows version of BepInEx linked above.
+
+- Install BepInEx into the game folder
+    - [Download BepInEx 5.4](https://github.com/BepInEx/BepInEx/releases/download/v5.4.23.3/BepInEx_win_x64_5.4.23.3.zip) and extract it into the game folder (right click the game in Steam, `Manage -> Browse local files`).
+    - You should end up with a `BepInEx` folder and `doorstop_config.ini` in the same folder as `rocketstation.exe`.
+    - Run the game once to create the folder structure.
+    - **Linux/Steam Deck only:** If running through Proton/Wine, follow the [additional BepInEx installation steps](https://docs.bepinex.dev/articles/advanced/proton_wine.html).
+        - Since Stationeers is running as a Windows executable through Proton, use the Windows version of BepInEx linked above.
 - Install StationeersLaunchPad
-  - download latest client zip from [Releases](https://github.com/StationeersLaunchPad/StationeersLaunchPad/releases)
-  - extract into `BepInEx/plugins` folder
+    - Download the latest client zip from [Releases](https://github.com/StationeersLaunchPad/StationeersLaunchPad/releases).
+    - Extract it into the `BepInEx/plugins` folder.
 
 ### Switch from StationeersMods
-__StationeersLaunchPad and StationeersMods can't be installed together__. Both mod loaders serve the same purpose and having both installed can cause issues. StationeersLaunchPad was created to replace and upgrade StationeersMods.
 
-- Remove `StationeersMods` folder from `Bepinex/plugins` in game folder
-  - to open game folder: right click game in steam, `Manage->Browse local files`
+**StationeersLaunchPad and StationeersMods can't be installed together.** Both mod loaders serve the same purpose and having both installed can cause issues. StationeersLaunchPad was created to replace and upgrade StationeersMods.
+
+- Remove the `StationeersMods` folder from `BepInEx/plugins` in the game folder.
+    - To open the game folder: right click the game in Steam, `Manage -> Browse local files`.
 - Install StationeersLaunchPad
-  - download latest client zip from [Releases](https://github.com/StationeersLaunchPad/StationeersLaunchPad/releases)
-  - extract into `BepInEx/plugins` folder
+    - Download the latest client zip from [Releases](https://github.com/StationeersLaunchPad/StationeersLaunchPad/releases).
+    - Extract it into the `BepInEx/plugins` folder.
 
 ### Verify Installation
-- If StationeersLaunchPad is installed correctly, you should see the LaunchPad window at the bottom of the loading screen
+
+- If StationeersLaunchPad is installed correctly, you should see the LaunchPad window at the bottom of the loading screen.
+
 <img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/a184a340-d461-4f99-bbe3-8699101fe15e" />
 
 ## Usage
 
-- Install mods into `%HOME%/documents/my games/stationeers/mods` or download them from steam workshop.
-- Start game. Mods will automatically load
-- If you want to reorder or enable/disable mods, click the loading window at the bottom when the game first opens
-  - To resume loading and step through stages, click the highlighted stage upper-left of the loading window
-- Mod will auto be updated unless otherwise chosen in configuration.
+- Install mods into `%HOME%/documents/my games/stationeers/mods` or download them from Steam Workshop.
+- Start the game. Mods will automatically load.
+- If you want to reorder or enable/disable mods, click the loading window at the bottom when the game first opens.
+    - To resume loading and step through stages, click the highlighted stage in the upper-left of the loading window.
+- Mods will auto-update unless otherwise chosen in configuration.
 
 ## Mod Profiles
 
@@ -47,8 +51,8 @@ Mod Profiles are optional saved lists of enabled mods and their load order. A pr
 <details>
 <summary><b>How to create and use a profile</b></summary>
 
-1. Open the LaunchPad menu during startup by clicking the SLP box that appears on the games "Boot Screen" (Splash Screen) and select the **Mod Profiles** tab.
-2. Enable and disable the mods in the list on the left using the checkboxes
+1. Open the LaunchPad menu during startup by clicking the SLP box that appears on the game's "Boot Screen" (Splash Screen) and select the **Mod Profiles** tab.
+2. Enable and disable the mods in the list on the left using the checkboxes.
 3. Enter a name under **Create from the current mod list**, then select **Create Profile**.
 4. Use **Save Changes** after changing the enabled mods or their order. Use **Revert Changes** to restore the saved profile.
 5. Select another profile from the profile picker when needed.
@@ -60,7 +64,7 @@ Select the built-in **Vanilla** profile to launch without any mods, or select **
 <details>
 <summary><b>How to share a profile</b></summary>
 
-Only profiles that exclusively contain mods from the workshop can be shared as compact `SLP1` codes (for now):
+Only profiles that exclusively contain mods from the Workshop can be shared as compact `SLP1` codes (for now):
 
 1. Save the profile, then open **SLP Window > Mod Profiles > Share Profile**.
 2. Select **Copy SLP1 Code** and send the code to another user.
@@ -88,34 +92,109 @@ Loading pauses and lists the missing entries. Workshop items can be resubscribed
 
 **Where are profiles stored?**
 
-Profiles are stored as separate XML files under the LaunchPad save path - usually `Documents\My Games\Stationeers`
+Profiles are stored as separate XML files under the LaunchPad save path - usually `Documents\My Games\Stationeers`.
 
 </details>
 
 ## Dedicated Server
 
-- Install Bepinex into dedicated server folder
-  - [Download BepInEx 5.4](https://github.com/BepInEx/BepInEx/releases/download/v5.4.23.3/BepInEx_win_x64_5.4.23.3.zip) and extract into dedicated server folder (`<steamcmd>/steamapps/common/Stationeers Dedicated Server`)
-  - should end up with `BepInEx` folder and `doorstop_config.ini` file in same folder as `rocketstation_DedicatedServer.exe`
-- Install StationeersLaunchPad
-  - download latest server zip from [Releases](https://github.com/StationeersLaunchPad/StationeersLaunchPad/releases)
-  - extract into `BepInEx/plugins` folder
-- In the game client, click the loading window at the bottom on startup to open configuration
-  - enable/disable and reorder mods to match what you want installed on the server
-  - on the Launchpad Configuration tab, click `Export Mod Package` to create a zip file containing the enabled mods and config file
-  - extract the zip file into the dedicated server folder (should create `modconfig.xml` and `mods` folder in same folder as `rocketstation_DedicatedServer.exe`)
+- Install BepInEx into the dedicated server folder.
+    - [Download BepInEx 5.4](https://github.com/BepInEx/BepInEx/releases/download/v5.4.23.3/BepInEx_win_x64_5.4.23.3.zip) and extract it into the dedicated server folder (`<steamcmd>/steamapps/common/Stationeers Dedicated Server`).
+    - You should end up with a `BepInEx` folder and `doorstop_config.ini` in the same folder as `rocketstation_DedicatedServer.exe`.
+- Install StationeersLaunchPad.
+    - Download the latest server zip from [Releases](https://github.com/StationeersLaunchPad/StationeersLaunchPad/releases).
+    - Extract it into the `BepInEx/plugins` folder.
+- In the game client, click the loading window at the bottom on startup to open configuration.
+    - Enable/disable and reorder mods to match what you want installed on the server.
+    - On the LaunchPad Configuration tab, click **Export Mod Package** to create a zip file containing the enabled mods and config file.
+    - Extract the zip file into the dedicated server folder. It should create `modconfig.xml` and a `mods` folder in the same folder as `rocketstation_DedicatedServer.exe`.
 
 ## Modding
-Information on modding stationeers can be found at:
+
+Information on modding Stationeers can be found at:
+
 - [Stationeers Modding Docs](https://stationeerslaunchpad.github.io/docs/) (work in progress)
-- [Stationeers Discord](https://discord.gg/stationeers) #modding channel
+- [Stationeers Discord](https://discord.gg/stationeers) `#modding` channel
 - [Stationeers Modding Discord](https://discord.gg/5qZbPVTw2U)
 - [LaunchPadBooster library](https://github.com/StationeersLaunchPad/LaunchPadBooster)
 
+### Default entrypoint lifecycle
+
+The existing supported `OnLoaded(...)` parameter signatures are unchanged. An `OnLoaded(...)` method may return either `void` or `bool`.
+
+Returning `bool` allows a mod to report whether initialization succeeded:
+
+```cs
+public bool OnLoaded(List<GameObject> prefabs, ConfigFile config)
+{
+  // Initialize the mod.
+  return true;
+}
+```
+
+Returning `false` tells StationeersLaunchPad that initialization failed and the mod should be cleaned up when it is safe to do so.
+
+Existing mods using `void OnLoaded(...)` remain supported.
+
+### Unloading
+
+A reversible default entrypoint can provide a parameterless `void OnUnloaded()` method:
+
+```cs
+public void OnUnloaded()
+{
+  // Undo Harmony patches, event subscriptions,
+  // registrations, and other changes made by the mod.
+}
+```
+
+`OnUnloaded()` can also be used while cleaning up a partially initialized mod, so implementations should tolerate partial initialization.
+
+Mods may optionally provide a parameterless `bool CanUnload()` method:
+
+```cs
+public bool CanUnload()
+{
+  return true;
+}
+```
+
+`CanUnload()` is checked before a normal/manual unload. Returning `false` prevents the unload at that time. If the method is absent, it defaults to `true`.
+
+StationeersLaunchPad checks all initialized entrypoints before beginning a manual unload so one entrypoint cannot veto after cleanup has already started.
+
+Current unload support is intended for the StationeersLaunchPad startup/loading workflow. Unloading while a world is running is not part of the supported lifecycle.
+
+### Safe Mode
+
+Safe Mode only loads default entrypoints that advertise a reversible lifecycle.
+
+A default entrypoint is Safe Mode compatible when:
+
+- it uses one of the existing supported `OnLoaded(...)` parameter signatures;
+- `OnLoaded(...)` returns `bool`;
+- it provides a parameterless `void OnUnloaded()` method.
+
+`CanUnload()` is optional and controls whether a compatible mod may be unloaded at a particular moment.
+
+Existing mods using `void OnLoaded(...)` remain supported during normal loading, but are not considered Safe Mode compatible.
+
+### Cleanup responsibilities
+
+StationeersLaunchPad cleans resources that it owns, including loaded AssetBundles, entrypoint GameObjects, configuration handlers, and its internal mod/assembly references.
+
+StationeersLaunchPad does not physically unload CLR/Mono assemblies. Static state in a mod assembly can therefore remain alive for the lifetime of the game process.
+
+Mods are responsible for reversing changes they make themselves, such as Harmony patches, event subscriptions, and direct changes to game state.
+
+Resources registered through LaunchPadBooster should be removed through LaunchPadBooster's corresponding removal APIs from `OnUnloaded()`.
+
 ### Linking against StationeersLaunchPad
-Linking against StationeersLaunchPad (using any class in the `StationeersLaunchPad` namespace or nested namespaces) is unsupported. These classes are not a stable API, and will change without notice. The code is MIT licensed so you are free to copy any utilities you want to use into your own mod. LaunchPadBooster also contains utilities with a stable API that can be used by mods. If there is something you need that only StationeersLaunchPad has, reach out on github or discord and it can be added as an injected parameter to the Default Entrypoint.
+
+Linking against StationeersLaunchPad (using any class in the `StationeersLaunchPad` namespace or nested namespaces) is unsupported. These classes are not a stable API, and will change without notice. The code is MIT licensed so you are free to copy any utilities you want to use into your own mod. LaunchPadBooster also contains utilities with a stable API that can be used by mods. If there is something you need that only StationeersLaunchPad has, reach out on GitHub or Discord and it can be added as an injected parameter to the Default Entrypoint.
 
 ## v0.2.25 Update Error
+
 StationeersLaunchPad v0.2.25 contains a bug that prevents the auto-update from functioning.
 
 Please follow the [Manual Update Instructions](https://stationeerslaunchpad.github.io/docs/slp/update_error_0.2.25/) if you are encountering this error.

--- a/StationeersLaunchPad/Configs.cs
+++ b/StationeersLaunchPad/Configs.cs
@@ -46,6 +46,7 @@ public static class Configs
   public static ConfigEntry<int> DedupePriorityWorkshop;
   public static ConfigEntry<LoadStrategyType> LoadStrategyType;
   public static ConfigEntry<LoadStrategyMode> LoadStrategyMode;
+  public static ConfigEntry<bool> SafeMode;
   public static ConfigEntry<bool> DisableSteamOnStart;
   public static ConfigEntry<string> SavePathOnStart;
   public static ConfigEntry<bool> RetainWorkshopMods;
@@ -196,6 +197,13 @@ public static class Configs
         "Parallel mode loads faster for a large number of mods, but may fail in extremely rare cases. Switch to serial mode if running into loading issues."
       )
     );
+    SafeMode = config.Bind(
+      new ConfigDefinition("Mod Loading", "SafeMode"),
+      false,
+      new ConfigDescription(
+        "Only load mods that support safe initialization failure and unloading."
+      )
+    );    
     SavePathOnStart = config.Bind(
       new ConfigDefinition("Mod Loading", "SavePathOverride"),
       "",

--- a/StationeersLaunchPad/Entrypoints/Default.cs
+++ b/StationeersLaunchPad/Entrypoints/Default.cs
@@ -93,6 +93,8 @@ public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
       null,
       System.Type.EmptyTypes,
       null);
+    if (unloadMethod != null && unloadMethod.ReturnType != typeof(void))
+      unloadMethod = null;
     
     return new (mod, type, loadMethod, unloadMethod, eparams);
   }

--- a/StationeersLaunchPad/Entrypoints/Default.cs
+++ b/StationeersLaunchPad/Entrypoints/Default.cs
@@ -14,20 +14,24 @@ namespace StationeersLaunchPad.Entrypoints;
 public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
 {
   private const string DEFAULT_METHOD_NAME = "OnLoaded";
+  private const string CAN_UNLOAD_METHOD_NAME = "CanUnload";
   private const string UNLOAD_METHOD_NAME = "OnUnloaded";
 
   public readonly LoadedMod Mod;
   public readonly MethodInfo LoadMethod;
+  public readonly MethodInfo CanUnloadMethod;
   public readonly MethodInfo UnloadMethod;
   public readonly List<EntrypointParam> Params;
 
   private DefaultEntrypoint(
     LoadedMod mod, Type type,
-    MethodInfo loadMethod, MethodInfo unloadMethod, List<EntrypointParam> eparams) : base(type)
+    MethodInfo loadMethod, MethodInfo unloadMethod,  MethodInfo canUnloadMethod,
+    List<EntrypointParam> eparams) : base(type)
   {
     Mod = mod;
     LoadMethod = loadMethod;
     UnloadMethod = unloadMethod;
+    CanUnloadMethod = canUnloadMethod;
     Params = eparams;
   }
 
@@ -61,6 +65,14 @@ public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
     return true;
   }
 
+  public override bool CanUnload()
+  {
+    if (CanUnloadMethod == null)
+      return true;
+
+    return (bool)CanUnloadMethod.Invoke(Instance, null);
+  }
+  
   public override void Unload()
   {
     UnloadMethod?.Invoke(Instance, null);
@@ -98,7 +110,18 @@ public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
     if (unloadMethod != null && unloadMethod.ReturnType != typeof(void))
       unloadMethod = null;
     
-    return new (mod, type, loadMethod, unloadMethod, eparams);
+    var canUnloadMethod = type.GetMethod(
+      CAN_UNLOAD_METHOD_NAME,
+      BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+      null,
+      System.Type.EmptyTypes,
+      null);
+
+    if (canUnloadMethod != null &&
+        canUnloadMethod.ReturnType != typeof(bool))
+      canUnloadMethod = null;
+    
+    return new (mod, type, loadMethod, unloadMethod, canUnloadMethod, eparams);
   }
 
   private static readonly ParamPatternMatch<EntrypointParam> Parser =

--- a/StationeersLaunchPad/Entrypoints/Default.cs
+++ b/StationeersLaunchPad/Entrypoints/Default.cs
@@ -31,6 +31,8 @@ public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
     Params = eparams;
   }
 
+  public override bool SafeModeCompatible => LoadMethod.ReturnType == typeof(bool) && UnloadMethod != null;
+  
   public override string DebugName() => $"Default Entry {Type.FullName}";
 
   public override void Instantiate(GameObject parent) =>

--- a/StationeersLaunchPad/Entrypoints/Default.cs
+++ b/StationeersLaunchPad/Entrypoints/Default.cs
@@ -14,17 +14,20 @@ namespace StationeersLaunchPad.Entrypoints;
 public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
 {
   private const string DEFAULT_METHOD_NAME = "OnLoaded";
+  private const string UNLOAD_METHOD_NAME = "OnUnloaded";
 
   public readonly LoadedMod Mod;
   public readonly MethodInfo LoadMethod;
+  public readonly MethodInfo UnloadMethod;
   public readonly List<EntrypointParam> Params;
 
   private DefaultEntrypoint(
     LoadedMod mod, Type type,
-    MethodInfo loadMethod, List<EntrypointParam> eparams) : base(type)
+    MethodInfo loadMethod, MethodInfo unloadMethod, List<EntrypointParam> eparams) : base(type)
   {
     Mod = mod;
     LoadMethod = loadMethod;
+    UnloadMethod = unloadMethod;
     Params = eparams;
   }
 
@@ -41,6 +44,11 @@ public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
     LoadMethod.Invoke(Instance, eparams);
   }
 
+  public override void Unload()
+  {
+    UnloadMethod?.Invoke(Instance, null);
+  }
+  
   public override IEnumerable<ConfigFile> Configs()
   {
     foreach (var p in Params)
@@ -60,7 +68,15 @@ public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
     var eparams = Parser.Parse(mparams);
     if (eparams == null)
       return null;
-    return new(mod, type, loadMethod, eparams);
+    
+    var unloadMethod = type.GetMethod(
+      UNLOAD_METHOD_NAME,
+      BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+      null,
+      System.Type.EmptyTypes,
+      null);
+    
+    return new (mod, type, loadMethod, unloadMethod, eparams);
   }
 
   private static readonly ParamPatternMatch<EntrypointParam> Parser =

--- a/StationeersLaunchPad/Entrypoints/Default.cs
+++ b/StationeersLaunchPad/Entrypoints/Default.cs
@@ -77,6 +77,9 @@ public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
   {
     if (loadMethod.Name != DEFAULT_METHOD_NAME)
       return null;
+    if (loadMethod.ReturnType != typeof(void) &&
+        loadMethod.ReturnType != typeof(bool))
+      return null;    
     var mparams = loadMethod.GetParameters();
     if (mparams.Length == 0)
       return null;

--- a/StationeersLaunchPad/Entrypoints/Default.cs
+++ b/StationeersLaunchPad/Entrypoints/Default.cs
@@ -43,6 +43,21 @@ public class DefaultEntrypoint : BehaviourEntrypoint<MonoBehaviour>
       eparams[i] = Params[i].GetParam(this);
     LoadMethod.Invoke(Instance, eparams);
   }
+  
+  public override bool TryInitialize(LoadedMod mod)
+  {
+    var eparams = new object[Params.Count];
+
+    for (var i = 0; i < eparams.Length; i++)
+      eparams[i] = Params[i].GetParam(this);
+
+    var result = LoadMethod.Invoke(Instance, eparams);
+
+    if (LoadMethod.ReturnType == typeof(bool))
+      return (bool)result;
+
+    return true;
+  }
 
   public override void Unload()
   {

--- a/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
+++ b/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
@@ -65,10 +65,19 @@ public partial class EntrypointSearch
 
     var allEntries = new List<ModEntrypoint>();
 
-    allEntries.AddRange(FindStationeersModsEntrypoints());
-    allEntries.AddRange(FindPrefabEntrypoints());
-    allEntries.AddRange(FindBepInExEntrypoints());
-    allEntries.AddRange(FindDefaultEntrypoints());
+    if (Configs.SafeMode.Value)
+    {
+      allEntries.AddRange(
+        FindDefaultEntrypoints().Where(entry => entry.SafeModeCompatible)
+      );
+    }
+    else
+    {
+      allEntries.AddRange(FindStationeersModsEntrypoints());
+      allEntries.AddRange(FindPrefabEntrypoints());
+      allEntries.AddRange(FindBepInExEntrypoints());
+      allEntries.AddRange(FindDefaultEntrypoints());
+    }
 
     return allEntries;
   }

--- a/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
+++ b/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
@@ -16,6 +16,9 @@ public abstract class ModEntrypoint
   public abstract void Instantiate(GameObject parent);
   public abstract void Initialize(LoadedMod mod);
   public abstract IEnumerable<ConfigFile> Configs();
+  public virtual void Unload()
+  {
+  }
 }
 
 public abstract class BehaviourEntrypoint<T>(Type type) : ModEntrypoint where T : MonoBehaviour

--- a/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
+++ b/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
@@ -19,6 +19,11 @@ public abstract class ModEntrypoint
   public virtual void Unload()
   {
   }
+  public virtual bool TryInitialize(LoadedMod mod)
+  {
+    Initialize(mod);
+    return true;
+  }
 }
 
 public abstract class BehaviourEntrypoint<T>(Type type) : ModEntrypoint where T : MonoBehaviour

--- a/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
+++ b/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
@@ -24,6 +24,7 @@ public abstract class ModEntrypoint
     Initialize(mod);
     return true;
   }
+  public virtual bool SafeModeCompatible => false;
 }
 
 public abstract class BehaviourEntrypoint<T>(Type type) : ModEntrypoint where T : MonoBehaviour

--- a/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
+++ b/StationeersLaunchPad/Entrypoints/ModEntrypoint.cs
@@ -16,6 +16,7 @@ public abstract class ModEntrypoint
   public abstract void Instantiate(GameObject parent);
   public abstract void Initialize(LoadedMod mod);
   public abstract IEnumerable<ConfigFile> Configs();
+  public virtual bool CanUnload() => true;
   public virtual void Unload()
   {
   }

--- a/StationeersLaunchPad/LaunchPadInfo.cs
+++ b/StationeersLaunchPad/LaunchPadInfo.cs
@@ -4,5 +4,5 @@ public class LaunchPadInfo
 {
   public const string NAME = "StationeersLaunchPad";
   public const string GUID = "stationeers.launchpad";
-  public const string VERSION = "0.5.0";
+  public const string VERSION = "0.5.1";
 }

--- a/StationeersLaunchPad/Loading/LoadStrategy.cs
+++ b/StationeersLaunchPad/Loading/LoadStrategy.cs
@@ -55,6 +55,41 @@ public abstract class LoadStrategy
     return !failed;
   }
 
+#if DEBUG
+  // To test round-trip of unloading/loading
+  public async UniTask<bool> LoadMod(LoadedMod mod)
+  {
+    try
+    {
+      if (!mod.LoadedAssemblies)
+      {
+        await mod.LoadAssembliesSerial();
+        mod.LoadedAssemblies = true;
+      }
+
+      if (!mod.LoadedAssets)
+      {
+        await mod.LoadAssetsSerial();
+        mod.LoadedAssets = true;
+      }
+
+      if (!mod.LoadedEntryPoints)
+      {
+        await mod.FindEntrypoints();
+        mod.PrintEntrypoints();
+        mod.LoadEntrypoints();
+        mod.LoadedEntryPoints = true;
+      }
+
+      return true;
+    }
+    catch (Exception ex)
+    {
+      LoadFailed(mod, ex);
+      return false;
+    }
+  }
+#endif
   public void LoadFailed(LoadedMod mod, Exception ex)
   {
     mod.Logger.LogException(ex);
@@ -197,4 +232,5 @@ public class LoadStrategyLinearParallel : LoadStrategy
       }
     }));
   }
+
 }

--- a/StationeersLaunchPad/Loading/LoadStrategy.cs
+++ b/StationeersLaunchPad/Loading/LoadStrategy.cs
@@ -58,7 +58,8 @@ public abstract class LoadStrategy
   public void LoadFailed(LoadedMod mod, Exception ex)
   {
     mod.Logger.LogException(ex);
-    mod.Unload();
+    if (mod.CanSafelyUnload)
+      mod.Unload();
     
     mod.LoadFailed = true;
     mod.LoadFinished = false;

--- a/StationeersLaunchPad/Loading/LoadStrategy.cs
+++ b/StationeersLaunchPad/Loading/LoadStrategy.cs
@@ -58,6 +58,8 @@ public abstract class LoadStrategy
   public void LoadFailed(LoadedMod mod, Exception ex)
   {
     mod.Logger.LogException(ex);
+    mod.Unload();
+    
     mod.LoadFailed = true;
     mod.LoadFinished = false;
 

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -208,6 +208,10 @@ public class LoadedMod
     foreach (var config in ConfigFiles)
       config.SettingChanged -= OnConfigSettingChanged;
     ConfigFiles.Clear();
+    
+    LoadedAssets = false;
+    LoadedEntryPoints = false;
+    LoadFinished = false;
   }
   
   private UniTask<ExportSettings> LoadAssetBundleExportSettings(string path, AssetBundle bundle)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -173,7 +173,8 @@ public class LoadedMod
 
   public void Unload()
   {
-    foreach (var entrypoint in _initializedEntrypoints)
+    for (var i = _initializedEntrypoints.Count - 1; i >= 0; i--)
+    {
       try
       {
         entrypoint.Unload(this);
@@ -182,7 +183,10 @@ public class LoadedMod
       {
         Logger.LogException(ex);
       }
-    
+    }
+
+    _initializedEntrypoints.Clear();
+
     if (_entryGameObject != null)
     {
       Object.Destroy(_entryGameObject);

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -164,7 +164,14 @@ public class LoadedMod
   public void Unload()
   {
     foreach (var entrypoint in Entrypoints)
-      entrypoint.Unload(this);
+      try
+      {
+        entrypoint.Unload(this);
+      }
+      catch (Exception ex)
+      {
+        Logger.LogException(ex);
+      }
     
     if (_entryGameObject != null)
     {

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -196,6 +196,9 @@ public class LoadedMod
     foreach (var assetBundle in AssetBundles)
       assetBundle?.Unload(false);
     AssetBundles.Clear();
+    Prefabs.Clear();
+    Exports.Clear();
+    Entrypoints.Clear();
   }
   
   private UniTask<ExportSettings> LoadAssetBundleExportSettings(string path, AssetBundle bundle)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -171,6 +171,10 @@ public class LoadedMod
       Object.Destroy(_entryGameObject);
       _entryGameObject = null;
     }
+    
+    foreach (var assetBundle in AssetBundles)
+      assetBundle?.Unload(false);
+    AssetBundles.Clear();
   }
   
   private UniTask<ExportSettings> LoadAssetBundleExportSettings(string path, AssetBundle bundle)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using BepInEx.Configuration;
 using Cysharp.Threading.Tasks;
@@ -38,6 +39,10 @@ public class LoadedMod
   public bool LoadFinished;
   public bool LoadFailed;
 
+  public bool CanSafelyUnload =>
+    _initializedEntrypoints.Count == 0 ||
+    _initializedEntrypoints.All(entrypoint => entrypoint.SafeModeCompatible);
+  
   public LoadedMod(ModInfo info)
   {
     Logger = Logger.Global.CreateChild(info.Name);

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -204,6 +204,10 @@ public class LoadedMod
     Prefabs.Clear();
     Exports.Clear();
     Entrypoints.Clear();
+    
+    foreach (var config in ConfigFiles)
+      config.SettingChanged -= OnConfigSettingChanged;
+    ConfigFiles.Clear();
   }
   
   private UniTask<ExportSettings> LoadAssetBundleExportSettings(string path, AssetBundle bundle)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -179,6 +179,35 @@ public class LoadedMod
     DirtyConfig();
   }
   
+  public bool TryUnload()
+  {
+    if (!CanSafelyUnload)
+      return false;
+
+    foreach (var entrypoint in _initializedEntrypoints)
+    {
+      try
+      {
+        if (!entrypoint.CanUnload())
+        {
+          Logger.LogWarning(
+            $"Entrypoint {entrypoint.DebugName()} refused unload"
+          );
+
+          return false;
+        }
+      }
+      catch (Exception ex)
+      {
+        Logger.LogException(ex);
+        return false;
+      }
+    }
+
+    Unload();
+    return true;
+  }
+  
   public void Unload()
   {
     for (var i = _initializedEntrypoints.Count - 1; i >= 0; i--)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -208,22 +208,6 @@ public class LoadedMod
     return true;
   }
   
-  private void RemoveLaunchPadBoosterRegistrations()
-  {
-    var modType = Type.GetType("LaunchPadBooster.Mod, LaunchPadBooster");
-    var removeOwnedBy = modType?.GetMethod(
-      "RemoveOwnedBy",
-      BindingFlags.Public | BindingFlags.Static
-    );
-
-    if (removeOwnedBy == null)
-      return;
-
-    foreach (var assembly in Assemblies)
-      removeOwnedBy.Invoke(null, [assembly]);
-  }
-  
-  
   public void Unload()
   {
     for (var i = _initializedEntrypoints.Count - 1; i >= 0; i--)
@@ -239,15 +223,6 @@ public class LoadedMod
     }
 
     _initializedEntrypoints.Clear();
-    
-    try
-    {
-      RemoveLaunchPadBoosterRegistrations();
-    }
-    catch (Exception ex)
-    {
-      Logger.LogException(ex);
-    }    
 
     if (_entryGameObject != null)
     {

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -165,6 +165,12 @@ public class LoadedMod
   {
     foreach (var entrypoint in Entrypoints)
       entrypoint.Unload(this);
+    
+    if (_entryGameObject != null)
+    {
+      Object.Destroy(_entryGameObject);
+      _entryGameObject = null;
+    }
   }
   
   private UniTask<ExportSettings> LoadAssetBundleExportSettings(string path, AssetBundle bundle)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -161,6 +161,12 @@ public class LoadedMod
     return assets;
   }
 
+  public void Unload()
+  {
+    foreach (var entrypoint in Entrypoints)
+      entrypoint.Unload(this);
+  }
+  
   private UniTask<ExportSettings> LoadAssetBundleExportSettings(string path, AssetBundle bundle)
   {
     var name = Path.GetFileName(path);

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -208,6 +208,22 @@ public class LoadedMod
     return true;
   }
   
+  private void RemoveLaunchPadBoosterRegistrations()
+  {
+    var modType = Type.GetType("LaunchPadBooster.Mod, LaunchPadBooster");
+    var removeOwnedBy = modType?.GetMethod(
+      "RemoveOwnedBy",
+      BindingFlags.Public | BindingFlags.Static
+    );
+
+    if (removeOwnedBy == null)
+      return;
+
+    foreach (var assembly in Assemblies)
+      removeOwnedBy.Invoke(null, [assembly]);
+  }
+  
+  
   public void Unload()
   {
     for (var i = _initializedEntrypoints.Count - 1; i >= 0; i--)
@@ -223,6 +239,15 @@ public class LoadedMod
     }
 
     _initializedEntrypoints.Clear();
+    
+    try
+    {
+      RemoveLaunchPadBoosterRegistrations();
+    }
+    catch (Exception ex)
+    {
+      Logger.LogException(ex);
+    }    
 
     if (_entryGameObject != null)
     {

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -125,7 +125,8 @@ public class LoadedMod
 
     // instantiate all entrypoints
     foreach (var entrypoint in Entrypoints)
-      entrypoint.Instantiate(_entryGameObject );
+      if (!entrypoint.TryInitialize(this))
+        throw new Exception($"Entrypoint {entrypoint.DebugName()} failed to initialize");
 
     // initialize all entrypoints
     foreach (var entrypoint in Entrypoints)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -199,8 +199,18 @@ public class LoadedMod
     }
     
     foreach (var assetBundle in AssetBundles)
-      assetBundle?.Unload(false);
+    {
+      try
+      {
+        assetBundle?.Unload(false);
+      }
+      catch (Exception ex)
+      {
+        Logger.LogException(ex);
+      }
+    }
     AssetBundles.Clear();
+    
     Prefabs.Clear();
     Exports.Clear();
     Entrypoints.Clear();

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -21,6 +21,7 @@ public class LoadedMod
   public Logger Logger;
 
   public List<Assembly> Assemblies = [];
+  public List<AssetBundle> AssetBundles = [];
   public List<GameObject> Prefabs = [];
   public List<ExportSettings> Exports = [];
   public ContentHandler ContentHandler;
@@ -69,6 +70,9 @@ public class LoadedMod
   private async UniTask LoadAssetsSingle(string path)
   {
     var bundle = await LoadAssetBundle(path);
+    lock (_lock)
+      AssetBundles.Add(bundle);
+    
     var prefabs = await LoadAssetBundleGameObjects(path, bundle);
     lock (_lock)
       Prefabs.AddRange(prefabs);

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -251,6 +251,7 @@ public class LoadedMod
       config.SettingChanged -= OnConfigSettingChanged;
     ConfigFiles.Clear();
     
+    LoadedAssemblies = false; // Need to mark the assembly as unloaded in any case.
     LoadedAssets = false;
     LoadedEntryPoints = false;
     LoadFinished = false;

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -104,7 +104,10 @@ public class LoadedMod
       Logger.LogDebug("Finding Entrypoints");
 
       Entrypoints.AddRange(EntrypointSearch.FindEntrypoints(this, Assemblies, Exports));
-
+      
+      if (Configs.SafeMode.Value && Entrypoints.Count == 0)
+        throw new Exception("No Safe Mode compatible entrypoints found");
+      
       Logger.LogInfo($"Found {Entrypoints.Count} Entrypoints");
     });
   }

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -124,23 +124,14 @@ public class LoadedMod
     _entryGameObject  = new GameObject { name = Info.Name };
     Object.DontDestroyOnLoad(gameObj);
 
-    // guarded initialization of entrypoints, Unload if fails
-    try
+    foreach (var entrypoint in Entrypoints)
     {
-      foreach (var entrypoint in Entrypoints)
-      {
-        _initializedEntrypoints.Add(entrypoint);
+      _initializedEntrypoints.Add(entrypoint);
 
-        if (!entrypoint.TryInitialize(this))
-          throw new Exception($"Entrypoint {entrypoint.DebugName()} failed to initialize");
+      if (!entrypoint.TryInitialize(this))
+        throw new Exception($"Entrypoint {entrypoint.DebugName()} failed to initialize");
 
-        ConfigFiles.AddRange(entrypoint.Configs());
-      }
-    }
-    catch
-    {
-      Unload();
-      throw;
+      ConfigFiles.AddRange(entrypoint.Configs());
     }
 
     foreach (var config in ConfigFiles)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -218,6 +218,11 @@ public class LoadedMod
     LoadedAssets = false;
     LoadedEntryPoints = false;
     LoadFinished = false;
+    
+    foreach (var assembly in Assemblies)
+      ModLoader.UnregisterAssembly(assembly);
+
+    Assemblies.Clear();
   }
   
   private UniTask<ExportSettings> LoadAssetBundleExportSettings(string path, AssetBundle bundle)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -144,7 +144,7 @@ public class LoadedMod
     }
 
     foreach (var config in ConfigFiles)
-      config.SettingChanged += (_, _) => DirtyConfig();
+      config.SettingChanged += OnConfigSettingChanged;
 
     ConfigFiles.Sort((a, b) => a.ConfigFilePath.CompareTo(b.ConfigFilePath));
 
@@ -171,6 +171,11 @@ public class LoadedMod
     return assets;
   }
 
+  private void OnConfigSettingChanged(object sender, SettingChangedEventArgs e)
+  {
+    DirtyConfig();
+  }
+  
   public void Unload()
   {
     for (var i = _initializedEntrypoints.Count - 1; i >= 0; i--)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -124,15 +124,23 @@ public class LoadedMod
     _entryGameObject  = new GameObject { name = Info.Name };
     Object.DontDestroyOnLoad(gameObj);
 
-    // initialize all entrypoints
-    foreach (var entrypoint in Entrypoints)
+    // guarded initialization of entrypoints, Unload if fails
+    try
     {
-      _initializedEntrypoints.Add(entrypoint);
+      foreach (var entrypoint in Entrypoints)
+      {
+        _initializedEntrypoints.Add(entrypoint);
 
-      if (!entrypoint.TryInitialize(this))
-        throw new Exception($"Entrypoint {entrypoint.DebugName()} failed to initialize");
+        if (!entrypoint.TryInitialize(this))
+          throw new Exception($"Entrypoint {entrypoint.DebugName()} failed to initialize");
 
-      ConfigFiles.AddRange(entrypoint.Configs());
+        ConfigFiles.AddRange(entrypoint.Configs());
+      }
+    }
+    catch
+    {
+      Unload();
+      throw;
     }
 
     foreach (var config in ConfigFiles)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -28,6 +28,7 @@ public class LoadedMod
   public ContentHandler ContentHandler;
 
   public List<ModEntrypoint> Entrypoints = [];
+  private readonly List<ModEntrypoint> _initializedEntrypoints = [];
   private GameObject _entryGameObject;
 
   public List<ConfigFile> ConfigFiles = [];
@@ -123,15 +124,14 @@ public class LoadedMod
     _entryGameObject  = new GameObject { name = Info.Name };
     Object.DontDestroyOnLoad(gameObj);
 
-    // instantiate all entrypoints
-    foreach (var entrypoint in Entrypoints)
-      if (!entrypoint.TryInitialize(this))
-        throw new Exception($"Entrypoint {entrypoint.DebugName()} failed to initialize");
-
     // initialize all entrypoints
     foreach (var entrypoint in Entrypoints)
     {
-      entrypoint.Initialize(this);
+      _initializedEntrypoints.Add(entrypoint);
+
+      if (!entrypoint.TryInitialize(this))
+        throw new Exception($"Entrypoint {entrypoint.DebugName()} failed to initialize");
+
       ConfigFiles.AddRange(entrypoint.Configs());
     }
 
@@ -165,7 +165,7 @@ public class LoadedMod
 
   public void Unload()
   {
-    foreach (var entrypoint in Entrypoints)
+    foreach (var entrypoint in _initializedEntrypoints)
       try
       {
         entrypoint.Unload(this);

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -27,6 +27,7 @@ public class LoadedMod
   public ContentHandler ContentHandler;
 
   public List<ModEntrypoint> Entrypoints = [];
+  private GameObject _entrypointRoot;
 
   public List<ConfigFile> ConfigFiles = [];
 
@@ -118,12 +119,12 @@ public class LoadedMod
   {
     Logger.LogDebug("Loading Entrypoints");
 
-    var gameObj = new GameObject { name = Info.Name };
+    _entrypointRoot  = new GameObject { name = Info.Name };
     Object.DontDestroyOnLoad(gameObj);
 
     // instantiate all entrypoints
     foreach (var entrypoint in Entrypoints)
-      entrypoint.Instantiate(gameObj);
+      entrypoint.Instantiate(_entrypointRoot );
 
     // initialize all entrypoints
     foreach (var entrypoint in Entrypoints)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using BepInEx.Configuration;
 using Cysharp.Threading.Tasks;
@@ -125,7 +124,7 @@ public class LoadedMod
     Logger.LogDebug("Loading Entrypoints");
 
     _entryGameObject  = new GameObject { name = Info.Name };
-    Object.DontDestroyOnLoad(_entryGameObject);
+    UnityEngine.Object.DontDestroyOnLoad(_entryGameObject);
     
     // Instantiate entry points
     foreach (var entrypoint in Entrypoints)
@@ -193,7 +192,7 @@ public class LoadedMod
 
     if (_entryGameObject != null)
     {
-      Object.Destroy(_entryGameObject);
+      UnityEngine.Object.Destroy(_entryGameObject);
       _entryGameObject = null;
     }
     

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -123,7 +123,12 @@ public class LoadedMod
 
     _entryGameObject  = new GameObject { name = Info.Name };
     Object.DontDestroyOnLoad(_entryGameObject);
+    
+    // Instantiate entry points
+    foreach (var entrypoint in Entrypoints)
+      entrypoint.Instantiate(_entryGameObject);
 
+    // Try initializing the entry points
     foreach (var entrypoint in Entrypoints)
     {
       _initializedEntrypoints.Add(entrypoint);
@@ -173,7 +178,7 @@ public class LoadedMod
     {
       try
       {
-        _initializedEntrypoints[i].Unload(this);
+        _initializedEntrypoints[i].Unload();
       }
       catch (Exception ex)
       {

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -27,7 +27,7 @@ public class LoadedMod
   public ContentHandler ContentHandler;
 
   public List<ModEntrypoint> Entrypoints = [];
-  private GameObject _entrypointRoot;
+  private GameObject _entryGameObject;
 
   public List<ConfigFile> ConfigFiles = [];
 
@@ -119,12 +119,12 @@ public class LoadedMod
   {
     Logger.LogDebug("Loading Entrypoints");
 
-    _entrypointRoot  = new GameObject { name = Info.Name };
+    _entryGameObject  = new GameObject { name = Info.Name };
     Object.DontDestroyOnLoad(gameObj);
 
     // instantiate all entrypoints
     foreach (var entrypoint in Entrypoints)
-      entrypoint.Instantiate(_entrypointRoot );
+      entrypoint.Instantiate(_entryGameObject );
 
     // initialize all entrypoints
     foreach (var entrypoint in Entrypoints)

--- a/StationeersLaunchPad/Loading/LoadedMod.cs
+++ b/StationeersLaunchPad/Loading/LoadedMod.cs
@@ -122,7 +122,7 @@ public class LoadedMod
     Logger.LogDebug("Loading Entrypoints");
 
     _entryGameObject  = new GameObject { name = Info.Name };
-    Object.DontDestroyOnLoad(gameObj);
+    Object.DontDestroyOnLoad(_entryGameObject);
 
     foreach (var entrypoint in Entrypoints)
     {
@@ -173,7 +173,7 @@ public class LoadedMod
     {
       try
       {
-        entrypoint.Unload(this);
+        _initializedEntrypoints[i].Unload(this);
       }
       catch (Exception ex)
       {

--- a/StationeersLaunchPad/Loading/ModLoader.cs
+++ b/StationeersLaunchPad/Loading/ModLoader.cs
@@ -22,6 +22,12 @@ public static class ModLoader
       AssemblyToMod[assembly] = mod;
     }
   }
+  
+  public static void UnregisterAssembly(Assembly assembly)
+  {
+    lock (AssembliesLock)
+      AssemblyToMod.Remove(assembly);
+  }
 
   public static bool TryGetExecutingMod(out LoadedMod mod)
   {

--- a/StationeersLaunchPad/README.md
+++ b/StationeersLaunchPad/README.md
@@ -1,89 +1,231 @@
-# StationeersLaunchPad
+<p align="center"><img src="docs/SLP_logo.png" /></p>
 
-## How it works
+StationeersLaunchPad
 
-`LaunchPadPlugin` Bepinex plugin patches the `SplashBehaviour` so it doesn't start loading the game immediately, then calls `LaunchPadConfig.Run`. The patch to `SplashBehavour.Draw` draws a mod loading window (`LaunchPadGUI`) instead of the normal progress bar.
+A Stationeers mod loader that allows you to edit mod configuration at game startup. This is compatible with BepInEx and StationeersMods mods installed locally in the home folder or downloaded from Steam Workshop.
 
-`LaunchPadConfig` loads the list of local and workshop mods, then the `modconfig.xml` file and sets up a tentantive runtime mod configuration. If the user doesn't click the loading window in a fixed time after startup (currently 3 seconds), it will automatically start loading the mod assemblies and resources, and then the game (handled in `LaunchPadConfig.Run`). 
+Visit the StationeersLaunchPad docs for more info on StationeersLaunchPad and modding Stationeers.
 
-If the user clicks the loading window (`LaunchPadGUI.DrawAutoLoad`), it opens a larger configuration editor allowing changes to enabled mods and order before load (`LaunchPadGUI.DrawManualLoad`).
+Installation
 
-The loading is currently done one mod at a time (`LoadStrategyLinearSerial` and `LoadStrategyLinearParallel` in `ModLoader.cs`)
+Fresh
 
-## Code Organization
+Install BepInEx into the game folder
 
-### [AssemblyInfo.cs](AssemblyInfo.cs)
-Simple structure holding assembly name and the names of other assemblies it directly references. Part of a prototype of adding implicit dependencies based on assembly references. Currently this information is loaded but unused.
+Download BepInEx 5.4 and extract it into the game folder (right click the game in Steam, Manage -> Browse local files).
 
-### [Github.cs](Github.cs)
-Utility class for fetching and downloading github assets/releases.
+You should end up with a BepInEx folder and doorstop_config.ini in the same folder as rocketstation.exe.
 
-### [ImGuiHelper.cs](ImGuiHelper.cs)
-Utility class with functions to help with common ImGui functionality.
+Run the game once to create the folder structure.
 
-### [LaunchPadAlertGUI.cs](LaunchPadAlertGUI.cs)
-ImGui mod alert window.
+Linux/Steam Deck only: If running through Proton/Wine, follow the additional BepInEx installation steps.
 
-### [LaunchPadGUI.cs](LaunchPadGUI.cs)
-ImGui mod configuration window.
+Since Stationeers is running as a Windows executable through Proton, use the Windows version of BepInEx linked above.
 
-### [LaunchPadConfig.cs](LaunchPadConfig.cs)
-Main workflow logic of loading mod configuration and mods.
+Install StationeersLaunchPad
 
-### [LaunchPadConfigGUI.cs](LaunchPadConfigGUI.cs)
-ImGui rendering class for configuration info.
+Download the latest client zip from Releases.
 
-### [LaunchPadConsoleGUI.cs](LaunchPadConsoleGUI.cs)
-ImGui rendering class for the console info.
+Extract it into the BepInEx/plugins folder.
 
-### [LaunchPadInfo.cs](LaunchPadInfo.cs)
-Info class for plugin name, guid, and version.
+Switch from StationeersMods
 
-### [LaunchPadLoaderGUI.cs](LaunchPadLoaderGUI.cs)
-ImGui rendering class for loading info.
+StationeersLaunchPad and StationeersMods can't be installed together. Both mod loaders serve the same purpose and having both installed can cause issues. StationeersLaunchPad was created to replace and upgrade StationeersMods.
 
-### [LaunchPadPatches.cs](LaunchPadPatches.cs)
-Harmony patch class.
+Remove the StationeersMods folder from BepInEx/plugins in the game folder.
 
-### [LaunchPadPaths.cs](LaunchPadPaths.cs)
-Commonly used paths for easy access.
+To open the game folder: right click the game in Steam, Manage -> Browse local files.
 
-### [LaunchPadPlugin.cs](LaunchPadPlugin.cs)
-Bepinex plugin entrypoint to the mod loader.
+Install StationeersLaunchPad
 
-### [LaunchPadUpdater.cs](LaunchPadUpdater.cs)
-Main class for handling automatic plugin updating.
+Download the latest client zip from Releases.
 
-### [LoadedMod.cs](LoadedMod.cs)
-Contains the implementations of loading in mod files, and information about load status.
+Extract it into the BepInEx/plugins folder.
 
-### [LoadStrategy.cs](LoadStrategy.cs)
-Contains all implementation types for loading assemblies, resloving types, loading assets, and loading entry points.
+Verify Installation
 
-### [LogBuffer.cs](LogBuffer.cs)
-Class for holding log lines.
+If StationeersLaunchPad is installed correctly, you should see the LaunchPad window at the bottom of the loading screen.
 
-### [LogLine.cs](LogLine.cs)
-Class for holding a log line info.
+<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/a184a340-d461-4f99-bbe3-8699101fe15e" />
 
-### [Logger.cs](Logger.cs)
-A logger that can be scoped to a specific mod, as well as a log handler that associates log messages with a specific mod. This works, but the scoped logs can only be viewed during startup for now.
+Usage
 
-### [LogWrapper.cs](LogWrapper.cs)
-Log wrapper that wraps Unity errors into the custom logger format.
+Install mods into %HOME%/documents/my games/stationeers/mods or download them from Steam Workshop.
 
-### [ModEntrypoint.cs](ModEntrypoint.cs)
-Contains mod entrypoint info classes for different types of mod entrypoints.
+Start the game. Mods will automatically load.
 
-### [ModInfo.cs](ModInfo.cs)
-Information about an installed mod (name, folder, about.xml).
+If you want to reorder or enable/disable mods, click the loading window at the bottom when the game first opens.
 
-### [ModLoader.cs](ModLoader.cs)
-Contains the workflow for loading enabled mods into the game, currently just a simple linear load.
-Also contains the logic for finding Bepinex and StationeersMods entry points in the mod files.
+To resume loading and step through stages, click the highlighted stage in the upper-left of the loading window.
 
-### [TextFormatting.cs](TextFormatting.cs)
-Logic for converting Steam description tags to TextMeshPro tags.
+Mods will auto-update unless otherwise chosen in configuration.
 
-### [UpdateSequence.cs](UpdateSequence.cs)
-Contains the logic for updating the plugin, as well as backing up and/or reverting updates.
+Mod Profiles
+
+Mod Profiles are optional saved lists of enabled mods and their load order. A profile can include Local, Workshop, and Repo mods, and the selected profile is applied automatically on startup.
+
+<details>
+<summary><b>How to create and use a profile</b></summary>
+
+Open the LaunchPad menu during startup by clicking the SLP box that appears on the game's "Boot Screen" (Splash Screen) and select the Mod Profiles tab.
+
+Enable and disable the mods in the list on the left using the checkboxes.
+
+Enter a name under Create from the current mod list, then select Create Profile.
+
+Use Save Changes after changing the enabled mods or their order. Use Revert Changes to restore the saved profile.
+
+Select another profile from the profile picker when needed.
+
+Select the built-in Vanilla profile to launch without any mods, or select Disable Profiles to return to the normal, classic workflow.
+
+</details>
+
+<details>
+<summary><b>How to share a profile</b></summary>
+
+Only profiles that exclusively contain mods from the Workshop can be shared as compact SLP1 codes (for now):
+
+Save the profile, then open SLP Window > Mod Profiles > Share Profile.
+
+Select Copy SLP1 Code and send the code to another user.
+
+To import one, paste it into the same tab and select Load SLP1 Code.
+
+SLP downloads missing Workshop items and applies the shared load order. Enter a name to save the imported list as a profile.
+
+SLP1 codes contain only Workshop IDs, load order, and an integrity checksum. They do not contain mod files, local or Repo mods, or mod configuration data.
+
+</details>
+
+<details>
+<summary><b>Profile FAQ</b></summary>
+
+Do I have to use profiles?
+
+No. Profiles are opt-in, and disabling them leaves the current mod list unchanged.
+
+What do "Unsaved changes" and "Revert Changes" mean?
+
+The mod list on the left is the working copy. Save Changes updates the selected profile; Revert Changes restores its saved enabled mods and order.
+
+What happens when a profile is missing mods?
+
+Loading pauses and lists the missing entries. Workshop items can be resubscribed directly; Local and Repo mods must be restored manually or removed from the profile.
+
+Where are profiles stored?
+
+Profiles are stored as separate XML files under the LaunchPad save path - usually Documents\My Games\Stationeers.
+
+</details>
+
+Dedicated Server
+
+Install BepInEx into the dedicated server folder.
+
+Download BepInEx 5.4 and extract it into the dedicated server folder (<steamcmd>/steamapps/common/Stationeers Dedicated Server).
+
+You should end up with a BepInEx folder and doorstop_config.ini in the same folder as rocketstation_DedicatedServer.exe.
+
+Install StationeersLaunchPad.
+
+Download the latest server zip from Releases.
+
+Extract it into the BepInEx/plugins folder.
+
+In the game client, click the loading window at the bottom on startup to open configuration.
+
+Enable/disable and reorder mods to match what you want installed on the server.
+
+On the LaunchPad Configuration tab, click Export Mod Package to create a zip file containing the enabled mods and config file.
+
+Extract the zip file into the dedicated server folder. It should create modconfig.xml and a mods folder in the same folder as rocketstation_DedicatedServer.exe.
+
+Modding
+
+Information on modding Stationeers can be found at:
+
+Stationeers Modding Docs (work in progress)
+
+Stationeers Discord #modding channel
+
+Stationeers Modding Discord
+
+LaunchPadBooster library
+
+Default entrypoint lifecycle
+
+The existing supported OnLoaded(...) parameter signatures are unchanged. An OnLoaded(...) method may return either void or bool.
+
+Returning bool allows a mod to report whether initialization succeeded:
+
+public bool OnLoaded(List<GameObject> prefabs, ConfigFile config)
+{
+// Initialize the mod.
+return true;
+}
+
+Returning false tells StationeersLaunchPad that initialization failed and the mod should be cleaned up when it is safe to do so.
+
+Existing mods using void OnLoaded(...) remain supported.
+
+Unloading
+
+A reversible default entrypoint can provide a parameterless void OnUnloaded() method:
+
+public void OnUnloaded()
+{
+// Undo Harmony patches, event subscriptions,
+// registrations, and other changes made by the mod.
+}
+
+OnUnloaded() can also be used while cleaning up a partially initialized mod, so implementations should tolerate partial initialization.
+
+Mods may optionally provide a parameterless bool CanUnload() method:
+
+public bool CanUnload()
+{
+return true;
+}
+
+CanUnload() is checked before a normal/manual unload. Returning false prevents the unload at that time. If the method is absent, it defaults to true.
+
+StationeersLaunchPad checks all initialized entrypoints before beginning a manual unload so one entrypoint cannot veto after cleanup has already started.
+
+Current unload support is intended for the StationeersLaunchPad startup/loading workflow. Unloading while a world is running is not part of the supported lifecycle.
+
+Safe Mode
+
+Safe Mode only loads default entrypoints that advertise a reversible lifecycle.
+
+A default entrypoint is Safe Mode compatible when:
+
+it uses one of the existing supported OnLoaded(...) parameter signatures;
+
+OnLoaded(...) returns bool;
+
+it provides a parameterless void OnUnloaded() method.
+
+CanUnload() is optional and controls whether a compatible mod may be unloaded at a particular moment.
+
+Existing mods using void OnLoaded(...) remain supported during normal loading, but are not considered Safe Mode compatible.
+
+Cleanup responsibilities
+
+StationeersLaunchPad cleans resources that it owns, including loaded AssetBundles, entrypoint GameObjects, configuration handlers, and its internal mod/assembly references.
+
+StationeersLaunchPad does not physically unload CLR/Mono assemblies. Static state in a mod assembly can therefore remain alive for the lifetime of the game process.
+
+Mods are responsible for reversing changes they make themselves, such as Harmony patches, event subscriptions, and direct changes to game state.
+
+Resources registered through LaunchPadBooster should be removed through LaunchPadBooster's corresponding removal APIs from OnUnloaded().
+
+Linking against StationeersLaunchPad
+
+Linking against StationeersLaunchPad (using any class in the StationeersLaunchPad namespace or nested namespaces) is unsupported. These classes are not a stable API, and will change without notice. The code is MIT licensed so you are free to copy any utilities you want to use into your own mod. LaunchPadBooster also contains utilities with a stable API that can be used by mods. If there is something you need that only StationeersLaunchPad has, reach out on GitHub or Discord and it can be added as an injected parameter to the Default Entrypoint.
+
+v0.2.25 Update Error
+
+StationeersLaunchPad v0.2.25 contains a bug that prevents the auto-update from functioning.
+
+Please follow the Manual Update Instructions if you are encountering this error.

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -473,6 +473,7 @@ public static class ManualLoadWindow
     {
       ImGui.BeginChild("##modinfo", ImGuiWindowFlags.HorizontalScrollbar);
       
+#if DEBUG
       if (selectedMod != null &&
           selectedMod.LoadFinished &&
           selectedMod.CanSafelyUnload)
@@ -482,7 +483,6 @@ public static class ManualLoadWindow
 
         ImGui.Spacing();
       }
-#if DEBUG
       // To test round-trip of unloading/loading
       if (selectedMod != null &&
           !selectedMod.LoadFinished &&

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -458,6 +458,15 @@ public static class ManualLoadWindow
     if (open)
     {
       ImGui.BeginChild("##modinfo", ImGuiWindowFlags.HorizontalScrollbar);
+      
+      if (selectedMod != null && selectedMod.LoadFinished)
+      {
+        if (ImGui.Button("Unload"))
+          selectedMod.Unload();
+
+        ImGui.Spacing();
+      }
+      
       ModInfoPanel.Draw(selectedInfo);
       ImGui.EndChild();
       ImGui.EndTabItem();

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using Cysharp.Threading.Tasks;
 using ImGuiNET;
 using StationeersLaunchPad.Loading;
 using StationeersLaunchPad.Metadata;
@@ -452,6 +451,20 @@ public static class ManualLoadWindow
     ImGuiHelper.ItemTooltip("Package enabled mods into a zip file for dedicated servers.");
   }
 
+  private static async UniTask ReloadUnloadedMods()
+  {
+    var (strategyType, strategyMode) = Configs.LoadStrategy;
+
+    LoadStrategy loadStrategy = (strategyType, strategyMode) switch
+    {
+      (LoadStrategyType.Linear, LoadStrategyMode.Serial) => new LoadStrategyLinearSerial(),
+      (LoadStrategyType.Linear, LoadStrategyMode.Parallel) => new LoadStrategyLinearParallel(),
+      _ => throw new Exception($"invalid load strategy ({strategyType}, {strategyMode})")
+    };
+
+    await loadStrategy.LoadMods();
+  }
+  
   private static void DrawModInfoTab(LoadStage stage)
   {
     var open = ImGui.BeginTabItem("Mod Info", openInfo ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None);
@@ -469,6 +482,29 @@ public static class ManualLoadWindow
 
         ImGui.Spacing();
       }
+#if DEBUG
+      // To test round-trip of unloading/loading
+      if (selectedMod != null &&
+          !selectedMod.LoadFinished &&
+          !selectedMod.LoadFailed)
+      {
+        if (ImGui.Button("Load Mod"))
+        {
+          var (strategyType, strategyMode) = Configs.LoadStrategy;
+
+          LoadStrategy loadStrategy = (strategyType, strategyMode) switch
+          {
+            (LoadStrategyType.Linear, LoadStrategyMode.Serial) => new LoadStrategyLinearSerial(),
+            (LoadStrategyType.Linear, LoadStrategyMode.Parallel) => new LoadStrategyLinearParallel(),
+            _ => throw new Exception($"invalid load strategy ({strategyType}, {strategyMode})")
+          };
+
+          loadStrategy.LoadMod(selectedMod).Forget();
+        }
+
+        ImGui.Spacing();
+      }
+#endif
       
       ModInfoPanel.Draw(selectedInfo);
       ImGui.EndChild();

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -460,10 +460,12 @@ public static class ManualLoadWindow
     {
       ImGui.BeginChild("##modinfo", ImGuiWindowFlags.HorizontalScrollbar);
       
-      if (selectedMod != null  && selectedMod.CanSafelyUnload && selectedMod.LoadFinished)
+      if (selectedMod != null &&
+          selectedMod.LoadFinished &&
+          selectedMod.CanSafelyUnload)
       {
         if (ImGui.Button("Unload"))
-          selectedMod.Unload();
+          selectedMod.TryUnload();
 
         ImGui.Spacing();
       }

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -460,11 +460,7 @@ public static class ManualLoadWindow
     {
       ImGui.BeginChild("##modinfo", ImGuiWindowFlags.HorizontalScrollbar);
       
-      var canUnload = selectedMod != null &&
-                      selectedMod.LoadFinished &&
-                      selectedMod.Entrypoints.All(e => e.SafeModeCompatible);
-      
-      if (selectedMod != null  && canUnload && selectedMod.LoadFinished)
+      if (selectedMod != null  && selectedMod.CanSafelyUnload && selectedMod.LoadFinished)
       {
         if (ImGui.Button("Unload"))
           selectedMod.Unload();

--- a/StationeersLaunchPad/UI/ManualLoadWindow.cs
+++ b/StationeersLaunchPad/UI/ManualLoadWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using ImGuiNET;
 using StationeersLaunchPad.Loading;
 using StationeersLaunchPad.Metadata;
@@ -459,7 +460,11 @@ public static class ManualLoadWindow
     {
       ImGui.BeginChild("##modinfo", ImGuiWindowFlags.HorizontalScrollbar);
       
-      if (selectedMod != null && selectedMod.LoadFinished)
+      var canUnload = selectedMod != null &&
+                      selectedMod.LoadFinished &&
+                      selectedMod.Entrypoints.All(e => e.SafeModeCompatible);
+      
+      if (selectedMod != null  && canUnload && selectedMod.LoadFinished)
       {
         if (ImGui.Button("Unload"))
           selectedMod.Unload();


### PR DESCRIPTION
# Summary

Adds a reversible mod lifecycle and Safe Mode support.

## Changes

- Existing supported `OnLoaded(...)` entrypoints may now return `bool`.
  - `true` indicates successful initialization.
  - `false` indicates initialization failed.
  - Existing `void OnLoaded(...)` entrypoints remain supported.
- Added support for optional parameterless `void OnUnloaded()`.
- Added support for optional parameterless `bool CanUnload()`.
  - Missing `CanUnload()` defaults to `true`.
  - Returning `false` prevents a normal/manual unload.
- Added Safe Mode compatibility detection.
  - Safe Mode compatible default entrypoints require `bool OnLoaded(...)` and `void OnUnloaded()`.
- Added Safe Mode configuration and entrypoint filtering.
- Added checked manual unloading through `TryUnload()`.
- Added an `Unload Mod` action for safely unloadable mods.
- Tracks initialized entrypoints so partially initialized mods can still run cleanup.
- Calls entrypoint unload handlers in reverse initialization order.
- Tracks loaded AssetBundles and unloads them during cleanup.
- Tracks and destroys the shared entrypoint GameObject.
- Removes StationeersLaunchPad assembly-to-mod registry mappings during unload.
- Unsubscribes configuration change handlers during unload.
- Clears SLP-owned prefab, export, entrypoint, and configuration references.
- Centralizes load-failure cleanup through the existing load strategy.
- CLR/Mono assemblies themselves are not physically unloaded.

## Lifecycle ownership

- StationeersLaunchPad removes resources owned by StationeersLaunchPad.
- Mods remain responsible for reversing their own Harmony patches, event subscriptions, static state, and direct game changes.
- Resources registered through LaunchPadBooster should be removed by the mod through the corresponding LaunchPadBooster removal APIs.

## Reversible mod contract

```csharp
private static readonly Mod MOD = new("TestMod", "1.0");
private static Harmony _harmony = new Harmony("TestMod");

public bool OnLoaded(List<GameObject> prefabs, ConfigFile config)
{
    // Initialize the mod.
    MOD.AddPrefabs(prefabs);

    _harmony.PatchAll(); // Any exception while patching will force a false return

    return true;
}

public bool CanUnload()
{
    // Optional runtime veto if the modder doesn't want the mod to unload for any reason.
    return true;
}

public void OnUnloaded()
{
    // Undo mod-owned changes.
    // harmony?.UnpatchSelf();

    // Undo registrations requested through LaunchPadBooster.
    MOD.RemovePrefabs();
    // MOD.RemoveSaveDataTypes();
    // MOD.RemoveNetworkRegistrations();

    // Release LaunchPadBooster-owned bookkeeping last.
    MOD.Remove();
}
```

Note: AI generated PR summary from the commits in the PR