### PR TITLE
Hotfix v0.5.1

### DIFF
--- a/StationeersLaunchPad/LaunchPadConfig.cs
+++ b/StationeersLaunchPad/LaunchPadConfig.cs
@@ -164,7 +164,8 @@ public static class LaunchPadConfig
     Settings.CurrentData.SavePath = LaunchPadPaths.SavePath;
 
     await StageInitializing();
-    await StageUpdating();
+    if (!await StageUpdating())
+      return;
 
     var firstLoad = true;
     do
@@ -232,10 +233,11 @@ public static class LaunchPadConfig
     await SLPCommand.MoveToStage(CommandStage.Init);
   }
 
-  private static async UniTask StageUpdating()
+  // Returns false when startup must stop, such as after a server update requests shutdown.
+  private static async UniTask<bool> StageUpdating()
   {
     if (Stage == LoadStage.Failed || !Configs.CheckForUpdate.Value)
-      return;
+      return true;
 
     Stage = LoadStage.Updating;
     try
@@ -243,13 +245,13 @@ public static class LaunchPadConfig
       Logger.Global.LogInfo("Checking Version");
       var release = await LaunchPadUpdater.GetUpdateRelease();
       if (release == null)
-        return;
+        return true;
 
       if (!Configs.AutoUpdateOnStart.Value && !await LaunchPadUpdater.CheckShouldUpdate(release))
-        return;
+        return true;
 
       if (!await LaunchPadUpdater.UpdateToRelease(release))
-        return;
+        return true;
 
       Logger.Global.LogError($"StationeersLaunchPad updated to {release.TagName}, please restart your game!");
       Configs.PostUpdateCleanup.Value = true;
@@ -259,11 +261,19 @@ public static class LaunchPadConfig
       Logger.Global.LogError("An error occurred during update.");
       Logger.Global.LogException(ex);
       StopAutoLoad();
-      return;
+      return true;
     }
 
-    if (!await Platform.ContinueAfterUpdate())
+    if (await Platform.ContinueAfterUpdate())
+      return true;
+
+    if (!Platform.IsServer)
+    {
       StopAutoLoad();
+      return true;
+    }
+
+    return false;
   }
 
   private static async UniTask StageSearching(bool firstLoad)

--- a/StationeersLaunchPad/LaunchPadInfo.cs
+++ b/StationeersLaunchPad/LaunchPadInfo.cs
@@ -4,5 +4,5 @@ public class LaunchPadInfo
 {
   public const string NAME = "StationeersLaunchPad";
   public const string GUID = "stationeers.launchpad";
-  public const string VERSION = "0.5.0";
+  public const string VERSION = "0.5.1";
 }

--- a/StationeersLaunchPad/Steam.cs
+++ b/StationeersLaunchPad/Steam.cs
@@ -42,6 +42,8 @@ public static class Steam
       foreach (var item in needsUpdate)
         Logger.Global.LogInfo($"- {item.Title} ({item.Id})");
 
+      await UniTask.SwitchToMainThread();
+
       await UniTask.WhenAll(needsUpdate.Select(item => item.DownloadAsync().AsUniTask()));
     }
 

--- a/StationeersLaunchPad/Steam.cs
+++ b/StationeersLaunchPad/Steam.cs
@@ -24,33 +24,14 @@ public static class Steam
   {
     var allItems = new List<Item>();
     var page = 1;
-    const int batchSize = 5; // number of pages to fetch in parallel
 
     while (true)
     {
-      // Prepare batch of pages
-      var pageTasks = new List<UniTask<Item[]>>();
-      for (var i = 0; i < batchSize; i++)
-      {
-        var currentPage = page + i;
-        pageTasks.Add(FetchWorkshopPage(currentPage));
-      }
-
-      var results = await UniTask.WhenAll(pageTasks);
-      var hasItems = false;
-      foreach (var items in results)
-      {
-        if (items.Length > 0)
-        {
-          allItems.AddRange(items);
-          hasItems = true;
-        }
-      }
-
-      if (!hasItems)
-        break; // no more pages
-
-      page += batchSize;
+      var items = await FetchWorkshopPage(page);
+      if (items.Length == 0)
+        break;
+      allItems.AddRange(items);
+      page++;
     }
 
     // Determine which items need updates
@@ -70,12 +51,30 @@ public static class Steam
   // Helper to fetch a single workshop page
   private static async UniTask<Item[]> FetchWorkshopPage(int page)
   {
-    var query = Query.Items.WithTag("Mod");
-    using var result = await query.AllowCachedResponse(0).WhereUserSubscribed().GetPageAsync(page);
+    const int maxAttempts = 3;
+    for (var attempt = 1; attempt <= maxAttempts; attempt++)
+    {
+      try
+      {
+        var query = Query.Items.WithTag("Mod");
+        using var result = await query.AllowCachedResponse(0)
+          .WhereUserSubscribed().GetPageAsync(page);
 
-    return !result.HasValue || result.Value.ResultCount == 0
-      ? []
-      : [.. result.Value.Entries.Where(item => item.Result != Result.FileNotFound)];
+        return !result.HasValue || result.Value.ResultCount == 0
+          ? []
+          : [.. result.Value.Entries.Where(item => item.Result != Result.FileNotFound)];
+      }
+      catch (Exception ex)
+      {
+        Logger.Global.LogWarning(
+          $"Workshop query page {page} failed (attempt {attempt}/{maxAttempts})");
+        Logger.Global.LogException(ex);
+        if (attempt == maxAttempts)
+          throw;
+        await UniTask.Yield();
+      }
+    }
+    return [];
   }
 
   public static async UniTask<bool> SubscribeAndDownload(ulong workshopId, ulong? unsubscribeWorkshopId = null)


### PR DESCRIPTION
This hotfix bundles three stability fixes for the existing v0.5 release:

### Steamworks query stability

Workshop queries are now serialized to avoid overlapping SteamUGC operations that could sporadically fail while initializing preview URLs.

### Dedicated-server post-update shutdown

After SLP requests a shutdown following an update, startup now stops immediately instead of continuing into mod discovery and issuing repeated `Application.Quit()` calls.
This would cause a Dedicated server to throw non-descructive errors.

### Workshop startup updates

Fixes an error encountered when updating Workshop mods during startup. This could prevent SLP and thus the game from loading entirely.